### PR TITLE
hack: path generation

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSSwiftDependency.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSSwiftDependency.kt
@@ -5,9 +5,15 @@
 package software.amazon.smithy.aws.swift.codegen
 import software.amazon.smithy.codegen.core.SymbolDependency
 import software.amazon.smithy.codegen.core.SymbolDependencyContainer
+import java.nio.file.FileSystem
+import kotlin.io.path.Path
 
 enum class AWSSwiftDependency(val type: String, val namespace: String, val version: String, val url: String, var packageName: String) : SymbolDependencyContainer {
-    AWS_CLIENT_RUNTIME("", "AWSClientRuntime", "0.1.0", "~/Projects/Amplify/SwiftSDK/aws-sdk-swift/AWSClientRuntime", "AWSClientRuntime");
+    AWS_CLIENT_RUNTIME("",
+        "AWSClientRuntime",
+        "0.1.0",
+        myAbsolutePath("aws-sdk-swift", "aws-sdk-swift/AWSClientRuntime"),
+        "AWSClientRuntime");
 
     override fun getDependencies(): List<SymbolDependency> {
         val dependency = SymbolDependency.builder()
@@ -19,4 +25,17 @@ enum class AWSSwiftDependency(val type: String, val namespace: String, val versi
                 .build()
         return listOf(dependency)
     }
+}
+
+fun myAbsolutePath(searchString: String, relativePath: String): String {
+    //This isn't a good solution because user.dir can change.. hmmm
+    val javaClassPath = System.getProperty("user.dir")
+    val matchingPaths = javaClassPath.split(":").filter { it.contains(searchString) }
+    if (matchingPaths.isNotEmpty()) {
+        val firstPath = matchingPaths.first()
+        val startIndex = firstPath.indexOf(searchString)
+        val rootPath = firstPath.substring(0, startIndex).trim().removeSuffix("/")
+        return "$rootPath/$relativePath"
+    }
+    return ""
 }


### PR DESCRIPTION
No need to review, this is a total hack.

Unfortunately, using `java.class.path` is not reliable because during jar generation, there's nothing we can use in that variable.
The only thing that seems "stable" is `user.dir`, but even that is a hack.

I'll continue to work on allowing something in `gradle.properties` so that when we run the generation process, we'll have a variable that is somewhat reliable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
