### PR TITLE
fix: path generation for local dev

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSSwiftDependency.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSSwiftDependency.kt
@@ -8,20 +8,22 @@ import software.amazon.smithy.codegen.core.SymbolDependencyContainer
 import java.io.File
 
 enum class AWSSwiftDependency(val type: String, val namespace: String, val version: String, val url: String, var packageName: String) : SymbolDependencyContainer {
-    AWS_CLIENT_RUNTIME("",
+    AWS_CLIENT_RUNTIME(
+        "",
         "AWSClientRuntime",
         "0.1.0",
         computeAbsolutePath("aws-sdk-swift/AWSClientRuntime"),
-        "AWSClientRuntime");
+        "AWSClientRuntime"
+    );
 
     override fun getDependencies(): List<SymbolDependency> {
         val dependency = SymbolDependency.builder()
-                .dependencyType(type)
-                .packageName(namespace)
-                .version(version)
-                .putProperty("url", url)
-                .putProperty("swiftPackageName", packageName)
-                .build()
+            .dependencyType(type)
+            .packageName(namespace)
+            .version(version)
+            .putProperty("url", url)
+            .putProperty("swiftPackageName", packageName)
+            .build()
         return listOf(dependency)
     }
 }
@@ -34,7 +36,7 @@ private fun computeAbsolutePath(relativePath: String): String {
         if (file.isDirectory) {
             return fileName
         }
-        userDirPath = userDirPath.substring(0, userDirPath.length-1)
+        userDirPath = userDirPath.substring(0, userDirPath.length - 1)
     }
     return ""
 }


### PR DESCRIPTION
This seems like it would work for local development (when smithy-swift, aws-sdk-swift and aws-crt-swift are all checked out to the same directory), but will need to iterate on this to support deployment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
