### PR TITLE
fix: Tests containing FooError with __type in GreetingWithErrorsFooErrorTest.swift

### DIFF
--- a/AWSClientRuntime/AWSClientRuntime/Protocols/RestJSON/RestJSONErrorPayload.swift
+++ b/AWSClientRuntime/AWSClientRuntime/Protocols/RestJSON/RestJSONErrorPayload.swift
@@ -17,7 +17,7 @@
 public struct RestJSONErrorPayload: Decodable {
     /// Payload Members which might hold Error name
     let code: String?
-    let _type: String?
+    let __type: String?
 
     /// Payload Members which might hold Error message
     let message: String?
@@ -30,7 +30,7 @@ public struct RestJSONErrorPayload: Decodable {
         if code != nil {
             return code
         } else {
-            return _type
+            return __type
         }
     }
 


### PR DESCRIPTION


*Issue #176047323:*

*Description of changes:*
3 tests in GreetingWithErrorsFooErrorTest.swift namely testRestJsonFooErrorWithDunderType(), testRestJsonFooErrorWithDunderTypeAndNamespace() and testRestJsonFooErrorWithDunderTypeUriAndNamespace() are fixed. The problem was that the "_type" String in RestJSONErrorPayload.swift was supposed to be "__type".


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
