### PR TITLE
feat: Enabled unit tests related to document type

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/RestJsonProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/RestJsonProtocolGenerator.kt
@@ -21,14 +21,7 @@ abstract class RestJsonProtocolGenerator : AWSHttpBindingProtocolGenerator() {
     override val defaultTimestampFormat: TimestampFormatTrait.Format = TimestampFormatTrait.Format.EPOCH_SECONDS
 
     override fun generateProtocolUnitTests(ctx: ProtocolGenerator.GenerationContext) {
-        val ignoredTests = setOf(
-                // FIXME - document type not fully supported yet
-                "InlineDocumentInput",
-                "InlineDocumentAsPayloadInput",
-                "InlineDocumentOutput",
-                "InlineDocumentAsPayloadInputOutput"
-        )
-
+        
         val requestTestBuilder = HttpProtocolUnitTestRequestGenerator.Builder()
         val responseTestBuilder = HttpProtocolUnitTestResponseGenerator.Builder()
         val errorTestBuilder = HttpProtocolUnitTestErrorGenerator.Builder()
@@ -37,8 +30,7 @@ abstract class RestJsonProtocolGenerator : AWSHttpBindingProtocolGenerator() {
                 ctx,
                 requestTestBuilder,
                 responseTestBuilder,
-                errorTestBuilder,
-                ignoredTests
+                errorTestBuilder
         ).generateProtocolTests()
     }
 


### PR DESCRIPTION
*Issue #172587150:*

*Description of changes:*
The following unit tests are enabled and passing in the swift SDK : InlineDocumentAsPayloadRequestTest, InlineDocumentRequestTest, InlineDocumentResponseTest, InlineDocumentAsPayloadResponseTest.

Document type implementation in Smithy-swift : https://github.com/aws-amplify/smithy-swift/pull/78

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
