### PR TITLE
chore: upgrade versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 plugins {
-    kotlin("jvm") version "1.3.72" apply false
+    kotlin("jvm") version "1.4.21" apply false
 }
 
 allprojects {

--- a/codegen/smithy-aws-swift-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-swift-codegen/build.gradle.kts
@@ -13,13 +13,14 @@ version = "0.1.0"
 val smithyVersion: String by project
 val kotestVersion: String by project
 val smithySwiftVersion: String by project
+val junitVersion: String by project
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
     api("software.amazon.smithy:smithy-swift-codegen:$smithySwiftVersion")
     api("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.1")
+    testImplementation("org.junit.jupiter:junit-jupiter:$junitVersion")
     testImplementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,17 +1,18 @@
 kotlin.code.style=official
 
 # codegen
-smithyVersion=1.4.0
+smithyVersion=1.5.1
 
 smithySwiftVersion = 0.1.0
 
 # kotlin
-kotlinVersion=1.3.72
+kotlinVersion=1.4.21
 kotlin.native.ignoreDisabledTargets=true
 
 
 # testing/utility
 # FIXME - junit5 not working
-ktlintVersion=0.36.0
+ktlintVersion=0.40.0
 kotestVersion=4.0.5
+junitVersion=5.6.2
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
*Description of changes:* This PR upgrades the versions of the following libraries/frameworks:
Kotlin: 1.4.21
Gradle: 6.8
Smithy: 1.5.1
ktlint: 0.40.0
junit: 5.6.2
Dokka plugin: 1.4.20
Smithy Gradle Plugin: 0.5.2


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
