### PR TITLE
chore: add presignable model integration

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/PresignableModelIntegration.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/PresignableModelIntegration.kt
@@ -1,0 +1,46 @@
+package software.amazon.smithy.aws.swift.codegen.customization
+
+import software.amazon.smithy.aws.swift.codegen.model.traits.Presignable
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.model.transform.ModelTransformer
+import software.amazon.smithy.swift.codegen.SwiftSettings
+import software.amazon.smithy.swift.codegen.integration.SwiftIntegration
+import software.amazon.smithy.swift.codegen.model.expectShape
+
+internal val DEFAULT_PRESIGNABLE_OPERATIONS: Map<String, Set<String>> = mapOf(
+    "com.amazonaws.s3#AmazonS3" to setOf(
+        "com.amazonaws.s3#GetObject",
+        "com.amazonaws.s3#PutObject",
+        "com.amazonaws.s3#UploadPart"
+    ),
+    "com.amazonaws.sts#AWSSecurityTokenServiceV20110615" to setOf(
+        "com.amazonaws.sts#GetCallerIdentity"
+    ),
+    "com.amazonaws.polly#Parrot_v1" to setOf(
+        "com.amazonaws.polly#SynthesizeSpeech"
+    )
+)
+
+class PresignableModelIntegration(private val presignedOperations: Map<String, Set<String>> = DEFAULT_PRESIGNABLE_OPERATIONS) : SwiftIntegration {
+    override fun enabledForService(model: Model, settings: SwiftSettings): Boolean {
+        val currentServiceId = model.expectShape<ServiceShape>(settings.service).id.toString()
+
+        return presignedOperations.keys.contains(currentServiceId)
+    }
+
+    override fun preprocessModel(model: Model, settings: SwiftSettings): Model {
+        val currentServiceId = model.expectShape<ServiceShape>(settings.service).id.toString()
+        val presignedOperationIds = presignedOperations[currentServiceId]
+            ?: error("Expected operation id for service $currentServiceId, but none found in $presignedOperations")
+        val transformer = ModelTransformer.create()
+
+        return transformer.mapShapes(model) { shape ->
+            if (presignedOperationIds.contains(shape.id.toString())) {
+                shape.asOperationShape().get().toBuilder().addTrait(Presignable()).build()
+            } else {
+                shape
+            }
+        }
+    }
+}

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/model/traits/Presignable.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/model/traits/Presignable.kt
@@ -1,0 +1,29 @@
+package software.amazon.smithy.aws.swift.codegen.model.traits
+
+import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.model.node.ObjectNode
+import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.traits.AnnotationTrait
+
+/**
+ * This custom trait designates operations from which presigners can be generated.
+ *
+ * Operations decorated with this trait have been deemed useful to be called out of band
+ * from a normal client-based operation call.  This may be due to the operation being embedded in
+ * another operation call or the customer may wish to invoke the presigned request at a later time or in
+ * some part of their software that does not have access to a service client instance.
+ *
+ * Behavior for how a operation is presignable is in some ways protocol specific:
+ * restXml - for operations which require bodies as input, these are unsigned
+ * awsQuery - GET calls are performed by mapping the body into the querystring
+ *
+ * This trait may be generalized to Smithy itself.  If this happens, this integration should be removed
+ * entirely.
+ */
+class Presignable : AnnotationTrait {
+    companion object {
+        val ID: ShapeId = ShapeId.from("smithy.swift.traits#presignable")
+    }
+    constructor(node: ObjectNode) : super(ID, node)
+    constructor() : this(Node.objectNode())
+}

--- a/codegen/smithy-aws-swift-codegen/src/main/resources/META-INF/services/software.amazon.smithy.swift.codegen.integration.SwiftIntegration
+++ b/codegen/smithy-aws-swift-codegen/src/main/resources/META-INF/services/software.amazon.smithy.swift.codegen.integration.SwiftIntegration
@@ -4,4 +4,5 @@ software.amazon.smithy.aws.swift.codegen.customization.s3.S3ErrorIntegration
 software.amazon.smithy.aws.swift.codegen.customization.apigateway.ApiGatewayAddAcceptHeader
 software.amazon.smithy.aws.swift.codegen.customization.glacier.GlacierAddVersionHeader
 software.amazon.smithy.aws.swift.codegen.customization.BoxServices
+software.amazon.smithy.aws.swift.codegen.customization.PresignableModelIntegration
 


### PR DESCRIPTION
This PR adds a pre-signable trait to specific operations that are pre-signable.  We will eventually use this trait to generate what we need so that customers can create get presigned requests.

## Issue \#
One of many PRs that will be made to drive #230 to completion

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.