### PR TITLE
fix: signing fix for s3

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/s3/S3SigningConfig.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/s3/S3SigningConfig.kt
@@ -44,6 +44,6 @@ private class S3SigningMiddleware() : AWSSigningMiddleware() {
         op: OperationShape
     ): String {
         val hasUnsignedPayload = op.hasTrait<UnsignedPayloadTrait>()
-        return "signedBodyHeader: .contentSha256, unsignedBody: $hasUnsignedPayload"
+        return "useDoubleURIEncode: false, shouldNormalizeURIPath: false, signedBodyHeader: .contentSha256, unsignedBody: $hasUnsignedPayload"
     }
 }


### PR DESCRIPTION
*Description of changes:* This PR is based off a Kotlin discovery and fix: https://github.com/awslabs/aws-sdk-kotlin/pull/270 

Details copied from Kotlin summary for context:
CRT normalizes and double escapes URI paths by default in accordance to the requirements of sigv4. The one and only exception to these is S3.

From https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html:

Each path segment must be URI-encoded twice (except for Amazon S3 which only gets URI-encoded once).

From https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html#canonical-request:

You do not normalize URI paths for requests to Amazon S3. For example, you may have a bucket with an object named "my-object//example//photo.user". Normalizing the path changes the object name in the request to "my-object/example/photo.user". This is an incorrect path for that object.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
