### PR TITLE
fix: automatically add copyright header to new files

### DIFF
--- a/AWSClientRuntime/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/AWSClientRuntime/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>FILEHEADER</key>
+    <string>
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//</string>
+</dict>
+</plist>


### PR DESCRIPTION
corresponding pr: https://github.com/awslabs/smithy-swift/pull/110

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
