### PR TITLE
feat: update interface for presigner to include expiration only

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGenerator.kt
@@ -8,6 +8,7 @@ import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.swift.codegen.ClientRuntimeTypes.Http.SdkHttpRequest
 import software.amazon.smithy.swift.codegen.ClientRuntimeTypes.Middleware.NoopHandler
 import software.amazon.smithy.swift.codegen.SwiftDelegator
+import software.amazon.smithy.swift.codegen.SwiftTypes
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.core.CodegenContext
 import software.amazon.smithy.swift.codegen.core.toProtocolGenerationContext
@@ -61,7 +62,7 @@ class PresignerGenerator : SwiftIntegration {
         val httpBindingResolver = protocolGenerator.getProtocolHttpBindingResolver(protocolGeneratorContext, protocolGenerator.defaultContentType)
 
         writer.openBlock("extension $inputType {", "}") {
-            writer.openBlock("public func presign(config: \$N, expiration: Int64) -> \$T {", "}", AWSClientConfiguration, SdkHttpRequest) {
+            writer.openBlock("public func presign(config: \$N, expiration: \$N) -> \$T {", "}", AWSClientConfiguration, SwiftTypes.Int64, SdkHttpRequest) {
                 writer.write("let serviceName = \"${ctx.settings.sdkId}\"")
                 writer.write("let input = self")
                 val operationStackName = "operation"

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGenerator.kt
@@ -62,7 +62,7 @@ class PresignerGenerator : SwiftIntegration {
         val httpBindingResolver = protocolGenerator.getProtocolHttpBindingResolver(protocolGeneratorContext, protocolGenerator.defaultContentType)
 
         writer.openBlock("extension $inputType {", "}") {
-            writer.openBlock("public func presign(config: \$N, sigv4Config: \$D) -> \$T {", "}", AWSClientConfiguration, SigV4Config, SdkHttpRequest) {
+            writer.openBlock("public func presign(config: \$N, expiration: Int64) -> \$T {", "}", AWSClientConfiguration, SdkHttpRequest) {
                 writer.write("let serviceName = \"${ctx.settings.sdkId}\"")
                 writer.write("let input = self")
                 val operationStackName = "operation"

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGenerator.kt
@@ -1,7 +1,6 @@
 package software.amazon.smithy.aws.swift.codegen
 
 import software.amazon.smithy.aws.swift.codegen.AWSClientRuntimeTypes.Core.AWSClientConfiguration
-import software.amazon.smithy.aws.swift.codegen.AWSClientRuntimeTypes.Signing.SigV4Config
 import software.amazon.smithy.aws.swift.codegen.middleware.AWSSigningMiddleware
 import software.amazon.smithy.aws.swift.codegen.model.traits.Presignable
 import software.amazon.smithy.model.shapes.OperationShape

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/AWSSigningMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/AWSSigningMiddleware.kt
@@ -51,7 +51,7 @@ open class AWSSigningMiddleware(val paramsCallback: AWSSigningMiddlewareParamsCa
     private fun renderConfigDeclaration(writer: SwiftWriter, op: OperationShape, executionContext: MiddlewareRenderableExecutionContext) {
         writer.addImport(SigV4Config)
         when (executionContext) {
-            MiddlewareRenderableExecutionContext.PRESIGNER -> writer.write("let sigv4Config = sigv4Config ?? \$N(${middlewareParamsString(op)})", SigV4Config)
+            MiddlewareRenderableExecutionContext.PRESIGNER -> writer.write("let sigv4Config = \$N(expiration: expiration, ${middlewareParamsString(op)})", SigV4Config)
             else -> writer.write("let sigv4Config = \$N(${middlewareParamsString(op)})", SigV4Config)
         }
     }

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/AWSSigningMiddlewareTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/AWSSigningMiddlewareTests.kt
@@ -124,7 +124,7 @@ stack.finalizeStep.intercept(position: .before, middleware: AWSClientRuntime.Sig
     fun `renderSigningMiddleware unsignedBody true, presigner`() {
         val expectedContents =
             """
-let sigv4Config = sigv4Config ?? AWSClientRuntime.SigV4Config(unsignedBody: true)
+let sigv4Config = AWSClientRuntime.SigV4Config(expiration: expiration, unsignedBody: true)
 stack.finalizeStep.intercept(position: .before, middleware: AWSClientRuntime.SigV4Middleware(config: sigv4Config))"""
         val writer = SwiftWriter("testName")
         val serviceShape = ServiceShape.builder()
@@ -151,7 +151,7 @@ stack.finalizeStep.intercept(position: .before, middleware: AWSClientRuntime.Sig
     fun `renderSigningMiddleware unsignedBody false, presigner`() {
         val expectedContents =
             """
-let sigv4Config = sigv4Config ?? AWSClientRuntime.SigV4Config(unsignedBody: false)
+let sigv4Config = AWSClientRuntime.SigV4Config(expiration: expiration, unsignedBody: false)
 stack.finalizeStep.intercept(position: .before, middleware: AWSClientRuntime.SigV4Middleware(config: sigv4Config))"""
         val writer = SwiftWriter("testName")
         val serviceShape = ServiceShape.builder()

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGeneratorTests.kt
@@ -19,7 +19,7 @@ class PresignerGeneratorTests {
             import ClientRuntime
             
             extension GetFooInput {
-                public func presign(config: AWSClientRuntime.AWSClientConfiguration, expiration: Int64) -> ClientRuntime.SdkHttpRequest? {
+                public func presign(config: AWSClientRuntime.AWSClientConfiguration, expiration: Swift.Int64) -> ClientRuntime.SdkHttpRequest? {
                     let serviceName = "Example"
                     let input = self
                     let encoder = ClientRuntime.JSONEncoder()
@@ -76,7 +76,7 @@ class PresignerGeneratorTests {
             import ClientRuntime
             
             extension PostFooInput {
-                public func presign(config: AWSClientRuntime.AWSClientConfiguration, expiration: Int64) -> ClientRuntime.SdkHttpRequest? {
+                public func presign(config: AWSClientRuntime.AWSClientConfiguration, expiration: Swift.Int64) -> ClientRuntime.SdkHttpRequest? {
                     let serviceName = "Example"
                     let input = self
                     let encoder = ClientRuntime.JSONEncoder()
@@ -134,7 +134,7 @@ class PresignerGeneratorTests {
             import ClientRuntime
             
             extension PutFooInput {
-                public func presign(config: AWSClientRuntime.AWSClientConfiguration, expiration: Int64) -> ClientRuntime.SdkHttpRequest? {
+                public func presign(config: AWSClientRuntime.AWSClientConfiguration, expiration: Swift.Int64) -> ClientRuntime.SdkHttpRequest? {
                     let serviceName = "Example"
                     let input = self
                     let encoder = ClientRuntime.JSONEncoder()

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGeneratorTests.kt
@@ -19,7 +19,7 @@ class PresignerGeneratorTests {
             import ClientRuntime
             
             extension GetFooInput {
-                public func presign(config: AWSClientRuntime.AWSClientConfiguration, sigv4Config: AWSClientRuntime.SigV4Config? = nil) -> ClientRuntime.SdkHttpRequest? {
+                public func presign(config: AWSClientRuntime.AWSClientConfiguration, expiration: Int64) -> ClientRuntime.SdkHttpRequest? {
                     let serviceName = "Example"
                     let input = self
                     let encoder = ClientRuntime.JSONEncoder()
@@ -50,7 +50,7 @@ class PresignerGeneratorTests {
                     operation.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<GetFooInput, GetFooOutputResponse, GetFooOutputError>(contentType: "application/json"))
                     operation.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
                     operation.finalizeStep.intercept(position: .after, middleware: AWSClientRuntime.RetryerMiddleware(retryer: config.retryer))
-                    let sigv4Config = sigv4Config ?? AWSClientRuntime.SigV4Config(unsignedBody: false)
+                    let sigv4Config = AWSClientRuntime.SigV4Config(expiration: expiration, unsignedBody: false)
                     operation.finalizeStep.intercept(position: .before, middleware: AWSClientRuntime.SigV4Middleware(config: sigv4Config))
                     operation.deserializeStep.intercept(position: .before, middleware: ClientRuntime.LoggerMiddleware(clientLogMode: config.clientLogMode))
                     operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.DeserializeMiddleware())
@@ -76,7 +76,7 @@ class PresignerGeneratorTests {
             import ClientRuntime
             
             extension PostFooInput {
-                public func presign(config: AWSClientRuntime.AWSClientConfiguration, sigv4Config: AWSClientRuntime.SigV4Config? = nil) -> ClientRuntime.SdkHttpRequest? {
+                public func presign(config: AWSClientRuntime.AWSClientConfiguration, expiration: Int64) -> ClientRuntime.SdkHttpRequest? {
                     let serviceName = "Example"
                     let input = self
                     let encoder = ClientRuntime.JSONEncoder()
@@ -108,7 +108,7 @@ class PresignerGeneratorTests {
                     operation.serializeStep.intercept(position: .after, middleware: PostFooInputBodyMiddleware())
                     operation.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
                     operation.finalizeStep.intercept(position: .after, middleware: AWSClientRuntime.RetryerMiddleware(retryer: config.retryer))
-                    let sigv4Config = sigv4Config ?? AWSClientRuntime.SigV4Config(unsignedBody: false)
+                    let sigv4Config = AWSClientRuntime.SigV4Config(expiration: expiration, unsignedBody: false)
                     operation.finalizeStep.intercept(position: .before, middleware: AWSClientRuntime.SigV4Middleware(config: sigv4Config))
                     operation.deserializeStep.intercept(position: .before, middleware: ClientRuntime.LoggerMiddleware(clientLogMode: config.clientLogMode))
                     operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.DeserializeMiddleware())
@@ -134,7 +134,7 @@ class PresignerGeneratorTests {
             import ClientRuntime
             
             extension PutFooInput {
-                public func presign(config: AWSClientRuntime.AWSClientConfiguration, sigv4Config: AWSClientRuntime.SigV4Config? = nil) -> ClientRuntime.SdkHttpRequest? {
+                public func presign(config: AWSClientRuntime.AWSClientConfiguration, expiration: Int64) -> ClientRuntime.SdkHttpRequest? {
                     let serviceName = "Example"
                     let input = self
                     let encoder = ClientRuntime.JSONEncoder()
@@ -166,7 +166,7 @@ class PresignerGeneratorTests {
                     operation.serializeStep.intercept(position: .after, middleware: PutFooInputBodyMiddleware())
                     operation.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
                     operation.finalizeStep.intercept(position: .after, middleware: AWSClientRuntime.RetryerMiddleware(retryer: config.retryer))
-                    let sigv4Config = sigv4Config ?? AWSClientRuntime.SigV4Config(unsignedBody: false)
+                    let sigv4Config = AWSClientRuntime.SigV4Config(expiration: expiration, unsignedBody: false)
                     operation.finalizeStep.intercept(position: .before, middleware: AWSClientRuntime.SigV4Middleware(config: sigv4Config))
                     operation.deserializeStep.intercept(position: .before, middleware: ClientRuntime.LoggerMiddleware(clientLogMode: config.clientLogMode))
                     operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.DeserializeMiddleware())


### PR DESCRIPTION
Instead of passing in a AWSconfig, customers now pass in an expiration of type `Int64`:

```
let pollyConfig = try PollyClient.PollyClientConfiguration(region: "us-west-2")
let input = SynthesizeSpeechInput(outputFormat: .mp3, text: "hello john", voiceId: .lucia)
guard let presignedRequest: SdkHttpRequest = input.presign(config: pollyConfig, expiration: 500) else {
    exit(1)
}
```
This mirror's the interface that aws-sdk-kotlin exposes for their generic presigner

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.