### PR TITLE
fix: endpoint prefix can be nil

### DIFF
--- a/AWSClientRuntime/Sources/Middlewares/EndpointResolverMiddleware.swift
+++ b/AWSClientRuntime/Sources/Middlewares/EndpointResolverMiddleware.swift
@@ -27,7 +27,7 @@ public struct EndpointResolverMiddleware<OperationStackOutput: HttpResponseBindi
         do {
             let awsEndpoint = try endpointResolver.resolve(serviceId: serviceId,
                                                            region: region)
-            let host = "\(context.getHostPrefix())\(awsEndpoint.endpoint.host)"
+            let host = "\(context.getHostPrefix() ?? "")\(awsEndpoint.endpoint.host)"
             
             if let protocolType = awsEndpoint.endpoint.protocolType {
                 input.withProtocol(protocolType)


### PR DESCRIPTION
*Description of changes:* Endpoint Prefix can be nil, this PR accommodates for that.
Corresponding PR in smithy-swift [here](https://github.com/awslabs/smithy-swift/pull/153).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
