### PR TITLE
fix: remove default date encode strat for aws query

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/AWSHttpProtocolAwsQueryCustomizations.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/AWSHttpProtocolAwsQueryCustomizations.kt
@@ -17,9 +17,6 @@ class AWSHttpProtocolAwsQueryCustomizations : AWSHttpProtocolCustomizations() {
         val properties = mutableListOf<ClientProperty>()
         val requestEncoderOptions = mutableMapOf<String, String>()
         val responseDecoderOptions = mutableMapOf<String, String>()
-        // TODO: Determine what default is for AWSQuery
-        requestEncoderOptions["dateEncodingStrategy"] = ".secondsSince1970"
-        responseDecoderOptions["dateDecodingStrategy"] = ".secondsSince1970"
         properties.add(AWSHttpRequestFormURLEncoder(requestEncoderOptions))
         properties.add(AWSHttpResponseXMLDecoder(responseDecoderOptions))
         return properties


### PR DESCRIPTION


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
