### PR TITLE
chore: move Packages to Sources for client runtime

### DIFF
--- a/AWSClientRuntime/Package.swift
+++ b/AWSClientRuntime/Package.swift
@@ -36,11 +36,11 @@ if let smithySwiftDir = ProcessInfo.processInfo.environment["SMITHY_SWIFT_CI_DIR
    let crtDir = ProcessInfo.processInfo.environment["AWS_CRT_SWIFT_CI_DIR"] {
     package.dependencies += [
         .package(name: "AwsCrt", path: "\(crtDir)"),
-        .package(name: "ClientRuntime", path: "\(smithySwiftDir)/Packages")
+        .package(name: "ClientRuntime", path: "\(smithySwiftDir)/Sources")
     ]
 } else {
     package.dependencies += [
         .package(name: "AwsCrt", path: "~/Projects/Amplify/SwiftSDK/aws-crt-swift"),
-        .package(name: "ClientRuntime", path: "~/Projects/Amplify/SwiftSDK/smithy-swift/Packages")
+        .package(name: "ClientRuntime", path: "~/Projects/Amplify/SwiftSDK/smithy-swift/Sources")
     ]
 }


### PR DESCRIPTION
Corresponding
https://github.com/awslabs/smithy-swift/pull/267

Ran into some issue where i am unable to see the Packages folder when pulling clientRuntime via spm via branch dependency.  Attempting to move things over to a folder called Sources


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
