### PR TITLE
fix: use correct content type

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHttpBindingProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHttpBindingProtocolGenerator.kt
@@ -44,13 +44,6 @@ abstract class AWSHttpBindingProtocolGenerator : HttpBindingProtocolGenerator() 
     override val shouldRenderCodingKeysForEncodable = true
 
     override fun generateProtocolUnitTests(ctx: ProtocolGenerator.GenerationContext): Int {
-        val testsToIgnore = setOf(
-            "RestJsonHttpPayloadTraitsWithBlob",
-            "RestJsonHttpPayloadTraitsWithMediaTypeWithBlob",
-            "RestJsonStreamingTraitsWithBlob",
-            "RestJsonStreamingTraitsRequireLengthWithBlob",
-            "RestJsonStreamingTraitsWithMediaTypeWithBlob"
-        )
         return HttpProtocolTestGenerator(
             ctx,
             requestTestBuilder,
@@ -58,8 +51,7 @@ abstract class AWSHttpBindingProtocolGenerator : HttpBindingProtocolGenerator() 
             errorTestBuilder,
             httpProtocolCustomizable,
             operationMiddleware,
-            serdeContext,
-            testsToIgnore
+            serdeContext
         ).generateProtocolTests()
     }
 

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/FormURLHttpBindingResolver.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/FormURLHttpBindingResolver.kt
@@ -12,7 +12,8 @@ import software.amazon.smithy.swift.codegen.integration.protocols.core.StaticHtt
 
 class FormURLHttpBindingResolver(
     private val context: ProtocolGenerator.GenerationContext,
-) : StaticHttpBindingResolver(context, httpTrait) {
+    private val contentType: String
+) : StaticHttpBindingResolver(context, httpTrait, contentType) {
 
     companion object {
         private val httpTrait: HttpTrait = HttpTrait

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGenerator.kt
@@ -59,7 +59,7 @@ class PresignerGenerator : SwiftIntegration {
         writer.addImport(SdkHttpRequest)
 
         val operationsIndex = OperationIndex.of(ctx.model)
-        val httpBindingResolver = protocolGenerator.getProtocolHttpBindingResolver(protocolGeneratorContext)
+        val httpBindingResolver = protocolGenerator.getProtocolHttpBindingResolver(protocolGeneratorContext, protocolGenerator.defaultContentType)
 
         writer.openBlock("extension $inputType {", "}") {
             writer.openBlock("public func presign(config: \$N) -> \$T {", "}", AWSClientConfiguration, SdkHttpRequest) {

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_0_ProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_0_ProtocolGenerator.kt
@@ -30,8 +30,8 @@ open class AwsJson1_0_ProtocolGenerator : AWSHttpBindingProtocolGenerator() {
         AWSJsonHttpResponseBindingErrorGenerator()
     )
     override val serdeContext = serdeContextJSON
-    override fun getProtocolHttpBindingResolver(ctx: ProtocolGenerator.GenerationContext):
-        HttpBindingResolver = AwsJsonHttpBindingResolver(ctx)
+    override fun getProtocolHttpBindingResolver(ctx: ProtocolGenerator.GenerationContext, defaultContentType: String):
+        HttpBindingResolver = AwsJsonHttpBindingResolver(ctx, defaultContentType)
 
     override fun addProtocolSpecificMiddleware(ctx: ProtocolGenerator.GenerationContext, operation: OperationShape) {
         super.addProtocolSpecificMiddleware(ctx, operation)

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_1_ProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_1_ProtocolGenerator.kt
@@ -30,8 +30,8 @@ class AwsJson1_1_ProtocolGenerator : AWSHttpBindingProtocolGenerator() {
         AWSJsonHttpResponseBindingErrorGenerator()
     )
     override val serdeContext = serdeContextJSON
-    override fun getProtocolHttpBindingResolver(ctx: ProtocolGenerator.GenerationContext):
-        HttpBindingResolver = AwsJsonHttpBindingResolver(ctx)
+    override fun getProtocolHttpBindingResolver(ctx: ProtocolGenerator.GenerationContext, defaultContentType: String):
+        HttpBindingResolver = AwsJsonHttpBindingResolver(ctx, defaultContentType)
 
     override fun addProtocolSpecificMiddleware(ctx: ProtocolGenerator.GenerationContext, operation: OperationShape) {
         super.addProtocolSpecificMiddleware(ctx, operation)

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJsonHttpBindingResolver.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJsonHttpBindingResolver.kt
@@ -12,7 +12,8 @@ import software.amazon.smithy.swift.codegen.integration.protocols.core.StaticHtt
 
 class AwsJsonHttpBindingResolver(
     private val context: ProtocolGenerator.GenerationContext,
-) : StaticHttpBindingResolver(context, awsJsonHttpTrait) {
+    private val defaultContentType: String
+) : StaticHttpBindingResolver(context, awsJsonHttpTrait, defaultContentType) {
 
     companion object {
         private val awsJsonHttpTrait: HttpTrait = HttpTrait

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/AwsQueryProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/AwsQueryProtocolGenerator.kt
@@ -51,8 +51,8 @@ open class AwsQueryProtocolGenerator : AWSHttpBindingProtocolGenerator() {
     )
 
     override val serdeContext = HttpProtocolUnitTestGenerator.SerdeContext("FormURLEncoder()", "XMLDecoder()")
-    override fun getProtocolHttpBindingResolver(ctx: ProtocolGenerator.GenerationContext):
-        HttpBindingResolver = FormURLHttpBindingResolver(ctx)
+    override fun getProtocolHttpBindingResolver(ctx: ProtocolGenerator.GenerationContext, defaultContentType: String):
+        HttpBindingResolver = FormURLHttpBindingResolver(ctx, defaultContentType)
 
     override val shouldRenderDecodableBodyStructForInputShapes = false
     override val shouldRenderCodingKeysForEncodable = false

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/ec2query/Ec2QueryProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/ec2query/Ec2QueryProtocolGenerator.kt
@@ -44,8 +44,8 @@ class Ec2QueryProtocolGenerator : AWSHttpBindingProtocolGenerator() {
     )
 
     override val serdeContext = HttpProtocolUnitTestGenerator.SerdeContext("FormURLEncoder()", "XMLDecoder()")
-    override fun getProtocolHttpBindingResolver(ctx: ProtocolGenerator.GenerationContext):
-        HttpBindingResolver = FormURLHttpBindingResolver(ctx)
+    override fun getProtocolHttpBindingResolver(ctx: ProtocolGenerator.GenerationContext, contentType: String):
+        HttpBindingResolver = FormURLHttpBindingResolver(ctx, contentType)
 
     override val shouldRenderDecodableBodyStructForInputShapes = false
     override val shouldRenderCodingKeysForEncodable = false

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/restxml/RestXmlProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/restxml/RestXmlProtocolGenerator.kt
@@ -71,8 +71,7 @@ class RestXmlProtocolGenerator : AWSHttpBindingProtocolGenerator() {
             "S3VirtualHostDualstackAddressing",
             "S3VirtualHostAccelerateAddressing",
             "S3VirtualHostDualstackAccelerateAddressing",
-            "S3OperationAddressingPreferred",
-            "HttpPayloadTraitsWithMediaTypeWithBlob" // content type
+            "S3OperationAddressingPreferred"
         )
         return HttpProtocolTestGenerator(
             ctx,


### PR DESCRIPTION
corresponding:
https://github.com/awslabs/smithy-swift/pull/348

Uses the correct content type instead of just the default one

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.