### PR TITLE
fix: Prefix build targets in package manifest on a release

### DIFF
--- a/TestLambdaSdk/Package.swift
+++ b/TestLambdaSdk/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         //FIXME change this path to be non-localized
-        .package(name: "S3", path: "~/Projects/Amplify/SwiftSDK/aws-sdk-swift/codegen/sdk-codegen/build/smithyprojections/sdk-codegen/s3.2006-03-01/swift-codegen"),
+        .package(name: "AWSS3", path: "~/Projects/Amplify/SwiftSDK/aws-sdk-swift/codegen/sdk-codegen/build/smithyprojections/sdk-codegen/s3.2006-03-01/swift-codegen"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -22,7 +22,7 @@ let package = Package(
         .executableTarget(
             name: "TestSdk",
             dependencies: [
-                "S3"
+                "AWSS3"
             ]),
         .testTarget(
             name: "TestSdkTests",

--- a/TestLambdaSdk/Sources/TestSdk/main.swift
+++ b/TestLambdaSdk/Sources/TestSdk/main.swift
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-import S3
+import AWSS3
 import Foundation
 import ClientRuntime
 

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -6,13 +6,11 @@
 // This build file has been adapted from the Go v2 SDK, here:
 // https://github.com/aws/aws-sdk-go-v2/blob/master/codegen/sdk-codegen/build.gradle.kts
 
-import software.amazon.smithy.model.Model
-import software.amazon.smithy.model.node.Node
-import software.amazon.smithy.model.node.ObjectNode
-import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.gradle.tasks.SmithyBuild
-import kotlin.streams.toList
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.ServiceShape
 import java.util.Properties
+import kotlin.streams.toList
 
 plugins {
     id("software.amazon.smithy") version "0.5.3"
@@ -101,7 +99,7 @@ fun generateSmithyBuild(services: List<AwsService>): String {
                       "sdkId": "${service.sdkId}",
                       "author": "Amazon Web Services",
                       "gitRepo": "${service.gitRepo}",
-                      "swiftVersion": "5.3.0",
+                      "swiftVersion": "5.4.0",
                       "build": {
                           "rootProject": $buildStandaloneSdk
                       }

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -93,7 +93,7 @@ fun generateSmithyBuild(services: List<AwsService>): String {
                 "plugins": {
                     "swift-codegen": {
                       "service": "${service.name}",
-                      "module" : "AWS${service.packageName}",
+                      "module" : "${service.packageName}",
                       "moduleVersion": "${service.packageVersion}",
                       "homepage": "https://docs.amplify.aws/",
                       "sdkId": "${service.sdkId}",
@@ -153,7 +153,7 @@ fun discoverServices(): List<AwsService> {
 
             AwsService(
                 name = service.id.toString(),
-                packageName = "${serviceApi.sdkId.filterNot { it.isWhitespace() }.capitalize()}",
+                packageName = "AWS${serviceApi.sdkId.filterNot { it.isWhitespace() }.capitalize()}",
                 packageVersion = "1.0",
                 modelFile = file,
                 projectionName = name + "." + version.toLowerCase(),

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -93,7 +93,7 @@ fun generateSmithyBuild(services: List<AwsService>): String {
                 "plugins": {
                     "swift-codegen": {
                       "service": "${service.name}",
-                      "module" : "${service.packageName}",
+                      "module" : "AWS${service.packageName}",
                       "moduleVersion": "${service.packageVersion}",
                       "homepage": "https://docs.amplify.aws/",
                       "sdkId": "${service.sdkId}",

--- a/scripts/generatePackageSwift.swift
+++ b/scripts/generatePackageSwift.swift
@@ -47,8 +47,7 @@ func generateProducts(_ releasedSDKs: [String]) {
     print("    products: [")
     print("        .library(name: \"AWSClientRuntime\", targets: [\"AWSClientRuntime\"]),")
     for sdk in releasedSDKs {
-        let prefixedName = "AWS\(sdk)"
-        print("        .library(name: \"\(prefixedName)\", targets: [\"\(prefixedName)\"]),")
+        print("        .library(name: \"\(sdk)\", targets: [\"\(sdk)\"]),")
     }
     print("    ],")
 
@@ -87,8 +86,7 @@ func generateTargets(_ releasedSDKs: [String]) {
 """
     print(targetsBeginning)
     for sdk in releasedSDKs {
-        let prefixedName = "AWS\(sdk)"
-        print("        .target(name: \"\(prefixedName)\", dependencies: [.product(name: \"ClientRuntime\", package: \"ClientRuntime\"), \"AWSClientRuntime\"], path: \"./release/\(sdk)\"),")
+        print("        .target(name: \"\(sdk)\", dependencies: [.product(name: \"ClientRuntime\", package: \"ClientRuntime\"), \"AWSClientRuntime\"], path: \"./release/\(sdk)\"),")
     }
     print("        ]")
     

--- a/scripts/generatePackageSwift.swift
+++ b/scripts/generatePackageSwift.swift
@@ -47,7 +47,8 @@ func generateProducts(_ releasedSDKs: [String]) {
     print("    products: [")
     print("        .library(name: \"AWSClientRuntime\", targets: [\"AWSClientRuntime\"]),")
     for sdk in releasedSDKs {
-        print("        .library(name: \"\(sdk)\", targets: [\"\(sdk)\"]),")
+        let prefixedName = "AWS\(sdk)"
+        print("        .library(name: \"\(prefixedName)\", targets: [\"\(prefixedName)\"]),")
     }
     print("    ],")
 
@@ -86,7 +87,8 @@ func generateTargets(_ releasedSDKs: [String]) {
 """
     print(targetsBeginning)
     for sdk in releasedSDKs {
-        print("        .target(name: \"\(sdk)\", dependencies: [.product(name: \"ClientRuntime\", package: \"ClientRuntime\"), \"AWSClientRuntime\"], path: \"./release/\(sdk)\"),")
+        let prefixedName = "AWS\(sdk)"
+        print("        .target(name: \"\(prefixedName)\", dependencies: [.product(name: \"ClientRuntime\", package: \"ClientRuntime\"), \"AWSClientRuntime\"], path: \"./release/\(sdk)\"),")
     }
     print("        ]")
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->
This resolves a naming conflict issue Amplify was having with SPM.
no corresponding PR

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.