### PR TITLE
fix: Revert patch to prevent loc header issue per updated smithy gradle plugin

### DIFF
--- a/codegen/protocol-test-codegen/build.gradle.kts
+++ b/codegen/protocol-test-codegen/build.gradle.kts
@@ -5,7 +5,7 @@
 import software.amazon.smithy.gradle.tasks.SmithyBuild
 
 plugins {
-    id("software.amazon.smithy") version "0.5.2"
+    id("software.amazon.smithy") version "0.5.3"
 }
 
 description = "Smithy protocol test suite"

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -15,7 +15,7 @@ import kotlin.streams.toList
 import java.util.Properties
 
 plugins {
-    id("software.amazon.smithy") version "0.5.2"
+    id("software.amazon.smithy") version "0.5.3"
 }
 
 dependencies {

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHttpProtocolCustomizations.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHttpProtocolCustomizations.kt
@@ -7,9 +7,6 @@ import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolCustomizable
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
-import software.amazon.smithy.swift.codegen.resources.Resources
-import java.nio.file.Files
-import java.nio.file.Paths
 
 abstract class AWSHttpProtocolCustomizations : HttpProtocolCustomizable() {
     override fun renderContextAttributes(ctx: ProtocolGenerator.GenerationContext, writer: SwiftWriter, serviceShape: ServiceShape, op: OperationShape) {
@@ -27,18 +24,7 @@ abstract class AWSHttpProtocolCustomizations : HttpProtocolCustomizable() {
     }
 
     override fun renderInternals(ctx: ProtocolGenerator.GenerationContext) {
-        val path = determinePath("AWS_SDK_SWIFT_CI_DIR", "/codegen/smithy-aws-swift-codegen/src/main/resources/software.amazon.smithy.aws.swift.codegen")
-        val filePath = path + "/endpoints.json"
-        val jsonContents = Files.readString(Paths.get(filePath))
-        val endpointData = Node.parse(jsonContents).expectObjectNode()
+        val endpointData = Node.parse(EndpointResolverGenerator::class.java.getResource("/software.amazon.smithy.aws.swift.codegen/endpoints.json").readText()).expectObjectNode()
         EndpointResolverGenerator(endpointData).render(ctx)
-    }
-
-    private fun determinePath(baseEnvVar: String, relativePath: String): String {
-        val userDirPathOverride = System.getenv(baseEnvVar)
-        if (!userDirPathOverride.isNullOrEmpty()) {
-            return userDirPathOverride + relativePath
-        }
-        return Resources.computeAbsolutePath("aws-sdk-swift" + relativePath)
     }
 }


### PR DESCRIPTION
*Description of changes:* Smithy gradle plugin was updated to correct the invalid loc header bug per this PR: https://github.com/awslabs/smithy-gradle-plugin/pull/40

This PR reverts a patch we implemented in order to prevent running up against this and updates the plugin to take advantage of the fix.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
