### PR TITLE
chore: generate test targets if needed

### DIFF
--- a/codegen/protocol-test-codegen-local/build.gradle.kts
+++ b/codegen/protocol-test-codegen-local/build.gradle.kts
@@ -46,7 +46,6 @@ fun generateSmithyBuild(tests: List<CodegenTest>): String {
                       "author": "Amazon Web Services",
                       "homepage": "https://docs.amplify.aws/",
                       "swiftVersion": "5.4.0",
-                      "shouldGenerateUnitTestTarget": true,
                       "build": {
                         "rootProject": true
                       }

--- a/codegen/protocol-test-codegen/build.gradle.kts
+++ b/codegen/protocol-test-codegen/build.gradle.kts
@@ -111,8 +111,7 @@ fun generateSmithyBuild(tests: List<ProtocolTest>): String {
                   "gitRepo": "https://github.com/aws-amplify/smithy-swift.git",
                   "author": "Amazon Web Services",
                   "homepage": "https://docs.amplify.aws/",
-                  "swiftVersion": "5.4.0",
-                  "shouldGenerateUnitTestTarget": true
+                  "swiftVersion": "5.4.0"
                 }
               }
             }"""

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -70,7 +70,6 @@ data class AwsService(
     val modelFile: File,
     val projectionName: String,
     val gitRepo: String,
-    val shouldGenerateUnitTestTarget: Boolean,
     val sdkId: String
 )
 
@@ -103,7 +102,6 @@ fun generateSmithyBuild(services: List<AwsService>): String {
                       "author": "Amazon Web Services",
                       "gitRepo": "${service.gitRepo}",
                       "swiftVersion": "5.3.0",
-                      "shouldGenerateUnitTestTarget": false,
                       "build": {
                           "rootProject": $buildStandaloneSdk
                       }
@@ -162,8 +160,7 @@ fun discoverServices(): List<AwsService> {
                 modelFile = file,
                 projectionName = name + "." + version.toLowerCase(),
                 sdkId = serviceApi.sdkId,
-                gitRepo = "https://github.com/aws-amplify/aws-sdk-swift.git",
-                shouldGenerateUnitTestTarget = false)
+                gitRepo = "https://github.com/aws-amplify/aws-sdk-swift.git")
         }
 }
 val discoveredServices: List<AwsService> by lazy { discoverServices() }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHttpBindingProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHttpBindingProtocolGenerator.kt
@@ -45,8 +45,8 @@ abstract class AWSHttpBindingProtocolGenerator : HttpBindingProtocolGenerator() 
     override val shouldRenderDecodableBodyStructForInputShapes = true
     override val shouldRenderCodingKeysForEncodable = true
 
-    override fun generateProtocolUnitTests(ctx: ProtocolGenerator.GenerationContext) {
-        HttpProtocolTestGenerator(
+    override fun generateProtocolUnitTests(ctx: ProtocolGenerator.GenerationContext): Int {
+        return HttpProtocolTestGenerator(
             ctx,
             requestTestBuilder,
             responseTestBuilder,

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/restxml/RestXmlProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/restxml/RestXmlProtocolGenerator.kt
@@ -62,12 +62,12 @@ class RestXmlProtocolGenerator : AWSHttpBindingProtocolGenerator() {
         decoder.render()
     }
 
-    override fun generateProtocolUnitTests(ctx: ProtocolGenerator.GenerationContext) {
+    override fun generateProtocolUnitTests(ctx: ProtocolGenerator.GenerationContext): Int {
         val ignoredTests = setOf(
             // FIXME - escaped strings not fully supported in rest xml
             "SimpleScalarPropertiesComplexEscapes"
         )
-        HttpProtocolTestGenerator(
+        return HttpProtocolTestGenerator(
             ctx,
             requestTestBuilder,
             responseTestBuilder,


### PR DESCRIPTION
Corresponding:
https://github.com/awslabs/smithy-swift/pull/302

The approach is basically to detect if there were any request/response/error tests generated.  If so, create a target


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
