### PR TITLE
chore: Remove middleware function from HttpProtocolCustomizable

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AWSHttpProtocolJson10Customizations.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AWSHttpProtocolJson10Customizations.kt
@@ -5,28 +5,6 @@
 
 package software.amazon.smithy.aws.swift.codegen.awsjson
 
-import software.amazon.smithy.aws.swift.codegen.AWSClientRuntimeTypes
 import software.amazon.smithy.aws.swift.codegen.AWSHttpProtocolCustomizations
-import software.amazon.smithy.aws.swift.codegen.AWSSwiftDependency
-import software.amazon.smithy.codegen.core.Symbol
-import software.amazon.smithy.protocoltests.traits.HttpRequestTestCase
-import software.amazon.smithy.swift.codegen.SwiftWriter
 
-class AWSHttpProtocolJson10Customizations : AWSHttpProtocolCustomizations() {
-
-    override fun renderMiddlewareForGeneratedRequestTests(
-        writer: SwiftWriter,
-        test: HttpRequestTestCase,
-        operationStack: String,
-        inputSymbol: Symbol,
-        outputSymbol: Symbol,
-        outputErrorName: String,
-        hasHttpBody: Boolean
-    ) {
-        writer.addImport(AWSSwiftDependency.AWS_CLIENT_RUNTIME.target)
-        if (test.headers.keys.contains("X-Amz-Target")) {
-            val XAmzTargetValue = test.headers["X-Amz-Target"]
-            writer.write("$operationStack.serializeStep.intercept(position: .before, middleware: \$N<${inputSymbol.name}, $outputSymbol, $outputErrorName>(xAmzTarget: \"${XAmzTargetValue}\"))", AWSClientRuntimeTypes.AWSJSON.XAmzTargetMiddleware)
-        }
-    }
-}
+class AWSHttpProtocolJson10Customizations : AWSHttpProtocolCustomizations()

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AWSHttpProtocolJson11Customizations.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AWSHttpProtocolJson11Customizations.kt
@@ -5,28 +5,6 @@
 
 package software.amazon.smithy.aws.swift.codegen.awsjson
 
-import software.amazon.smithy.aws.swift.codegen.AWSClientRuntimeTypes
 import software.amazon.smithy.aws.swift.codegen.AWSHttpProtocolCustomizations
-import software.amazon.smithy.aws.swift.codegen.AWSSwiftDependency
-import software.amazon.smithy.codegen.core.Symbol
-import software.amazon.smithy.protocoltests.traits.HttpRequestTestCase
-import software.amazon.smithy.swift.codegen.SwiftWriter
 
-class AWSHttpProtocolJson11Customizations : AWSHttpProtocolCustomizations() {
-
-    override fun renderMiddlewareForGeneratedRequestTests(
-        writer: SwiftWriter,
-        test: HttpRequestTestCase,
-        operationStack: String,
-        inputSymbol: Symbol,
-        outputSymbol: Symbol,
-        outputErrorName: String,
-        hasHttpBody: Boolean
-    ) {
-        writer.addImport(AWSSwiftDependency.AWS_CLIENT_RUNTIME.target)
-        if (test.headers.keys.contains("X-Amz-Target")) {
-            val XAmzTargetValue = test.headers["X-Amz-Target"]
-            writer.write("$operationStack.serializeStep.intercept(position: .before, middleware: \$N<${inputSymbol.name}, $outputSymbol, $outputErrorName>(xAmzTarget: \"${XAmzTargetValue}\"))", AWSClientRuntimeTypes.AWSJSON.XAmzTargetMiddleware)
-        }
-    }
-}
+class AWSHttpProtocolJson11Customizations : AWSHttpProtocolCustomizations()


### PR DESCRIPTION
See corresponding pr for details:
https://github.com/awslabs/smithy-swift/pull/347

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.