### PR TITLE
chore: add yaml to automate release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,13 @@ env:
   AWS_CRT_SWIFT_CI_DIR: /Users/runner/work/aws-sdk-swift/aws-sdk-swift/target/build/deps/aws-crt-swift
   SMITHY_SWIFT_CI_DIR: /Users/runner/work/aws-sdk-swift/aws-sdk-swift/target/build/deps/smithy-swift
 
+# This release script is work in progress.  We will need to update the script to
+# * Ensure that unit tests pass for all targets prior to generating a release
+# * Create release based on one of the platform's built results
+# * Add Readme.md file in release folder
+# * Pin to versions of aws-crt-swift and smithy-swift
+#
+
 jobs:
   macos-release:
     runs-on: macos-11


### PR DESCRIPTION
**how this works**
1.  Create branch with the pattern of:
```
release/<releaseversionhere>
```
2.  Optionally commit a local.properties file to configure:
```
#excludeModels=location.2020-11-19, ssm.2014-11-06
onlyIncludeModels=accessanalyzer.2019-11-01, acm-pca.2017-08-22
```
3.  Push the branch

**Result:**
A branch with the built artifacts and updated package.swift file.

** Example:**
https://github.com/awslabs/aws-sdk-swift/tree/release/1.1.1
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
