### PR TITLE
fix: Enable RestJsonListsSerializeNull and RestJsonSerializesNullMapValues unit tests

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/RestJsonProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/RestJsonProtocolGenerator.kt
@@ -32,8 +32,6 @@ abstract class RestJsonProtocolGenerator : AWSHttpBindingProtocolGenerator() {
 
     override fun generateProtocolUnitTests(ctx: ProtocolGenerator.GenerationContext) {
         val ignoredTests = setOf(
-                "RestJsonListsSerializeNull", // TODO - sparse lists not supported - this test needs removed
-                "RestJsonSerializesNullMapValues", // TODO - sparse maps not supported - this test needs removed
                 // FIXME - document type not fully supported yet
                 "InlineDocumentInput",
                 "InlineDocumentAsPayloadInput",


### PR DESCRIPTION
*Issue  #175646885:*

*Description of changes:*
As part of the sparse support changes in smithy-swift https://github.com/aws-amplify/smithy-swift/pull/71, we are enabling RestJsonListsSerializeNull and RestJsonSerializesNullMapValues unit tests in RestJsonProtocolGenerator. Both are passing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
