### PR TITLE
feat: autofill Glacier accountId

### DIFF
--- a/codegen/Package.swift
+++ b/codegen/Package.swift
@@ -39,6 +39,8 @@ appendLibTarget(name: "AWSQueryTestSDK", path: "\(baseDir)/aws-query")
 appendTstTarget(name: "AWSQueryTestSDKTests", path: "\(baseDir)/aws-query", dependency: "AWSQueryTestSDK")
 
 //Service specific
+appendLibTarget(name: "GlacierTestSDK", path: "\(baseDir)/glacier")
+appendTstTarget(name: "GlacierTestSDKTests", path: "\(baseDir)/glacier", dependency: "GlacierTestSDK")
 appendLibTarget(name: "S3TestSDK", path: "\(baseDir)/s3")
 appendTstTarget(name: "S3TestSDKTests", path: "\(baseDir)/s3", dependency: "S3TestSDK")
 
@@ -71,7 +73,7 @@ func appendLibTarget(name: String, path: String) {
 func appendTstTarget(name: String, path: String, dependency: String) {
     package.targets.append(.testTarget(name: name,
                                        dependencies:  [
-                                        ._byNameItem(name: dependency, condition: nil),
+                                        .byNameItem(name: dependency, condition: nil),
                                         .product(name: "SmithyTestUtil", package: "ClientRuntime")
                                        ],
                                        path: "\(path)/swift-codegen/\(name)")

--- a/codegen/Package.swift
+++ b/codegen/Package.swift
@@ -73,7 +73,7 @@ func appendLibTarget(name: String, path: String) {
 func appendTstTarget(name: String, path: String, dependency: String) {
     package.targets.append(.testTarget(name: name,
                                        dependencies:  [
-                                        .byNameItem(name: dependency, condition: nil),
+                                        ._byNameItem(name: dependency, condition: nil),
                                         .product(name: "SmithyTestUtil", package: "ClientRuntime")
                                        ],
                                        path: "\(path)/swift-codegen/\(name)")

--- a/codegen/protocol-test-codegen/build.gradle.kts
+++ b/codegen/protocol-test-codegen/build.gradle.kts
@@ -2,8 +2,8 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
-import software.amazon.smithy.gradle.tasks.SmithyBuild
 import software.amazon.smithy.gradle.tasks.ProtocolTestTask
+import software.amazon.smithy.gradle.tasks.SmithyBuild
 
 plugins {
     id("software.amazon.smithy") version "0.5.3"
@@ -36,7 +36,7 @@ val enabledProtocols = listOf(
 
     // service specific tests
     //ProtocolTest("apigateway", "com.amazonaws.apigateway#BackplaneControlService"),
-    //ProtocolTest("glacier", "com.amazonaws.glacier#Glacier", "GlacierTestSDK")
+    ProtocolTest("glacier", "com.amazonaws.glacier#Glacier", "GlacierTestSDK"),
     ProtocolTest("s3", "com.amazonaws.s3#AmazonS3", "S3TestSDK")
 )
 

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHttpBindingProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHttpBindingProtocolGenerator.kt
@@ -45,10 +45,10 @@ abstract class AWSHttpBindingProtocolGenerator : HttpBindingProtocolGenerator() 
 
     override fun generateProtocolUnitTests(ctx: ProtocolGenerator.GenerationContext): Int {
         val ignoredTests = setOf(
-                // Glacier customizations
-                "GlacierChecksums", // aws-sdk-swift#208
-                "GlacierMultipartChecksums", // aws-sdk-swift#208
-            )
+            // Glacier customizations
+            "GlacierChecksums", // aws-sdk-swift#208
+            "GlacierMultipartChecksums", // aws-sdk-swift#208
+        )
         return HttpProtocolTestGenerator(
             ctx,
             requestTestBuilder,

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHttpBindingProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHttpBindingProtocolGenerator.kt
@@ -44,6 +44,11 @@ abstract class AWSHttpBindingProtocolGenerator : HttpBindingProtocolGenerator() 
     override val shouldRenderCodingKeysForEncodable = true
 
     override fun generateProtocolUnitTests(ctx: ProtocolGenerator.GenerationContext): Int {
+        val ignoredTests = setOf(
+                // Glacier customizations
+                "GlacierChecksums", // aws-sdk-swift#208
+                "GlacierMultipartChecksums", // aws-sdk-swift#208
+            )
         return HttpProtocolTestGenerator(
             ctx,
             requestTestBuilder,
@@ -51,7 +56,8 @@ abstract class AWSHttpBindingProtocolGenerator : HttpBindingProtocolGenerator() 
             errorTestBuilder,
             httpProtocolCustomizable,
             operationMiddleware,
-            serdeContext
+            serdeContext,
+            ignoredTests
         ).generateProtocolTests()
     }
 

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHttpBindingProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHttpBindingProtocolGenerator.kt
@@ -45,7 +45,6 @@ abstract class AWSHttpBindingProtocolGenerator : HttpBindingProtocolGenerator() 
 
     override fun generateProtocolUnitTests(ctx: ProtocolGenerator.GenerationContext): Int {
         val ignoredTests = setOf(
-            // Glacier customizations
             "GlacierChecksums", // aws-sdk-swift#208
             "GlacierMultipartChecksums", // aws-sdk-swift#208
         )

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/glacier/GlacierAcccountIdDefault.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/glacier/GlacierAcccountIdDefault.kt
@@ -1,0 +1,38 @@
+package software.amazon.smithy.aws.swift.codegen.customization.glacier
+
+import software.amazon.smithy.aws.swift.codegen.middleware.GlacierAccountIdMiddleware
+import software.amazon.smithy.aws.swift.codegen.sdkId
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.swift.codegen.SwiftSettings
+import software.amazon.smithy.swift.codegen.getOrNull
+import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
+import software.amazon.smithy.swift.codegen.integration.SwiftIntegration
+import software.amazon.smithy.swift.codegen.middleware.OperationMiddleware
+import software.amazon.smithy.swift.codegen.model.expectShape
+
+/**
+ * Adds a middleware for Glacier to autofill accountId when not set
+ * See: https://github.com/awslabs/aws-sdk-swift/issues/207
+ */
+class GlacierAccountIdDefault : SwiftIntegration {
+    override fun enabledForService(model: Model, settings: SwiftSettings): Boolean =
+        model.expectShape<ServiceShape>(settings.service).sdkId.equals("Glacier", ignoreCase = true)
+
+    override fun customizeMiddleware(
+        ctx: ProtocolGenerator.GenerationContext,
+        operationShape: OperationShape,
+        operationMiddleware: OperationMiddleware
+    ) {
+        val input = operationShape.input.getOrNull()?.let { ctx.model.expectShape<StructureShape>(it) }
+        val needsAccountIdMiddleware = input?.memberNames?.any { it.lowercase() == "accountid" } ?: false
+        if(needsAccountIdMiddleware) {
+            operationMiddleware.appendMiddleware(
+                operationShape,
+                GlacierAccountIdMiddleware()
+            )
+        }
+    }
+}

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/glacier/GlacierAcccountIdDefault.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/glacier/GlacierAcccountIdDefault.kt
@@ -28,7 +28,7 @@ class GlacierAccountIdDefault : SwiftIntegration {
     ) {
         val input = operationShape.input.getOrNull()?.let { ctx.model.expectShape<StructureShape>(it) }
         val needsAccountIdMiddleware = input?.memberNames?.any { it.lowercase() == "accountid" } ?: false
-        if(needsAccountIdMiddleware) {
+        if (needsAccountIdMiddleware) {
             operationMiddleware.appendMiddleware(
                 operationShape,
                 GlacierAccountIdMiddleware()

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/glacier/GlacierAcccountIdDefault.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/glacier/GlacierAcccountIdDefault.kt
@@ -29,7 +29,7 @@ class GlacierAccountIdDefault : SwiftIntegration {
         val input = operationShape.input.getOrNull()?.let { ctx.model.expectShape<StructureShape>(it) }
         val needsAccountIdMiddleware = input?.memberNames?.any { it.lowercase() == "accountid" } ?: false
         if (needsAccountIdMiddleware) {
-            operationMiddleware.appendMiddleware(
+            operationMiddleware.prependMiddleware(
                 operationShape,
                 GlacierAccountIdMiddleware()
             )

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/glacier/GlacierAcccountIdDefault.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/glacier/GlacierAcccountIdDefault.kt
@@ -31,7 +31,7 @@ class GlacierAccountIdDefault : SwiftIntegration {
         if (needsAccountIdMiddleware) {
             operationMiddleware.prependMiddleware(
                 operationShape,
-                GlacierAccountIdMiddleware()
+                GlacierAccountIdMiddleware(ctx.model, ctx.symbolProvider)
             )
         }
     }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/GlacierAccountIdMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/GlacierAccountIdMiddleware.kt
@@ -1,0 +1,41 @@
+package software.amazon.smithy.aws.swift.codegen.middleware
+
+import software.amazon.smithy.codegen.core.SymbolProvider
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.swift.codegen.ClientRuntimeTypes
+import software.amazon.smithy.swift.codegen.ServiceGenerator
+import software.amazon.smithy.swift.codegen.SwiftTypes
+import software.amazon.smithy.swift.codegen.SwiftWriter
+import software.amazon.smithy.swift.codegen.middleware.MiddlewarePosition
+import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderable
+import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderableExecutionContext
+import software.amazon.smithy.swift.codegen.middleware.MiddlewareStep
+import software.amazon.smithy.swift.codegen.model.expectShape
+
+class GlacierAccountIdMiddleware() : MiddlewareRenderable {
+    override val name = "GlacierAccountIdAutoFill"
+
+    override val middlewareStep = MiddlewareStep.INITIALIZESTEP
+
+    override val position = MiddlewarePosition.AFTER
+
+    override fun render(model: Model, symbolProvider: SymbolProvider, writer: SwiftWriter, op: OperationShape, operationStackName: String, executionContext: MiddlewareRenderableExecutionContext) {
+        val outputShapeName = ServiceGenerator.getOperationOutputShapeName(symbolProvider, model, op)
+        val outputErrorShapeName = ServiceGenerator.getOperationErrorShapeName(op)
+        val accountId = model.expectShape<StructureShape>(op.input.get()).members().first { it.memberName.lowercase() == "accountid" }
+        writer.openBlock(
+            "$operationStackName.${middlewareStep.stringValue()}.intercept(position: ${position.stringValue()}, id: \"${name}\") { (context, input, next) -> \$N<\$N<$outputShapeName>, \$N<$outputErrorShapeName>> in", "}",
+            SwiftTypes.Result,
+            ClientRuntimeTypes.Middleware.OperationOutput,
+            ClientRuntimeTypes.Core.SdkError
+        ) {
+            writer.write("var copiedInput = input")
+            writer.openBlock("if input.\$N.isEmptyOrNil {", "}", accountId.memberName) {
+                writer.write("copiedInput.${accountId.memberName} = \"-\"")
+            }
+            writer.write("return next.handle(context: context, input: copiedInput)")
+        }
+    }
+}

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/GlacierAccountIdMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/GlacierAccountIdMiddleware.kt
@@ -32,7 +32,7 @@ class GlacierAccountIdMiddleware() : MiddlewareRenderable {
             ClientRuntimeTypes.Core.SdkError
         ) {
             writer.write("var copiedInput = input")
-            writer.openBlock("if input.\$N.isEmptyOrNil {", "}", accountId.memberName) {
+            writer.openBlock("if input.${accountId.memberName}.isEmptyOrNil {", "}") {
                 writer.write("copiedInput.${accountId.memberName} = \"-\"")
             }
             writer.write("return next.handle(context: context, input: copiedInput)")

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/GlacierAccountIdMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/GlacierAccountIdMiddleware.kt
@@ -31,7 +31,7 @@ class GlacierAccountIdMiddleware() : MiddlewareRenderable {
             ClientRuntimeTypes.Middleware.OperationOutput,
             ClientRuntimeTypes.Core.SdkError
         ) {
-            writer.openBlock("guard let accountId = input.${accountId.memberName}, !accountId.isEmpty {", "}") {
+            writer.openBlock("guard let accountId = input.${accountId.memberName}, !accountId.isEmpty else {", "}") {
                 writer.write("var copiedInput = input")
                 writer.write("copiedInput.${accountId.memberName} = \"-\"")
                 writer.write("return next.handle(context: context, input: copiedInput)")

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/GlacierAccountIdMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/GlacierAccountIdMiddleware.kt
@@ -31,11 +31,12 @@ class GlacierAccountIdMiddleware() : MiddlewareRenderable {
             ClientRuntimeTypes.Middleware.OperationOutput,
             ClientRuntimeTypes.Core.SdkError
         ) {
-            writer.write("var copiedInput = input")
-            writer.openBlock("if input.${accountId.memberName}.isNilOrEmpty {", "}") {
+            writer.openBlock("guard let accountId = input.${accountId.memberName}, !accountId.isEmpty {", "}") {
+                writer.write("var copiedInput = input")
                 writer.write("copiedInput.${accountId.memberName} = \"-\"")
+                writer.write("return next.handle(context: context, input: copiedInput)")
             }
-            writer.write("return next.handle(context: context, input: copiedInput)")
+            writer.write("return next.handle(context: context, input: input)")
         }
     }
 }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/GlacierAccountIdMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/GlacierAccountIdMiddleware.kt
@@ -32,7 +32,7 @@ class GlacierAccountIdMiddleware() : MiddlewareRenderable {
             ClientRuntimeTypes.Core.SdkError
         ) {
             writer.write("var copiedInput = input")
-            writer.openBlock("if input.${accountId.memberName}.isEmptyOrNil {", "}") {
+            writer.openBlock("if input.${accountId.memberName}.isNilOrEmpty {", "}") {
                 writer.write("copiedInput.${accountId.memberName} = \"-\"")
             }
             writer.write("return next.handle(context: context, input: copiedInput)")

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/GlacierAccountIdMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/GlacierAccountIdMiddleware.kt
@@ -19,7 +19,7 @@ class GlacierAccountIdMiddleware() : MiddlewareRenderable {
 
     override val middlewareStep = MiddlewareStep.INITIALIZESTEP
 
-    override val position = MiddlewarePosition.AFTER
+    override val position = MiddlewarePosition.BEFORE
 
     override fun render(model: Model, symbolProvider: SymbolProvider, writer: SwiftWriter, op: OperationShape, operationStackName: String, executionContext: MiddlewareRenderableExecutionContext) {
         val outputShapeName = ServiceGenerator.getOperationOutputShapeName(symbolProvider, model, op)

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/GlacierAccountIdMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/GlacierAccountIdMiddleware.kt
@@ -10,18 +10,17 @@ import software.amazon.smithy.swift.codegen.SwiftTypes
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.middleware.MiddlewarePosition
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderable
-import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderableExecutionContext
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareStep
 import software.amazon.smithy.swift.codegen.model.expectShape
 
-class GlacierAccountIdMiddleware() : MiddlewareRenderable {
+class GlacierAccountIdMiddleware(private val model: Model, private val symbolProvider: SymbolProvider) : MiddlewareRenderable {
     override val name = "GlacierAccountIdAutoFill"
 
     override val middlewareStep = MiddlewareStep.INITIALIZESTEP
 
     override val position = MiddlewarePosition.BEFORE
 
-    override fun render(model: Model, symbolProvider: SymbolProvider, writer: SwiftWriter, op: OperationShape, operationStackName: String, executionContext: MiddlewareRenderableExecutionContext) {
+    override fun render(writer: SwiftWriter, op: OperationShape, operationStackName: String) {
         val outputShapeName = ServiceGenerator.getOperationOutputShapeName(symbolProvider, model, op)
         val outputErrorShapeName = ServiceGenerator.getOperationErrorShapeName(op)
         val accountId = model.expectShape<StructureShape>(op.input.get()).members().first { it.memberName.lowercase() == "accountid" }

--- a/codegen/smithy-aws-swift-codegen/src/main/resources/META-INF/services/software.amazon.smithy.swift.codegen.integration.SwiftIntegration
+++ b/codegen/smithy-aws-swift-codegen/src/main/resources/META-INF/services/software.amazon.smithy.swift.codegen.integration.SwiftIntegration
@@ -3,6 +3,7 @@ software.amazon.smithy.aws.swift.codegen.customization.s3.S3SigningConfig
 software.amazon.smithy.aws.swift.codegen.customization.s3.S3ErrorIntegration
 software.amazon.smithy.aws.swift.codegen.customization.apigateway.ApiGatewayAddAcceptHeader
 software.amazon.smithy.aws.swift.codegen.customization.glacier.GlacierAddVersionHeader
+software.amazon.smithy.aws.swift.codegen.customization.glacier.GlacierAccountIdDefault
 software.amazon.smithy.aws.swift.codegen.customization.BoxServices
 software.amazon.smithy.aws.swift.codegen.customization.PresignableModelIntegration
 software.amazon.smithy.aws.swift.codegen.customization.polly.PollyGetPresignerIntegration

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/GlacierAccountIdMiddlewareTest.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/GlacierAccountIdMiddlewareTest.kt
@@ -1,0 +1,69 @@
+package software.amazon.smithy.aws.swift.codegen.customizations
+
+import io.kotest.matchers.string.shouldContainOnlyOnce
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.aws.swift.codegen.middleware.GlacierAccountIdMiddleware
+import software.amazon.smithy.aws.swift.codegen.newTestContext
+import software.amazon.smithy.aws.swift.codegen.restjson.AWSRestJson1ProtocolGenerator
+import software.amazon.smithy.aws.traits.auth.UnsignedPayloadTrait
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.swift.codegen.SwiftWriter
+import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderableExecutionContext
+
+class GlacierAccountIdMiddlewareTest {
+        @Test
+    fun testGlacierMiddlewareRendersCorrectly() {
+            val writer = SwiftWriter("testName")
+            val serviceShape = ServiceShape.builder()
+                .id("com.test#Glacier")
+                .version("1.0")
+                .build()
+            val accountIdMember = MemberShape.builder()
+                .id("com.test#TestInputShapeName\$accountId")
+                .target("smithy.api#String")
+                .build()
+            val inputShape = StructureShape.builder()
+                .id("com.test#TestInputShapeName")
+                .addMember(accountIdMember)
+                .build()
+            val outputShape = StructureShape.builder().id("com.test#TestOutputShapeName").build()
+            val errorShape = StructureShape.builder().id("com.test#TestErrorShapeName").build()
+            val operationShape = OperationShape.builder()
+                .id("com.test#ExampleOperation")
+                .addTrait(UnsignedPayloadTrait())
+                .input { ShapeId.from("com.test#TestInputShapeName") }
+                .output { ShapeId.from("com.test#TestOutputShapeName") }
+                .addError("com.test#TestErrorShapeName")
+                .build()
+            val model = Model.builder()
+                .addShape(serviceShape)
+                .addShape(operationShape)
+                .addShape(accountIdMember)
+                .addShape(inputShape)
+                .addShape(outputShape)
+                .addShape(errorShape)
+                .build()
+            val context = model.newTestContext(serviceShapeId = "com.test#Glacier", generator = AWSRestJson1ProtocolGenerator()).ctx
+            val opStackName = "stack"
+            val glacierMiddleware = GlacierAccountIdMiddleware()
+
+            glacierMiddleware.render(model, context.symbolProvider, writer, operationShape, opStackName, MiddlewareRenderableExecutionContext.CLIENT)
+
+            val contents = writer.toString()
+            val expectedContents = """
+stack.initializeStep.intercept(position: .after, id: "GlacierAccountIdAutoFill") { (context, input, next) -> Swift.Result<ClientRuntime.OperationOutput<TestOutputShapeName>, ClientRuntime.SdkError<ExampleOperationOutputError>> in
+    guard let accountId = input.accountId, !accountId.isEmpty {
+        var copiedInput = input
+        copiedInput.accountId = "-"
+        return next.handle(context: context, input: copiedInput)
+    }
+    return next.handle(context: context, input: input)
+}"""
+            contents.shouldContainOnlyOnce(expectedContents)
+    }
+}

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/GlacierAccountIdMiddlewareTest.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/GlacierAccountIdMiddlewareTest.kt
@@ -57,7 +57,7 @@ class GlacierAccountIdMiddlewareTest {
         val contents = writer.toString()
         val expectedContents = """
 stack.initializeStep.intercept(position: .after, id: "GlacierAccountIdAutoFill") { (context, input, next) -> Swift.Result<ClientRuntime.OperationOutput<TestOutputShapeName>, ClientRuntime.SdkError<ExampleOperationOutputError>> in
-    guard let accountId = input.accountId, !accountId.isEmpty {
+    guard let accountId = input.accountId, !accountId.isEmpty else {
         var copiedInput = input
         copiedInput.accountId = "-"
         return next.handle(context: context, input: copiedInput)

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/GlacierAccountIdMiddlewareTest.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/GlacierAccountIdMiddlewareTest.kt
@@ -16,46 +16,46 @@ import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderableExecutionContext
 
 class GlacierAccountIdMiddlewareTest {
-        @Test
+    @Test
     fun testGlacierMiddlewareRendersCorrectly() {
-            val writer = SwiftWriter("testName")
-            val serviceShape = ServiceShape.builder()
-                .id("com.test#Glacier")
-                .version("1.0")
-                .build()
-            val accountIdMember = MemberShape.builder()
-                .id("com.test#TestInputShapeName\$accountId")
-                .target("smithy.api#String")
-                .build()
-            val inputShape = StructureShape.builder()
-                .id("com.test#TestInputShapeName")
-                .addMember(accountIdMember)
-                .build()
-            val outputShape = StructureShape.builder().id("com.test#TestOutputShapeName").build()
-            val errorShape = StructureShape.builder().id("com.test#TestErrorShapeName").build()
-            val operationShape = OperationShape.builder()
-                .id("com.test#ExampleOperation")
-                .addTrait(UnsignedPayloadTrait())
-                .input { ShapeId.from("com.test#TestInputShapeName") }
-                .output { ShapeId.from("com.test#TestOutputShapeName") }
-                .addError("com.test#TestErrorShapeName")
-                .build()
-            val model = Model.builder()
-                .addShape(serviceShape)
-                .addShape(operationShape)
-                .addShape(accountIdMember)
-                .addShape(inputShape)
-                .addShape(outputShape)
-                .addShape(errorShape)
-                .build()
-            val context = model.newTestContext(serviceShapeId = "com.test#Glacier", generator = AWSRestJson1ProtocolGenerator()).ctx
-            val opStackName = "stack"
-            val glacierMiddleware = GlacierAccountIdMiddleware()
+        val writer = SwiftWriter("testName")
+        val serviceShape = ServiceShape.builder()
+            .id("com.test#Glacier")
+            .version("1.0")
+            .build()
+        val accountIdMember = MemberShape.builder()
+            .id("com.test#TestInputShapeName\$accountId")
+            .target("smithy.api#String")
+            .build()
+        val inputShape = StructureShape.builder()
+            .id("com.test#TestInputShapeName")
+            .addMember(accountIdMember)
+            .build()
+        val outputShape = StructureShape.builder().id("com.test#TestOutputShapeName").build()
+        val errorShape = StructureShape.builder().id("com.test#TestErrorShapeName").build()
+        val operationShape = OperationShape.builder()
+            .id("com.test#ExampleOperation")
+            .addTrait(UnsignedPayloadTrait())
+            .input { ShapeId.from("com.test#TestInputShapeName") }
+            .output { ShapeId.from("com.test#TestOutputShapeName") }
+            .addError("com.test#TestErrorShapeName")
+            .build()
+        val model = Model.builder()
+            .addShape(serviceShape)
+            .addShape(operationShape)
+            .addShape(accountIdMember)
+            .addShape(inputShape)
+            .addShape(outputShape)
+            .addShape(errorShape)
+            .build()
+        val context = model.newTestContext(serviceShapeId = "com.test#Glacier", generator = AWSRestJson1ProtocolGenerator()).ctx
+        val opStackName = "stack"
+        val glacierMiddleware = GlacierAccountIdMiddleware()
 
-            glacierMiddleware.render(model, context.symbolProvider, writer, operationShape, opStackName, MiddlewareRenderableExecutionContext.CLIENT)
+        glacierMiddleware.render(model, context.symbolProvider, writer, operationShape, opStackName, MiddlewareRenderableExecutionContext.CLIENT)
 
-            val contents = writer.toString()
-            val expectedContents = """
+        val contents = writer.toString()
+        val expectedContents = """
 stack.initializeStep.intercept(position: .after, id: "GlacierAccountIdAutoFill") { (context, input, next) -> Swift.Result<ClientRuntime.OperationOutput<TestOutputShapeName>, ClientRuntime.SdkError<ExampleOperationOutputError>> in
     guard let accountId = input.accountId, !accountId.isEmpty {
         var copiedInput = input
@@ -64,6 +64,6 @@ stack.initializeStep.intercept(position: .after, id: "GlacierAccountIdAutoFill")
     }
     return next.handle(context: context, input: input)
 }"""
-            contents.shouldContainOnlyOnce(expectedContents)
+        contents.shouldContainOnlyOnce(expectedContents)
     }
 }

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/GlacierAccountIdMiddlewareTest.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/GlacierAccountIdMiddlewareTest.kt
@@ -56,7 +56,7 @@ class GlacierAccountIdMiddlewareTest {
 
         val contents = writer.toString()
         val expectedContents = """
-stack.initializeStep.intercept(position: .after, id: "GlacierAccountIdAutoFill") { (context, input, next) -> Swift.Result<ClientRuntime.OperationOutput<TestOutputShapeName>, ClientRuntime.SdkError<ExampleOperationOutputError>> in
+stack.initializeStep.intercept(position: .before, id: "GlacierAccountIdAutoFill") { (context, input, next) -> Swift.Result<ClientRuntime.OperationOutput<TestOutputShapeName>, ClientRuntime.SdkError<ExampleOperationOutputError>> in
     guard let accountId = input.accountId, !accountId.isEmpty else {
         var copiedInput = input
         copiedInput.accountId = "-"

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/GlacierAccountIdMiddlewareTest.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/GlacierAccountIdMiddlewareTest.kt
@@ -13,7 +13,6 @@ import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.swift.codegen.SwiftWriter
-import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderableExecutionContext
 
 class GlacierAccountIdMiddlewareTest {
     @Test
@@ -50,9 +49,9 @@ class GlacierAccountIdMiddlewareTest {
             .build()
         val context = model.newTestContext(serviceShapeId = "com.test#Glacier", generator = AWSRestJson1ProtocolGenerator()).ctx
         val opStackName = "stack"
-        val glacierMiddleware = GlacierAccountIdMiddleware()
+        val glacierMiddleware = GlacierAccountIdMiddleware(model, context.symbolProvider)
 
-        glacierMiddleware.render(model, context.symbolProvider, writer, operationShape, opStackName, MiddlewareRenderableExecutionContext.CLIENT)
+        glacierMiddleware.render(writer, operationShape, opStackName)
 
         val contents = writer.toString()
         val expectedContents = """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->
This closes #207 
## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Auto fills Glacier account id on operations that have account id with "-".
Corresponding PR: https://github.com/awslabs/smithy-swift/pull/355

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.