### PR TITLE
chore: script for building quickly

### DIFF
--- a/sbin/buildswiftsdk
+++ b/sbin/buildswiftsdk
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+#  Install directions
+#    Option 1:
+#      1.  Edit your PATH environment variable to include aws-sdk-swift/sbin.
+#    Option 2:
+#      1. Copy buildswiftsdk to some other directory that is in your path
+#      2. Export the environemnt variable BUILDSWIFTSDK_DIR to point to aws-sdk-swift.
+#        For example:
+#          BUILDSWIFTSDK_DIR=/path/to/aws-sdk-swift
+#  
+#  To Run:
+#    buildswiftsdk <recipe>
+#
+#  Suggestion:
+#    You may want to create an alias for this script
+#      For example:
+#        alias bss=buildswiftsdk
+# 
+
+usage() {
+    echo "Usage:"
+    echo " buildswiftsdk <recipe>"
+}
+
+pushdir() {
+    if [[ ! -d "${1}" ]]; then
+	echo "Error: pushdir: invalid directory: ${1}"
+	exit 1
+    fi
+    pushd "${1}" > /dev/null 2>&1
+}
+
+popdir() {
+    popd > /dev/null 2>&1
+}
+
+setupPaths() {
+    pushdir "${AWS_SDK_SWIFT_DIR_REL}"
+    AWS_SDK_SWIFT_DIR="${PWD}"
+    SMITHY_SWIFT_DIR_REL="${PWD}/../smithy-swift"
+    if [[ -d "${SMITHY_SWIFT_DIR_REL}" ]]; then
+	pushdir "${SMITHY_SWIFT_DIR_REL}"
+	SMITHY_SWIFT_DIR="${PWD}"
+	popdir
+    fi
+    popdir
+}
+
+checkPaths() {
+    error=0
+    if [[ ! -d "${SMITHY_SWIFT_DIR}" ]]; then
+	echo "Was unable to detect smithy-swift"
+	error=1
+    fi
+    if [[ ! -d "${AWS_SDK_SWIFT_DIR}" ]]; then
+	echo "Was unable to detect where aws-sdk-swift"
+	error=1
+    fi
+    if [[ ${error} -eq 1 ]]; then
+	exit 1
+    fi
+}
+
+AWS_SDK_SWIFT_DIR=""
+SMITHY_SWIFT_DIR=""
+if [[ -z "${BUILDSWIFTSDK_DIR}" ]]; then
+    AWS_SDK_SWIFT_DIR_REL=`dirname ${0}`/../
+else
+    AWS_SDK_SWIFT_DIR_REL="${BUILDSWIFTSDK_DIR}"
+fi
+setupPaths
+checkPaths
+
+
+
+pcg() {
+    cd "${SMITHY_SWIFT_DIR}" && \
+	./gradlew -p smithy-swift-codegen assemble && \
+	cd "${AWS_SDK_SWIFT_DIR}" && \
+	./gradlew -p codegen/protocol-test-codegen clean &&\
+	./gradlew -p codegen/protocol-test-codegen build
+    echo "Generated files should be in:"
+    echo "${AWS_SDK_SWIFT_DIR}/codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen"   
+}
+
+ssclean() {
+    cd "${SMITHY_SWIFT_DIR}" && \
+	./gradlew clean
+}
+
+sdkclean() {
+    cd "${AWS_SDK_SWIFT_DIR}" && \
+	./gradlew clean    
+}
+
+clean() {
+    ssclean && sdkclean
+}
+
+case "$1" in
+    "pcg")
+	pcg
+	;;
+    "clean")
+	clean
+	;;
+    "ssclean")
+	ssclean
+	;;
+    "sdkclean")
+	sdkclean
+	;;
+    *)
+	usage
+	;;
+esac
+	


### PR DESCRIPTION
**Summary**
A shell based build helper for `aws-sdk-swift` and `smithy-swift`

**Approach:**
I thought about modifying our gradle configs, but working between two packages adds complexity to gradle, so, I decided to implement this quick script in shell.

**Use case**
If you want to really quickly build the `protocol-test-codegen`, a developer would most likely:
```
cd smithy-swift
./gradlew  clean
./gradlew  build
cd ../aws-sdk-swift
./gradlew build
```

This is not ideal for a couple of reasons:
1. Doing a clean/build in `smithy-swift` does not take advantage of incremental builds.  (it destroys all build artifacts)
2. Doing a build in `smithy-swift` will kick off the unit tests.  This is inefficient when rapidly prototyping. We often don't care about the unit tests until we get something working.  It would ideal to just build/iterate rapidly, and handle updating unit tests later.
3. Doing a build in smithy-swift will kick off `smithy-swift-codgen-test`, which is not needed for `protocol-test-gen-codegen`. It's a good test to make sure we are generating compilable code, but not needed when you are focusing building `protocol-test-codgen`.
4.  Having to issue so many commands is error prone.  Sometimes you might forget to build smithy-swift prior to generating `protocol-test-codgen` clean
5. Running `./gradlew build` in `aws-sdk-swift` is inefficient because:
   **a.**  it includes `protocol-test-codegen`, `sdk-codegen`, and `smithy-aws-swift-codegen`.  Instead we should be able to invoke just `protocol-test-codegen`, and it should build itself and it's dependency `smithy-aws-swift-codegen` (if not we can change that).
  **b.** the`protocol-test-codegen` task lightweight, while `sdk-codgen` is not, and can eat up quite a bit of resources.  Normally, this using these resources is not a problem, but if you are trying to open the built artifacts from `protocol-test-codegen` in xcode while this is happening, this can strain your workstation.

**Solution**
```
alias bss=buildsdkswift
bss clean
bss pcg
```

Then issuing an incremental build on smithy-swift, then regenerating protocol-test-codegen:
```
bss pcg
```
**Time Difference**
* Doing full build of aws-sdk-sdk (with smithy-swift). - ~2 minutes
* First time`buildswiftsdk pcg`: 18 seconds
* Incremental build (single file change in smithy-swift)`buildswiftsdk pcg`: 10 seconds 
* 120s* x = 10 seconds = 0.083.. 92% difference.
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

