### PR TITLE
chore: improve release process to handle version dependencies

### DIFF
--- a/scripts/generatePackageSwift.swift
+++ b/scripts/generatePackageSwift.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 struct VersionDeps: Codable {
-    var crtVersion: String
+    var awsCRTSwiftVersion: String
     var clientRuntimeVersion: String
 }
 let plistFile = "versionDependencies.plist"
@@ -50,7 +50,7 @@ func generateProducts(_ releasedSDKs: [String]) {
 func generateDependencies(versions: VersionDeps) {
     let dependencies = """
     dependencies: [
-        .package(name: "AwsCrt", url: "https://github.com/awslabs/aws-crt-swift.git", from: "\(versions.crtVersion)"),
+        .package(name: "AwsCrt", url: "https://github.com/awslabs/aws-crt-swift.git", from: "\(versions.awsCRTSwiftVersion)"),
         .package(name: "ClientRuntime", url: "https://github.com/awslabs/smithy-swift.git", from: "\(versions.clientRuntimeVersion)")
     ],
 """

--- a/versionDependencies.plist
+++ b/versionDependencies.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>clientRuntimeVersion</key>
 	<string>0.0.1</string>
-	<key>crtVersion</key>
+	<key>awsCRTSwiftVersion</key>
 	<string>0.0.1</string>
 </dict>
 </plist>


### PR DESCRIPTION
This further automates the release so that when the Packages.swift file is generated on release, it will target a specific version of our dependencies


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
