### PR TITLE
fix: generatePackageSwift script needs to be run from rootdir

### DIFF
--- a/scripts/generatePackageSwift.swift
+++ b/scripts/generatePackageSwift.swift
@@ -72,7 +72,7 @@ func generateTargets(_ releasedSDKs: [String]) {
     
 }
 
-let sdksToIncludeInTargets = try! FileManager.default.contentsOfDirectory(atPath: "../release")
+let sdksToIncludeInTargets = try! FileManager.default.contentsOfDirectory(atPath: "release")
 let releasedSDKs = sdksToIncludeInTargets.sorted()
 
 generateHeader()


### PR DESCRIPTION



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
