### PR TITLE
fix: stop generation of response binding for awsjson1.x

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSErrorFromAWSRestHttpResponseGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSErrorFromAWSRestHttpResponseGenerator.kt
@@ -7,10 +7,7 @@ import software.amazon.smithy.swift.codegen.defaultName
 import software.amazon.smithy.swift.codegen.integration.ErrorFromHttpResponseGenerator
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 
-// TODO:
-// This is potentially getting called for JSON protocols due to generateDeserializers
-// We need to come back to this immediately and update this if this is being called for AWS JSON
-class AWSErrorFromHttpResponseGenerator : ErrorFromHttpResponseGenerator {
+class AWSErrorFromAWSRestHttpResponseGenerator : ErrorFromHttpResponseGenerator {
     override fun generateInitOperationFromHttpResponse(ctx: ProtocolGenerator.GenerationContext, op: OperationShape) {
         val operationErrorName = "${op.defaultName()}Error"
         val rootNamespace = ctx.settings.moduleName

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHttpBindingProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHttpBindingProtocolGenerator.kt
@@ -6,7 +6,6 @@ package software.amazon.smithy.aws.swift.codegen
 
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.swift.codegen.integration.CodingKeysGenerator
-import software.amazon.smithy.swift.codegen.integration.ErrorFromHttpResponseGenerator
 import software.amazon.smithy.swift.codegen.integration.HttpBindingProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolClientGeneratorFactory
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolTestGenerator
@@ -20,8 +19,8 @@ import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
  */
 abstract class AWSHttpBindingProtocolGenerator : HttpBindingProtocolGenerator() {
     override val codingKeysGenerator: CodingKeysGenerator = AWSCodingKeysGenerator()
-    override val errorFromHttpResponseGenerator: ErrorFromHttpResponseGenerator = AWSErrorFromHttpResponseGenerator()
     override val httpProtocolClientGeneratorFactory: HttpProtocolClientGeneratorFactory = AWSHttpProtocolClientGeneratorFactory()
+
     override val serviceErrorProtocolSymbol: Symbol = Symbol.builder()
         .name("AWSHttpServiceError")
         .namespace(AWSSwiftDependency.AWS_CLIENT_RUNTIME.namespace, "")

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_0_ProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_0_ProtocolGenerator.kt
@@ -4,6 +4,7 @@ import software.amazon.smithy.aws.swift.codegen.AWSHttpBindingProtocolGenerator
 import software.amazon.smithy.aws.traits.protocols.AwsJson1_0Trait
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.traits.TimestampFormatTrait
+import software.amazon.smithy.swift.codegen.integration.EmptyErrorFromHttpResponseGenerator
 import software.amazon.smithy.swift.codegen.integration.HttpBindingResolver
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 
@@ -11,6 +12,7 @@ open class AwsJson1_0_ProtocolGenerator : AWSHttpBindingProtocolGenerator() {
     override val defaultContentType: String = "application/x-amz-json-1.0"
     override val defaultTimestampFormat: TimestampFormatTrait.Format = TimestampFormatTrait.Format.EPOCH_SECONDS
     override val protocol: ShapeId = AwsJson1_0Trait.ID
+    override val errorFromHttpResponseGenerator = EmptyErrorFromHttpResponseGenerator()
 
     override fun getProtocolHttpBindingResolver(ctx: ProtocolGenerator.GenerationContext):
         HttpBindingResolver = AwsJsonHttpBindingResolver(ctx)

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_1_ProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_1_ProtocolGenerator.kt
@@ -4,6 +4,7 @@ import software.amazon.smithy.aws.swift.codegen.AWSHttpBindingProtocolGenerator
 import software.amazon.smithy.aws.traits.protocols.AwsJson1_1Trait
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.traits.TimestampFormatTrait
+import software.amazon.smithy.swift.codegen.integration.EmptyErrorFromHttpResponseGenerator
 import software.amazon.smithy.swift.codegen.integration.HttpBindingResolver
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 
@@ -11,6 +12,7 @@ class AwsJson1_1_ProtocolGenerator : AWSHttpBindingProtocolGenerator() {
     override val defaultContentType: String = "application/x-amz-json-1.1"
     override val defaultTimestampFormat: TimestampFormatTrait.Format = TimestampFormatTrait.Format.EPOCH_SECONDS
     override val protocol: ShapeId = AwsJson1_1Trait.ID
+    override val errorFromHttpResponseGenerator = EmptyErrorFromHttpResponseGenerator()
 
     override fun getProtocolHttpBindingResolver(ctx: ProtocolGenerator.GenerationContext):
         HttpBindingResolver = AwsJsonHttpBindingResolver(ctx)

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/restjson/AWSRestJson1ProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/restjson/AWSRestJson1ProtocolGenerator.kt
@@ -4,13 +4,16 @@
  */
 package software.amazon.smithy.aws.swift.codegen.restjson
 
+import software.amazon.smithy.aws.swift.codegen.AWSErrorFromAWSRestHttpResponseGenerator
 import software.amazon.smithy.aws.swift.codegen.AWSHttpBindingProtocolGenerator
 import software.amazon.smithy.aws.traits.protocols.RestJson1Trait
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.traits.TimestampFormatTrait
+import software.amazon.smithy.swift.codegen.integration.ErrorFromHttpResponseGenerator
 
 class AWSRestJson1ProtocolGenerator : AWSHttpBindingProtocolGenerator() {
     override val defaultContentType: String = "application/json"
     override val defaultTimestampFormat: TimestampFormatTrait.Format = TimestampFormatTrait.Format.EPOCH_SECONDS
     override val protocol: ShapeId = RestJson1Trait.ID
+    override val errorFromHttpResponseGenerator: ErrorFromHttpResponseGenerator = AWSErrorFromAWSRestHttpResponseGenerator()
 }

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/AwsJson1_0ProtocolGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/AwsJson1_0ProtocolGeneratorTests.kt
@@ -1,6 +1,7 @@
 package software.amazon.smithy.aws.swift.codegen
 
 import io.kotest.matchers.string.shouldContainOnlyOnce
+import io.kotest.matchers.string.shouldNotContain
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.aws.swift.codegen.awsjson.AwsJson1_0_ProtocolGenerator
 import software.amazon.smithy.build.MockManifest
@@ -132,15 +133,8 @@ class AwsJson1_0ProtocolGeneratorTests : TestsBase() {
                         }
                     }
                 }
-
-                extension GreetingWithErrorsError: HttpResponseBinding {
-                    public init(httpResponse: HttpResponse, decoder: ResponseDecoder? = nil) throws {
-                        let errorDetails = try RestJSONError(httpResponse: httpResponse)
-                        let requestID = httpResponse.headers.value(for: X_AMZN_REQUEST_ID_HEADER)
-                        try self.init(errorType: errorDetails.errorType, httpResponse: httpResponse, decoder: decoder, message: errorDetails.errorMessage, requestID: requestID)
-                    }
-                }
             """.trimIndent()
         contents.shouldContainOnlyOnce(expectedContents)
+        contents.shouldNotContain("RestJSONError")
     }
 }

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/RestJsonProtocolGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/RestJsonProtocolGeneratorTests.kt
@@ -23,6 +23,7 @@ class MockRestAWSHttpBindingJsonProtocolGenerator : AWSHttpBindingProtocolGenera
     override val defaultContentType: String = "application/json"
     override val defaultTimestampFormat: TimestampFormatTrait.Format = TimestampFormatTrait.Format.EPOCH_SECONDS
     override val protocol: ShapeId = RestJson1Trait.ID
+    override val errorFromHttpResponseGenerator = AWSErrorFromAWSRestHttpResponseGenerator()
 }
 
 // NOTE: protocol conformance is mostly handled by the protocol tests suite


### PR DESCRIPTION
Corresponding:
https://github.com/awslabs/smithy-swift/pull/105

@kneekey23  pointed this out in this pr here:
https://github.com/awslabs/aws-sdk-swift/pull/36

This stops generation of the extension of HttpResponseBinding for awsjson 1.1 protocols


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
