### PR TITLE
chore: Upgrade smithy to 1.10.0

### DIFF
--- a/AWSClientRuntime/Sources/Protocols/RestXML/RestXMLErrorPayload.swift
+++ b/AWSClientRuntime/Sources/Protocols/RestXML/RestXMLErrorPayload.swift
@@ -7,7 +7,7 @@
 
 public struct RestXMLErrorPayload: Decodable {
     public let errorCode: String
-    public let message: String
+    public let message: String?
     enum CodingKeys: String, CodingKey {
         case errorCode = "Code"
         case message = "Message"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 # codegen
-smithyVersion=1.9.1
+smithyVersion=1.10.0
 
 smithySwiftVersion = 0.1.0
 


### PR DESCRIPTION
Upgrading smithy to 1.10.0 and updating associated tests

## Description of changes
Need to get to 1.11.0, so incrementally updating to 1.10.0 first.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.