### PR TITLE
chore: refactor awsquery to separate decoder class

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/AwsQueryProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/AwsQueryProtocolGenerator.kt
@@ -28,7 +28,6 @@ import software.amazon.smithy.swift.codegen.integration.codingKeys.CodingKeysCus
 import software.amazon.smithy.swift.codegen.integration.codingKeys.DefaultCodingKeysGenerator
 import software.amazon.smithy.swift.codegen.integration.httpResponse.HttpResponseGenerator
 import software.amazon.smithy.swift.codegen.integration.serde.formurl.StructEncodeFormURLGenerator
-import software.amazon.smithy.swift.codegen.integration.serde.xml.StructDecodeXMLGenerator
 import software.amazon.smithy.swift.codegen.model.ShapeMetadata
 
 open class AwsQueryProtocolGenerator : AWSHttpBindingProtocolGenerator() {
@@ -76,7 +75,7 @@ open class AwsQueryProtocolGenerator : AWSHttpBindingProtocolGenerator() {
         writer: SwiftWriter,
         defaultTimestampFormat: TimestampFormatTrait.Format
     ) {
-        val decoder = StructDecodeXMLGenerator(ctx, members, shapeMetadata, writer, defaultTimestampFormat)
+        val decoder = AwsQueryStructDecodeXMLGenerator(ctx, members, shapeMetadata, writer, defaultTimestampFormat)
         decoder.render()
     }
 

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/AwsQueryStructDecodeXMLGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/AwsQueryStructDecodeXMLGenerator.kt
@@ -1,0 +1,44 @@
+package software.amazon.smithy.aws.swift.codegen.awsquery
+
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.traits.TimestampFormatTrait
+import software.amazon.smithy.swift.codegen.ClientRuntimeTypes
+import software.amazon.smithy.swift.codegen.SwiftTypes
+import software.amazon.smithy.swift.codegen.SwiftWriter
+import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
+import software.amazon.smithy.swift.codegen.integration.serde.xml.StructDecodeXMLGenerator
+import software.amazon.smithy.swift.codegen.model.ShapeMetadata
+
+class AwsQueryStructDecodeXMLGenerator(
+    ctx: ProtocolGenerator.GenerationContext,
+    private val members: List<MemberShape>,
+    private val metadata: Map<ShapeMetadata, Any>,
+    private val writer: SwiftWriter,
+    defaultTimestampFormat: TimestampFormatTrait.Format
+) : StructDecodeXMLGenerator(ctx, members, metadata, writer, defaultTimestampFormat) {
+    override fun render() {
+        writer.openBlock("public init (from decoder: \$N) throws {", "}", SwiftTypes.Decoder) {
+            if (members.isNotEmpty()) {
+                renderDecodeBody()
+            }
+        }
+    }
+
+    private fun renderDecodeBody() {
+        val containerName = "containerValues"
+        if (metadata.containsKey(ShapeMetadata.OPERATION_SHAPE)) {
+            val topLevelContainerName = "topLevelContainer"
+            writer.write("let $topLevelContainerName = try decoder.container(keyedBy: \$N.self)", ClientRuntimeTypes.Serde.Key)
+
+            val operationShape = metadata[ShapeMetadata.OPERATION_SHAPE] as OperationShape
+            val wrappedKeyValue = operationShape.id.name + "Result"
+            writer.write("let $containerName = try $topLevelContainerName.nestedContainer(keyedBy: CodingKeys.self, forKey: \$N(\"$wrappedKeyValue\"))", ClientRuntimeTypes.Serde.Key)
+        } else {
+            writer.write("let $containerName = try decoder.container(keyedBy: CodingKeys.self)")
+        }
+        members.forEach { member ->
+            renderSingleMember(member, containerName)
+        }
+    }
+}

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/BlobEncodeGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/BlobEncodeGeneratorTests.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.aws.swift.codegen.awsquery
+
+import io.kotest.matchers.string.shouldContainOnlyOnce
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.aws.swift.codegen.TestContext
+import software.amazon.smithy.aws.swift.codegen.TestContextGenerator.Companion.getFileContents
+import software.amazon.smithy.aws.swift.codegen.TestContextGenerator.Companion.initContextFrom
+import software.amazon.smithy.aws.swift.codegen.shouldSyntacticSanityCheck
+import software.amazon.smithy.aws.traits.protocols.AwsQueryTrait
+
+class BlobEncodeGeneratorTests {
+    @Test
+    fun `001 encode blobs`() {
+        val context = setupTests("awsquery/query-blobs.smithy", "aws.protocoltests.query#AwsQuery")
+        val contents = getFileContents(context.manifest, "/Example/models/BlobInputParamsInput+Encodable.swift")
+        contents.shouldSyntacticSanityCheck()
+        val expectedContents =
+            """
+            extension BlobInputParamsInput: Swift.Encodable, ClientRuntime.Reflection {
+                public func encode(to encoder: Swift.Encoder) throws {
+                    var container = encoder.container(keyedBy: ClientRuntime.Key.self)
+                    if let blobList = blobList {
+                        var blobListContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("BlobList"))
+                        for (index0, blob0) in blobList.enumerated() {
+                            try blobListContainer.encode(blob0.base64EncodedString(), forKey: ClientRuntime.Key("member.\(index0.advanced(by: 1))"))
+                        }
+                    }
+                    if let blobListFlattened = blobListFlattened {
+                        if !blobListFlattened.isEmpty {
+                            for (index0, blob0) in blobListFlattened.enumerated() {
+                                try container.encode(blob0.base64EncodedString(), forKey: ClientRuntime.Key("BlobListFlattened.\(index0.advanced(by: 1))"))
+                            }
+                        }
+                    }
+                    if let blobMap = blobMap {
+                        var blobMapContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("BlobMap"))
+                        for (index0, element0) in blobMap.sorted(by: { ${'$'}0.key < ${'$'}1.key }).enumerated() {
+                            let stringKey0 = element0.key
+                            let blobValue0 = element0.value
+                            var entryContainer0 = blobMapContainer.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("entry.\(index0.advanced(by: 1))"))
+                            var keyContainer0 = entryContainer0.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("key"))
+                            try keyContainer0.encode(stringKey0, forKey: ClientRuntime.Key(""))
+                            var valueContainer0 = entryContainer0.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("value"))
+                            try valueContainer0.encode(blobValue0.base64EncodedString(), forKey: ClientRuntime.Key(""))
+                        }
+                    }
+                    if let blobMapFlattened = blobMapFlattened {
+                        if !blobMapFlattened.isEmpty {
+                            for (index0, element0) in blobMapFlattened.sorted(by: { ${'$'}0.key < ${'$'}1.key }).enumerated() {
+                                let stringKey0 = element0.key
+                                let blobValue0 = element0.value
+                                var nestedContainer0 = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("BlobMapFlattened.\(index0.advanced(by: 1))"))
+                                var keyContainer0 = nestedContainer0.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("key"))
+                                try keyContainer0.encode(stringKey0, forKey: ClientRuntime.Key(""))
+                                var valueContainer0 = nestedContainer0.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("value"))
+                                try valueContainer0.encode(blobValue0.base64EncodedString(), forKey: ClientRuntime.Key(""))
+                            }
+                        }
+                    }
+                    if let blobMember = blobMember {
+                        try container.encode(blobMember.base64EncodedString(), forKey: ClientRuntime.Key("BlobMember"))
+                    }
+                    try container.encode("BlobInputParams", forKey:ClientRuntime.Key("Action"))
+                    try container.encode("2020-01-08", forKey:ClientRuntime.Key("Version"))
+                }
+            }
+            """.trimIndent()
+        contents.shouldContainOnlyOnce(expectedContents)
+    }
+
+    private fun setupTests(smithyFile: String, serviceShapeId: String): TestContext {
+        val context = initContextFrom(smithyFile, serviceShapeId, AwsQueryTrait.ID, "awsquery", "awsquery")
+        val generator = AwsQueryProtocolGenerator()
+        generator.generateCodableConformanceForNestedTypes(context.ctx)
+        generator.generateSerializers(context.ctx)
+        generator.generateDeserializers(context.ctx)
+        context.ctx.delegator.flushWriters()
+        return context
+    }
+}

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/ListEncodeFormURLGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/ListEncodeFormURLGeneratorTests.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.aws.swift.codegen.awsquery
+
+import io.kotest.matchers.string.shouldContainOnlyOnce
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.aws.swift.codegen.TestContext
+import software.amazon.smithy.aws.swift.codegen.TestContextGenerator
+import software.amazon.smithy.aws.swift.codegen.TestContextGenerator.Companion.getFileContents
+import software.amazon.smithy.aws.swift.codegen.shouldSyntacticSanityCheck
+import software.amazon.smithy.aws.traits.protocols.AwsQueryTrait
+
+class ListEncodeFormURLGeneratorTests {
+    @Test
+    fun `001 encode different types of lists`() {
+        val context = setupTests("awsquery/query-lists.smithy", "aws.protocoltests.query#AwsQuery")
+        val contents = getFileContents(context.manifest, "/Example/models/QueryListsInput+Encodable.swift")
+        contents.shouldSyntacticSanityCheck()
+        val expectedContents =
+            """
+            extension QueryListsInput: Swift.Encodable, ClientRuntime.Reflection {
+                public func encode(to encoder: Swift.Encoder) throws {
+                    var container = encoder.container(keyedBy: ClientRuntime.Key.self)
+                    if let complexListArg = complexListArg {
+                        var complexListArgContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("ComplexListArg"))
+                        for (index0, greetingstruct0) in complexListArg.enumerated() {
+                            try complexListArgContainer.encode(greetingstruct0, forKey: ClientRuntime.Key("member.\(index0.advanced(by: 1))"))
+                        }
+                    }
+                    if let flattenedListArg = flattenedListArg {
+                        if !flattenedListArg.isEmpty {
+                            for (index0, string0) in flattenedListArg.enumerated() {
+                                var flattenedListArgContainer0 = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("FlattenedListArg.\(index0.advanced(by: 1))"))
+                                try flattenedListArgContainer0.encode(string0, forKey: ClientRuntime.Key(""))
+                            }
+                        }
+                    }
+                    if let flattenedListArgWithXmlName = flattenedListArgWithXmlName {
+                        if !flattenedListArgWithXmlName.isEmpty {
+                            for (index0, string0) in flattenedListArgWithXmlName.enumerated() {
+                                var flattenedListArgWithXmlNameContainer0 = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("Hi.\(index0.advanced(by: 1))"))
+                                try flattenedListArgWithXmlNameContainer0.encode(string0, forKey: ClientRuntime.Key(""))
+                            }
+                        }
+                    }
+                    if let listArg = listArg {
+                        var listArgContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("ListArg"))
+                        for (index0, string0) in listArg.enumerated() {
+                            try listArgContainer.encode(string0, forKey: ClientRuntime.Key("member.\(index0.advanced(by: 1))"))
+                        }
+                    }
+                    if let listArgWithXmlNameMember = listArgWithXmlNameMember {
+                        var listArgWithXmlNameMemberContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("ListArgWithXmlNameMember"))
+                        for (index0, string0) in listArgWithXmlNameMember.enumerated() {
+                            try listArgWithXmlNameMemberContainer.encode(string0, forKey: ClientRuntime.Key("item.\(index0.advanced(by: 1))"))
+                        }
+                    }
+                    if let flatTsList = flatTsList {
+                        if !flatTsList.isEmpty {
+                            for (index0, timestamp0) in flatTsList.enumerated() {
+                                var flatTsListContainer0 = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("flatTsList.\(index0.advanced(by: 1))"))
+                                try flatTsListContainer0.encode(TimestampWrapper(timestamp0, format: .epochSeconds), forKey: ClientRuntime.Key(""))
+                            }
+                        }
+                    }
+                    if let tsList = tsList {
+                        var tsListContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("tsList"))
+                        for (index0, timestamp0) in tsList.enumerated() {
+                            try tsListContainer.encode(TimestampWrapper(timestamp0, format: .epochSeconds), forKey: ClientRuntime.Key("member.\(index0.advanced(by: 1))"))
+                        }
+                    }
+                    try container.encode("QueryLists", forKey:ClientRuntime.Key("Action"))
+                    try container.encode("2020-01-08", forKey:ClientRuntime.Key("Version"))
+                }
+            }
+            """.trimIndent()
+        contents.shouldContainOnlyOnce(expectedContents)
+    }
+
+    private fun setupTests(smithyFile: String, serviceShapeId: String): TestContext {
+        val context =
+            TestContextGenerator.initContextFrom(smithyFile, serviceShapeId, AwsQueryTrait.ID, "awsquery", "awsquery")
+        val generator = AwsQueryProtocolGenerator()
+        generator.generateCodableConformanceForNestedTypes(context.ctx)
+        generator.generateSerializers(context.ctx)
+        context.ctx.delegator.flushWriters()
+        return context
+    }
+}

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/MapEncodeFormURLGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/MapEncodeFormURLGeneratorTests.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.aws.swift.codegen.awsquery
+
+import io.kotest.matchers.string.shouldContainOnlyOnce
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.aws.swift.codegen.TestContext
+import software.amazon.smithy.aws.swift.codegen.TestContextGenerator
+import software.amazon.smithy.aws.swift.codegen.TestContextGenerator.Companion.getFileContents
+import software.amazon.smithy.aws.swift.codegen.shouldSyntacticSanityCheck
+import software.amazon.smithy.aws.traits.protocols.AwsQueryTrait
+
+class MapEncodeFormURLGeneratorTests {
+
+    @Test
+    fun `001 encode different types of maps`() {
+        val context = setupTests("awsquery/query-maps.smithy", "aws.protocoltests.query#AwsQuery")
+        val contents = getFileContents(context.manifest, "/Example/models/QueryMapsInput+Encodable.swift")
+        contents.shouldSyntacticSanityCheck()
+        val expectedContents =
+            """
+            extension QueryMapsInput: Swift.Encodable, ClientRuntime.Reflection {
+                public func encode(to encoder: Swift.Encoder) throws {
+                    var container = encoder.container(keyedBy: ClientRuntime.Key.self)
+                    if let complexMapArg = complexMapArg {
+                        var complexMapArgContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("ComplexMapArg"))
+                        for (index0, element0) in complexMapArg.sorted(by: { ${'$'}0.key < ${'$'}1.key }).enumerated() {
+                            let stringKey0 = element0.key
+                            let greetingstructValue0 = element0.value
+                            var entryContainer0 = complexMapArgContainer.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("entry.\(index0.advanced(by: 1))"))
+                            var keyContainer0 = entryContainer0.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("key"))
+                            try keyContainer0.encode(stringKey0, forKey: ClientRuntime.Key(""))
+                            var valueContainer0 = entryContainer0.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("value"))
+                            try valueContainer0.encode(greetingstructValue0, forKey: ClientRuntime.Key(""))
+                        }
+                    }
+                    if let flattenedMap = flattenedMap {
+                        if !flattenedMap.isEmpty {
+                            for (index0, element0) in flattenedMap.sorted(by: { ${'$'}0.key < ${'$'}1.key }).enumerated() {
+                                let stringKey0 = element0.key
+                                let stringValue0 = element0.value
+                                var nestedContainer0 = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("FlattenedMap.\(index0.advanced(by: 1))"))
+                                var keyContainer0 = nestedContainer0.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("key"))
+                                try keyContainer0.encode(stringKey0, forKey: ClientRuntime.Key(""))
+                                var valueContainer0 = nestedContainer0.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("value"))
+                                try valueContainer0.encode(stringValue0, forKey: ClientRuntime.Key(""))
+                            }
+                        }
+                    }
+                    if let flattenedMapWithXmlName = flattenedMapWithXmlName {
+                        if !flattenedMapWithXmlName.isEmpty {
+                            for (index0, element0) in flattenedMapWithXmlName.sorted(by: { ${'$'}0.key < ${'$'}1.key }).enumerated() {
+                                let stringKey0 = element0.key
+                                let stringValue0 = element0.value
+                                var nestedContainer0 = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("Hi.\(index0.advanced(by: 1))"))
+                                var keyContainer0 = nestedContainer0.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("K"))
+                                try keyContainer0.encode(stringKey0, forKey: ClientRuntime.Key(""))
+                                var valueContainer0 = nestedContainer0.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("V"))
+                                try valueContainer0.encode(stringValue0, forKey: ClientRuntime.Key(""))
+                            }
+                        }
+                    }
+                    if let mapArg = mapArg {
+                        var mapArgContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("MapArg"))
+                        for (index0, element0) in mapArg.sorted(by: { ${'$'}0.key < ${'$'}1.key }).enumerated() {
+                            let stringKey0 = element0.key
+                            let stringValue0 = element0.value
+                            var entryContainer0 = mapArgContainer.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("entry.\(index0.advanced(by: 1))"))
+                            var keyContainer0 = entryContainer0.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("key"))
+                            try keyContainer0.encode(stringKey0, forKey: ClientRuntime.Key(""))
+                            var valueContainer0 = entryContainer0.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("value"))
+                            try valueContainer0.encode(stringValue0, forKey: ClientRuntime.Key(""))
+                        }
+                    }
+                    if let mapOfLists = mapOfLists {
+                        var mapOfListsContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("MapOfLists"))
+                        for (index0, element0) in mapOfLists.sorted(by: { ${'$'}0.key < ${'$'}1.key }).enumerated() {
+                            let stringKey0 = element0.key
+                            let stringlistValue0 = element0.value
+                            var entryContainer0 = mapOfListsContainer.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("entry.\(index0.advanced(by: 1))"))
+                            var keyContainer0 = entryContainer0.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("key"))
+                            try keyContainer0.encode(stringKey0, forKey: ClientRuntime.Key(""))
+                            var valueContainer1 = entryContainer0.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("value"))
+                            for (index1, string1) in stringlistValue0.enumerated() {
+                                try valueContainer1.encode(string1, forKey: ClientRuntime.Key("member.\(index1.advanced(by: 1))"))
+                            }
+                        }
+                    }
+                    if let mapWithXmlMemberName = mapWithXmlMemberName {
+                        var mapWithXmlMemberNameContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("MapWithXmlMemberName"))
+                        for (index0, element0) in mapWithXmlMemberName.sorted(by: { ${'$'}0.key < ${'$'}1.key }).enumerated() {
+                            let stringKey0 = element0.key
+                            let stringValue0 = element0.value
+                            var entryContainer0 = mapWithXmlMemberNameContainer.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("entry.\(index0.advanced(by: 1))"))
+                            var keyContainer0 = entryContainer0.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("K"))
+                            try keyContainer0.encode(stringKey0, forKey: ClientRuntime.Key(""))
+                            var valueContainer0 = entryContainer0.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("V"))
+                            try valueContainer0.encode(stringValue0, forKey: ClientRuntime.Key(""))
+                        }
+                    }
+                    if let renamedMapArg = renamedMapArg {
+                        var renamedMapArgContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("Foo"))
+                        for (index0, element0) in renamedMapArg.sorted(by: { ${'$'}0.key < ${'$'}1.key }).enumerated() {
+                            let stringKey0 = element0.key
+                            let stringValue0 = element0.value
+                            var entryContainer0 = renamedMapArgContainer.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("entry.\(index0.advanced(by: 1))"))
+                            var keyContainer0 = entryContainer0.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("key"))
+                            try keyContainer0.encode(stringKey0, forKey: ClientRuntime.Key(""))
+                            var valueContainer0 = entryContainer0.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("value"))
+                            try valueContainer0.encode(stringValue0, forKey: ClientRuntime.Key(""))
+                        }
+                    }
+                    try container.encode("QueryMaps", forKey:ClientRuntime.Key("Action"))
+                    try container.encode("2020-01-08", forKey:ClientRuntime.Key("Version"))
+                }
+            }
+            """.trimIndent()
+        contents.shouldContainOnlyOnce(expectedContents)
+    }
+
+    private fun setupTests(smithyFile: String, serviceShapeId: String): TestContext {
+        val context =
+            TestContextGenerator.initContextFrom(smithyFile, serviceShapeId, AwsQueryTrait.ID, "awsquery", "awsquery")
+        val generator = AwsQueryProtocolGenerator()
+        generator.generateCodableConformanceForNestedTypes(context.ctx)
+        generator.generateSerializers(context.ctx)
+        context.ctx.delegator.flushWriters()
+        return context
+    }
+}

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/QueryIdempotencyTokenAutoFillGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/QueryIdempotencyTokenAutoFillGeneratorTests.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.aws.swift.codegen.awsquery
+
+import io.kotest.matchers.string.shouldContainOnlyOnce
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.aws.swift.codegen.TestContext
+import software.amazon.smithy.aws.swift.codegen.TestContextGenerator
+import software.amazon.smithy.aws.swift.codegen.TestContextGenerator.Companion.getFileContents
+import software.amazon.smithy.aws.swift.codegen.shouldSyntacticSanityCheck
+import software.amazon.smithy.aws.traits.protocols.AwsQueryTrait
+
+class QueryIdempotencyTokenAutoFillGeneratorTests {
+
+    @Test
+    fun `001 hardcodes action and version into input type`() {
+        val context = setupTests("awsquery/query-idempotency-token.smithy", "aws.protocoltests.query#AwsQuery")
+        val contents = getFileContents(context.manifest, "/Example/models/QueryIdempotencyTokenAutoFillInput+Encodable.swift")
+        contents.shouldSyntacticSanityCheck()
+        val expectedContents =
+            """
+            extension QueryIdempotencyTokenAutoFillInput: Swift.Encodable, ClientRuntime.Reflection {
+                public func encode(to encoder: Swift.Encoder) throws {
+                    var container = encoder.container(keyedBy: ClientRuntime.Key.self)
+                    if let token = token {
+                        try container.encode(token, forKey: ClientRuntime.Key("token"))
+                    }
+                    try container.encode("QueryIdempotencyTokenAutoFill", forKey:ClientRuntime.Key("Action"))
+                    try container.encode("2020-01-08", forKey:ClientRuntime.Key("Version"))
+                }
+            }
+            """.trimIndent()
+        contents.shouldContainOnlyOnce(expectedContents)
+    }
+
+    private fun setupTests(smithyFile: String, serviceShapeId: String): TestContext {
+        val context =
+            TestContextGenerator.initContextFrom(smithyFile, serviceShapeId, AwsQueryTrait.ID, "awsquery", "awsquery")
+        val generator = AwsQueryProtocolGenerator()
+        generator.generateCodableConformanceForNestedTypes(context.ctx)
+        generator.generateSerializers(context.ctx)
+        context.ctx.delegator.flushWriters()
+        return context
+    }
+}

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/StructDecodeWrappedXMLGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/StructDecodeWrappedXMLGeneratorTests.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.aws.swift.codegen.awsquery
+
+import io.kotest.matchers.string.shouldContainOnlyOnce
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.aws.swift.codegen.TestContext
+import software.amazon.smithy.aws.swift.codegen.TestContextGenerator
+import software.amazon.smithy.aws.swift.codegen.TestContextGenerator.Companion.getFileContents
+import software.amazon.smithy.aws.traits.protocols.AwsQueryTrait
+
+class StructDecodeWrappedXMLGeneratorTests {
+
+    @Test
+    fun `wrapped map decodable`() {
+        val context = setupTests("awsquery/flattened-map.smithy", "aws.protocoltests.query#AwsQuery")
+        val contents = getFileContents(context.manifest, "/Example/models/FlattenedXmlMapOutputResponseBody+Decodable.swift")
+        val expectedContents = """
+        struct FlattenedXmlMapOutputResponseBody: Swift.Equatable {
+            public let myMap: [Swift.String:Swift.String]?
+        }
+        
+        extension FlattenedXmlMapOutputResponseBody: Swift.Decodable {
+            enum CodingKeys: Swift.String, Swift.CodingKey {
+                case myMap
+            }
+        
+            public init (from decoder: Swift.Decoder) throws {
+                let topLevelContainer = try decoder.container(keyedBy: ClientRuntime.Key.self)
+                let containerValues = try topLevelContainer.nestedContainer(keyedBy: CodingKeys.self, forKey: ClientRuntime.Key("FlattenedXmlMapResult"))
+                if containerValues.contains(.myMap) {
+                    struct KeyVal0{struct key{}; struct value{}}
+                    let myMapWrappedContainer = containerValues.nestedContainerNonThrowable(keyedBy: ClientRuntime.MapEntry<Swift.String, Swift.String, KeyVal0.key, KeyVal0.value>.CodingKeys.self, forKey: .myMap)
+                    if myMapWrappedContainer != nil {
+                        let myMapContainer = try containerValues.decodeIfPresent([ClientRuntime.MapKeyValue<Swift.String, Swift.String, KeyVal0.key, KeyVal0.value>].self, forKey: .myMap)
+                        var myMapBuffer: [Swift.String:Swift.String]? = nil
+                        if let myMapContainer = myMapContainer {
+                            myMapBuffer = [Swift.String:Swift.String]()
+                            for stringContainer0 in myMapContainer {
+                                myMapBuffer?[stringContainer0.key] = stringContainer0.value
+                            }
+                        }
+                        myMap = myMapBuffer
+                    } else {
+                        myMap = [:]
+                    }
+                } else {
+                    myMap = nil
+                }
+            }
+        }
+        """.trimIndent()
+
+        contents.shouldContainOnlyOnce(expectedContents)
+    }
+
+    private fun setupTests(smithyFile: String, serviceShapeId: String): TestContext {
+        val context =
+            TestContextGenerator.initContextFrom(smithyFile, serviceShapeId, AwsQueryTrait.ID, "awsquery", "awsquery")
+        val generator = AwsQueryProtocolGenerator()
+        generator.generateCodableConformanceForNestedTypes(context.ctx)
+        generator.generateDeserializers(context.ctx)
+        context.ctx.delegator.flushWriters()
+        return context
+    }
+}

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/TimestampGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/TimestampGeneratorTests.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.aws.swift.codegen.awsquery
+
+import io.kotest.matchers.string.shouldContainOnlyOnce
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.aws.swift.codegen.TestContext
+import software.amazon.smithy.aws.swift.codegen.TestContextGenerator
+import software.amazon.smithy.aws.swift.codegen.TestContextGenerator.Companion.getFileContents
+import software.amazon.smithy.aws.swift.codegen.shouldSyntacticSanityCheck
+import software.amazon.smithy.aws.traits.protocols.AwsQueryTrait
+
+class TimestampGeneratorTests {
+
+    @Test
+    fun `001 encode timestamps`() {
+        val context = setupTests("awsquery/query-timestamp.smithy", "aws.protocoltests.query#AwsQuery")
+        val contents = getFileContents(context.manifest, "/Example/models/QueryTimestampsInput+Encodable.swift")
+        contents.shouldSyntacticSanityCheck()
+        val expectedContents =
+            """
+            extension QueryTimestampsInput: Swift.Encodable, ClientRuntime.Reflection {
+                public func encode(to encoder: Swift.Encoder) throws {
+                    var container = encoder.container(keyedBy: ClientRuntime.Key.self)
+                    if let epochMember = epochMember {
+                        try container.encode(ClientRuntime.TimestampWrapper(epochMember, format: .epochSeconds), forKey: ClientRuntime.Key("epochMember"))
+                    }
+                    if let epochTarget = epochTarget {
+                        try container.encode(ClientRuntime.TimestampWrapper(epochTarget, format: .epochSeconds), forKey: ClientRuntime.Key("epochTarget"))
+                    }
+                    if let normalFormat = normalFormat {
+                        try container.encode(ClientRuntime.TimestampWrapper(normalFormat, format: .dateTime), forKey: ClientRuntime.Key("normalFormat"))
+                    }
+                    try container.encode("QueryTimestamps", forKey:ClientRuntime.Key("Action"))
+                    try container.encode("2020-01-08", forKey:ClientRuntime.Key("Version"))
+                }
+            }
+            """.trimIndent()
+        contents.shouldContainOnlyOnce(expectedContents)
+    }
+
+    private fun setupTests(smithyFile: String, serviceShapeId: String): TestContext {
+        val context =
+            TestContextGenerator.initContextFrom(smithyFile, serviceShapeId, AwsQueryTrait.ID, "awsquery", "awsquery")
+        val generator = AwsQueryProtocolGenerator()
+        generator.generateCodableConformanceForNestedTypes(context.ctx)
+        generator.generateSerializers(context.ctx)
+        context.ctx.delegator.flushWriters()
+        return context
+    }
+}

--- a/codegen/smithy-aws-swift-codegen/src/test/resources/software.amazon.smithy.aws.swift.codegen/awsquery/flattened-map.smithy
+++ b/codegen/smithy-aws-swift-codegen/src/test/resources/software.amazon.smithy.aws.swift.codegen/awsquery/flattened-map.smithy
@@ -1,0 +1,32 @@
+$version: "1.0"
+
+namespace aws.protocoltests.query
+
+use aws.api#service
+use aws.protocols#awsQuery
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+@service(sdkId: "Query Protocol")
+@awsQuery
+@xmlNamespace(uri: "https://example.com/")
+service AwsQuery {
+    version: "2020-01-08",
+    operations: [
+        FlattenedXmlMap
+    ]
+}
+
+operation FlattenedXmlMap {
+    output: FlattenedXmlMapOutput
+}
+
+structure FlattenedXmlMapOutput {
+    @xmlFlattened
+    myMap: StringMap,
+}
+
+map StringMap {
+    key: String,
+    value: String
+}

--- a/codegen/smithy-aws-swift-codegen/src/test/resources/software.amazon.smithy.aws.swift.codegen/awsquery/query-blobs.smithy
+++ b/codegen/smithy-aws-swift-codegen/src/test/resources/software.amazon.smithy.aws.swift.codegen/awsquery/query-blobs.smithy
@@ -1,0 +1,42 @@
+$version: "1.0"
+
+namespace aws.protocoltests.query
+
+use aws.api#service
+use aws.protocols#awsQuery
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+@service(sdkId: "Query Protocol")
+@awsQuery
+@xmlNamespace(uri: "https://example.com/")
+service AwsQuery {
+    version: "2020-01-08",
+    operations: [
+        BlobInputParams
+    ]
+}
+
+operation BlobInputParams {
+    input: BlobInputParamsInput
+}
+
+structure BlobInputParamsInput {
+    BlobMember: Blob,
+    BlobMap: BlobMap,
+    BlobList: BlobList,
+    @xmlFlattened
+    BlobListFlattened: BlobList,
+
+    @xmlFlattened
+    BlobMapFlattened: BlobMap,
+}
+
+list BlobList {
+    member: Blob,
+}
+
+map BlobMap {
+    key: String,
+    value: Blob,
+}

--- a/codegen/smithy-aws-swift-codegen/src/test/resources/software.amazon.smithy.aws.swift.codegen/awsquery/query-idempotency-token.smithy
+++ b/codegen/smithy-aws-swift-codegen/src/test/resources/software.amazon.smithy.aws.swift.codegen/awsquery/query-idempotency-token.smithy
@@ -1,0 +1,28 @@
+$version: "1.0"
+
+namespace aws.protocoltests.query
+
+use aws.api#service
+use aws.protocols#awsQuery
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+@service(sdkId: "Query Protocol")
+@awsQuery
+@xmlNamespace(uri: "https://example.com/")
+service AwsQuery {
+    version: "2020-01-08",
+    operations: [
+        QueryIdempotencyTokenAutoFill
+    ]
+}
+
+@tags(["client-only"])
+operation QueryIdempotencyTokenAutoFill {
+    input: QueryIdempotencyTokenAutoFillInput
+}
+
+structure QueryIdempotencyTokenAutoFillInput {
+    @idempotencyToken
+    token: String,
+}

--- a/codegen/smithy-aws-swift-codegen/src/test/resources/software.amazon.smithy.aws.swift.codegen/awsquery/query-lists.smithy
+++ b/codegen/smithy-aws-swift-codegen/src/test/resources/software.amazon.smithy.aws.swift.codegen/awsquery/query-lists.smithy
@@ -1,0 +1,64 @@
+$version: "1.0"
+
+namespace aws.protocoltests.query
+
+use aws.api#service
+use aws.protocols#awsQuery
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+@service(sdkId: "Query Protocol")
+@awsQuery
+@xmlNamespace(uri: "https://example.com/")
+service AwsQuery {
+    version: "2020-01-08",
+    operations: [
+        QueryLists
+    ]
+}
+
+operation QueryLists {
+    input: QueryListsInput
+}
+
+structure QueryListsInput {
+    ListArg: StringList,
+    ComplexListArg: GreetingList,
+
+    @xmlFlattened
+    FlattenedListArg: StringList,
+
+    tsList: TimestampList,
+
+    @xmlFlattened
+    flatTsList: TimestampList,
+
+    ListArgWithXmlNameMember: ListWithXmlName,
+
+    // Notice that the xmlName on the targeted list member is ignored.
+    @xmlFlattened
+    @xmlName("Hi")
+    FlattenedListArgWithXmlName: ListWithXmlName,
+}
+
+list StringList {
+    member: String,
+}
+
+structure GreetingStruct {
+    hi: String,
+}
+list GreetingList {
+    member: GreetingStruct
+}
+
+list ListWithXmlName {
+    @xmlName("item")
+    member: String
+}
+
+
+list TimestampList {
+    @timestampFormat("epoch-seconds")
+    member: Timestamp
+}

--- a/codegen/smithy-aws-swift-codegen/src/test/resources/software.amazon.smithy.aws.swift.codegen/awsquery/query-maps.smithy
+++ b/codegen/smithy-aws-swift-codegen/src/test/resources/software.amazon.smithy.aws.swift.codegen/awsquery/query-maps.smithy
@@ -1,0 +1,72 @@
+$version: "1.0"
+
+namespace aws.protocoltests.query
+
+use aws.api#service
+use aws.protocols#awsQuery
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+@service(sdkId: "Query Protocol")
+@awsQuery
+@xmlNamespace(uri: "https://example.com/")
+service AwsQuery {
+    version: "2020-01-08",
+    operations: [
+        QueryMaps
+    ]
+}
+
+operation QueryMaps {
+    input: QueryMapsInput
+}
+
+structure QueryMapsInput {
+    MapArg: StringMap,
+
+    @xmlName("Foo")
+    RenamedMapArg: StringMap,
+
+    ComplexMapArg: ComplexMap,
+
+    MapWithXmlMemberName: MapWithXmlName,
+
+    @xmlFlattened
+    FlattenedMap: StringMap,
+
+    @xmlFlattened
+    @xmlName("Hi")
+    FlattenedMapWithXmlName: MapWithXmlName,
+
+    MapOfLists: MapOfLists,
+}
+
+map StringMap {
+    key: String,
+    value: String,
+}
+
+map ComplexMap {
+    key: String,
+    value: GreetingStruct,
+}
+structure GreetingStruct {
+    hi: String,
+}
+
+map MapWithXmlName {
+    @xmlName("K")
+    key: String,
+
+    @xmlName("V")
+    value: String
+}
+
+map MapOfLists {
+    key: String,
+    value: StringList,
+}
+
+list StringList {
+    member: String,
+}

--- a/codegen/smithy-aws-swift-codegen/src/test/resources/software.amazon.smithy.aws.swift.codegen/awsquery/query-timestamp.smithy
+++ b/codegen/smithy-aws-swift-codegen/src/test/resources/software.amazon.smithy.aws.swift.codegen/awsquery/query-timestamp.smithy
@@ -1,0 +1,35 @@
+$version: "1.0"
+
+namespace aws.protocoltests.query
+
+use aws.api#service
+use aws.protocols#awsQuery
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+@service(sdkId: "Query Protocol")
+@awsQuery
+@xmlNamespace(uri: "https://example.com/")
+service AwsQuery {
+    version: "2020-01-08",
+    operations: [
+        QueryTimestamps
+    ]
+}
+
+operation QueryTimestamps {
+    input: QueryTimestampsInput
+}
+
+structure QueryTimestampsInput {
+    // Timestamps are serialized as RFC 3339 date-time values by default.
+    normalFormat: Timestamp,
+
+    @timestampFormat("epoch-seconds")
+    epochMember: Timestamp,
+
+    epochTarget: EpochSeconds,
+}
+
+@timestampFormat("epoch-seconds")
+timestamp EpochSeconds


### PR DESCRIPTION
## Description of changes
In order to support `s3UnwrappedXmlOutput` we'll need to pass in the service shape via the metadata to `MemberShapeDecodeXMLGenerator` -- but this is in conflict with how this class works with AWSQuery.  This needs to be updated.

We'll need to refactor this first, and then we can update the code to accommodate `s3UnwrappedXmlOutput`

Corresponding:
https://github.com/awslabs/smithy-swift/pull/334

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.