### PR TITLE
fix: enable Restxml tests to run as part of testAllProtocols

### DIFF
--- a/codegen/protocol-test-codegen/build.gradle.kts
+++ b/codegen/protocol-test-codegen/build.gradle.kts
@@ -74,7 +74,7 @@ open class ProtocolTestTask : DefaultTask() {
 
 // The following section exposes Smithy protocol test suites as gradle test targets
 // for the configured protocols in [enabledProtocols].
-val enabledProtocols = listOf("aws-json-10", "aws-json-11", "aws-restjson")
+val enabledProtocols = listOf("aws-json-10", "aws-json-11", "aws-restjson", "rest-xml")
 
 enabledProtocols.forEach {
     tasks.register<ProtocolTestTask>("testProtocol-${it}") {


### PR DESCRIPTION
(no corresponding pr)

whoops.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
