### PR TITLE
chore: refactor remove MiddlewareRenderableExecutionContext and update interface

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGenerator.kt
@@ -16,7 +16,6 @@ import software.amazon.smithy.swift.codegen.core.toProtocolGenerationContext
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.SwiftIntegration
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareExecutionGenerator
-import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderableExecutionContext
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareStep
 import software.amazon.smithy.swift.codegen.middleware.OperationMiddleware
 import software.amazon.smithy.swift.codegen.model.expectShape
@@ -84,8 +83,7 @@ class PresignerGenerator : SwiftIntegration {
                     httpBindingResolver,
                     protocolGenerator.httpProtocolCustomizable,
                     operationMiddleware,
-                    operationStackName,
-                    MiddlewareRenderableExecutionContext.PRESIGNER
+                    operationStackName
                 )
                 generator.render(op) { writer, _ ->
                     writer.write("return nil")

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_0_ProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_0_ProtocolGenerator.kt
@@ -36,6 +36,6 @@ open class AwsJson1_0_ProtocolGenerator : AWSHttpBindingProtocolGenerator() {
     override fun addProtocolSpecificMiddleware(ctx: ProtocolGenerator.GenerationContext, operation: OperationShape) {
         super.addProtocolSpecificMiddleware(ctx, operation)
 
-        operationMiddleware.appendMiddleware(operation, AWSXAmzTargetMiddleware(ctx.service))
+        operationMiddleware.appendMiddleware(operation, AWSXAmzTargetMiddleware(ctx.model, ctx.symbolProvider, ctx.service))
     }
 }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_1_ProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_1_ProtocolGenerator.kt
@@ -36,6 +36,6 @@ class AwsJson1_1_ProtocolGenerator : AWSHttpBindingProtocolGenerator() {
     override fun addProtocolSpecificMiddleware(ctx: ProtocolGenerator.GenerationContext, operation: OperationShape) {
         super.addProtocolSpecificMiddleware(ctx, operation)
 
-        operationMiddleware.appendMiddleware(operation, AWSXAmzTargetMiddleware(ctx.service))
+        operationMiddleware.appendMiddleware(operation, AWSXAmzTargetMiddleware(ctx.model, ctx.symbolProvider, ctx.service))
     }
 }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/AwsQueryProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/AwsQueryProtocolGenerator.kt
@@ -99,6 +99,6 @@ open class AwsQueryProtocolGenerator : AWSHttpBindingProtocolGenerator() {
         // Original instance of OperationInputBodyMiddleware checks if there is an HTTP Body, but for AWSQuery
         // we always need to have an InputBodyMiddleware
         operationMiddleware.removeMiddleware(operation, MiddlewareStep.SERIALIZESTEP, "OperationInputBodyMiddleware")
-        operationMiddleware.appendMiddleware(operation, OperationInputBodyMiddleware(true))
+        operationMiddleware.appendMiddleware(operation, OperationInputBodyMiddleware(ctx.model, ctx.symbolProvider, true))
     }
 }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/polly/PollyGetPresignerIntegration.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/polly/PollyGetPresignerIntegration.kt
@@ -23,7 +23,6 @@ import software.amazon.smithy.swift.codegen.core.toProtocolGenerationContext
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.SwiftIntegration
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareExecutionGenerator
-import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderableExecutionContext
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareStep
 import software.amazon.smithy.swift.codegen.middleware.OperationMiddleware
 import software.amazon.smithy.swift.codegen.model.expectShape
@@ -106,7 +105,6 @@ class PollyGetPresignerIntegration(private val presignedOperations: Map<String, 
                     protocolGenerator.httpProtocolCustomizable,
                     operationMiddleware,
                     operationStackName,
-                    MiddlewareRenderableExecutionContext.PRESIGNER,
                     ::overrideHttpMethodWithGet
                 )
                 generator.render(op) { writer, _ ->

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/AWSSigningMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/AWSSigningMiddleware.kt
@@ -9,7 +9,6 @@ import software.amazon.smithy.aws.swift.codegen.AWSClientRuntimeTypes
 import software.amazon.smithy.aws.swift.codegen.AWSClientRuntimeTypes.Signing.SigV4Config
 import software.amazon.smithy.aws.traits.auth.SigV4Trait
 import software.amazon.smithy.aws.traits.auth.UnsignedPayloadTrait
-import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.knowledge.ServiceIndex
 import software.amazon.smithy.model.shapes.OperationShape
@@ -18,7 +17,6 @@ import software.amazon.smithy.model.traits.OptionalAuthTrait
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.middleware.MiddlewarePosition
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderable
-import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderableExecutionContext
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareStep
 import software.amazon.smithy.swift.codegen.model.expectTrait
 import software.amazon.smithy.swift.codegen.model.hasTrait
@@ -34,21 +32,18 @@ open class AWSSigningMiddleware(val paramsCallback: AWSSigningMiddlewareParamsCa
     override val position = MiddlewarePosition.BEFORE
 
     override fun render(
-        model: Model,
-        symbolProvider: SymbolProvider,
         writer: SwiftWriter,
         op: OperationShape,
         operationStackName: String,
-        executionContext: MiddlewareRenderableExecutionContext
     ) {
-        renderConfigDeclaration(writer, op, executionContext)
+        renderConfigDeclaration(writer, op)
         writer.write(
             "$operationStackName.${middlewareStep.stringValue()}.intercept(position: ${position.stringValue()}, middleware: \$N(config: sigv4Config))",
             AWSClientRuntimeTypes.Signing.SigV4Middleware
         )
     }
 
-    private fun renderConfigDeclaration(writer: SwiftWriter, op: OperationShape, executionContext: MiddlewareRenderableExecutionContext) {
+    private fun renderConfigDeclaration(writer: SwiftWriter, op: OperationShape) {
         writer.addImport(SigV4Config)
         writer.write("let sigv4Config = \$N(${middlewareParamsString(op)})", SigV4Config)
     }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/AWSXAmzTargetMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/AWSXAmzTargetMiddleware.kt
@@ -14,10 +14,13 @@ import software.amazon.smithy.swift.codegen.ServiceGenerator
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.middleware.MiddlewarePosition
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderable
-import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderableExecutionContext
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareStep
 
-class AWSXAmzTargetMiddleware(val serviceShape: ServiceShape) : MiddlewareRenderable {
+class AWSXAmzTargetMiddleware(
+    val model: Model,
+    val symbolProvider: SymbolProvider,
+    val serviceShape: ServiceShape
+) : MiddlewareRenderable {
 
     override val name = "AWSXAmzTargetMiddleware"
 
@@ -26,12 +29,9 @@ class AWSXAmzTargetMiddleware(val serviceShape: ServiceShape) : MiddlewareRender
     override val position = MiddlewarePosition.BEFORE
 
     override fun render(
-        model: Model,
-        symbolProvider: SymbolProvider,
         writer: SwiftWriter,
         op: OperationShape,
         operationStackName: String,
-        executionContext: MiddlewareRenderableExecutionContext
     ) {
         val inputShapeName = ServiceGenerator.getOperationInputShapeName(symbolProvider, model, op)
         val outputShapeName = ServiceGenerator.getOperationOutputShapeName(symbolProvider, model, op)

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/EndpointResolverMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/EndpointResolverMiddleware.kt
@@ -6,13 +6,10 @@
 package software.amazon.smithy.aws.swift.codegen.middleware
 
 import software.amazon.smithy.aws.swift.codegen.AWSClientRuntimeTypes
-import software.amazon.smithy.codegen.core.SymbolProvider
-import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.middleware.MiddlewarePosition
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderable
-import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderableExecutionContext
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareStep
 
 class EndpointResolverMiddleware : MiddlewareRenderable {
@@ -23,7 +20,7 @@ class EndpointResolverMiddleware : MiddlewareRenderable {
 
     override val position = MiddlewarePosition.BEFORE
 
-    override fun render(model: Model, symbolProvider: SymbolProvider, writer: SwiftWriter, op: OperationShape, operationStackName: String, executionContext: MiddlewareRenderableExecutionContext) {
+    override fun render(writer: SwiftWriter, op: OperationShape, operationStackName: String) {
         writer.write("$operationStackName.${middlewareStep.stringValue()}.intercept(position: ${position.stringValue()}, middleware: \$N(${middlewareParamsString()}))", AWSClientRuntimeTypes.Core.EndpointResolverMiddleware)
     }
 

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/MutateHeadersMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/MutateHeadersMiddleware.kt
@@ -1,13 +1,10 @@
 package software.amazon.smithy.aws.swift.codegen.middleware
 
-import software.amazon.smithy.codegen.core.SymbolProvider
-import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.swift.codegen.ClientRuntimeTypes
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.middleware.MiddlewarePosition
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderable
-import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderableExecutionContext
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareStep
 
 class MutateHeadersMiddleware(
@@ -21,7 +18,7 @@ class MutateHeadersMiddleware(
 
     override val position = MiddlewarePosition.AFTER
 
-    override fun render(model: Model, symbolProvider: SymbolProvider, writer: SwiftWriter, op: OperationShape, operationStackName: String, executionContext: MiddlewareRenderableExecutionContext) {
+    override fun render(writer: SwiftWriter, op: OperationShape, operationStackName: String) {
         val paramsString = middlewareParamsString()
         writer.write("$operationStackName.${middlewareStep.stringValue()}.intercept(position: ${position.stringValue()}, middleware: \$N($paramsString))", ClientRuntimeTypes.Middleware.MutateHeadersMiddleware)
     }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/RetryMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/RetryMiddleware.kt
@@ -6,13 +6,10 @@
 package software.amazon.smithy.aws.swift.codegen.middleware
 
 import software.amazon.smithy.aws.swift.codegen.AWSClientRuntimeTypes
-import software.amazon.smithy.codegen.core.SymbolProvider
-import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.middleware.MiddlewarePosition
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderable
-import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderableExecutionContext
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareStep
 
 class RetryMiddleware : MiddlewareRenderable {
@@ -23,7 +20,7 @@ class RetryMiddleware : MiddlewareRenderable {
 
     override val position = MiddlewarePosition.AFTER
 
-    override fun render(model: Model, symbolProvider: SymbolProvider, writer: SwiftWriter, op: OperationShape, operationStackName: String, executionContext: MiddlewareRenderableExecutionContext) {
+    override fun render(writer: SwiftWriter, op: OperationShape, operationStackName: String) {
         writer.write("$operationStackName.${middlewareStep.stringValue()}.intercept(position: ${position.stringValue()}, middleware: \$N(${middlewareParamsString()}))", AWSClientRuntimeTypes.Core.RetryerMiddleware)
     }
 

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/SynthesizeSpeechInputGETQueryItemMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/SynthesizeSpeechInputGETQueryItemMiddleware.kt
@@ -1,12 +1,9 @@
 package software.amazon.smithy.aws.swift.codegen.middleware
 
-import software.amazon.smithy.codegen.core.SymbolProvider
-import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.middleware.MiddlewarePosition
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderable
-import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderableExecutionContext
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareStep
 
 class SynthesizeSpeechInputGETQueryItemMiddleware : MiddlewareRenderable {
@@ -17,7 +14,7 @@ class SynthesizeSpeechInputGETQueryItemMiddleware : MiddlewareRenderable {
 
     override val position = MiddlewarePosition.AFTER
 
-    override fun render(model: Model, symbolProvider: SymbolProvider, writer: SwiftWriter, op: OperationShape, operationStackName: String, executionContext: MiddlewareRenderableExecutionContext) {
+    override fun render(writer: SwiftWriter, op: OperationShape, operationStackName: String) {
         writer.write("$operationStackName.${middlewareStep.stringValue()}.intercept(position: ${position.stringValue()}, middleware: $name())")
     }
 }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/UserAgentMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/UserAgentMiddleware.kt
@@ -6,14 +6,11 @@
 package software.amazon.smithy.aws.swift.codegen.middleware
 
 import software.amazon.smithy.aws.swift.codegen.AWSClientRuntimeTypes
-import software.amazon.smithy.codegen.core.SymbolProvider
-import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.swift.codegen.SwiftSettings
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.middleware.MiddlewarePosition
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderable
-import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderableExecutionContext
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareStep
 
 class UserAgentMiddleware(val settings: SwiftSettings) : MiddlewareRenderable {
@@ -24,7 +21,7 @@ class UserAgentMiddleware(val settings: SwiftSettings) : MiddlewareRenderable {
 
     override val position = MiddlewarePosition.BEFORE
 
-    override fun render(model: Model, symbolProvider: SymbolProvider, writer: SwiftWriter, op: OperationShape, operationStackName: String, executionContext: MiddlewareRenderableExecutionContext) {
+    override fun render(writer: SwiftWriter, op: OperationShape, operationStackName: String) {
         writer.write("$operationStackName.${middlewareStep.stringValue()}.intercept(position: ${position.stringValue()}, middleware: \$N(${middlewareParamsString()}))", AWSClientRuntimeTypes.Core.UserAgentMiddleware)
     }
 

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/AWSSigningMiddlewareTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/AWSSigningMiddlewareTests.kt
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.aws.swift.codegen.middleware.AWSSigningMiddleware
-import software.amazon.smithy.aws.swift.codegen.restjson.AWSRestJson1ProtocolGenerator
 import software.amazon.smithy.aws.traits.auth.SigV4Trait
 import software.amazon.smithy.aws.traits.auth.UnsignedPayloadTrait
 import software.amazon.smithy.model.Model
@@ -20,7 +19,6 @@ import software.amazon.smithy.model.traits.AuthTrait
 import software.amazon.smithy.model.traits.HttpBasicAuthTrait
 import software.amazon.smithy.model.traits.OptionalAuthTrait
 import software.amazon.smithy.swift.codegen.SwiftWriter
-import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderableExecutionContext
 
 class AWSSigningMiddlewareTests {
     @Test
@@ -74,21 +72,14 @@ class AWSSigningMiddlewareTests {
 let sigv4Config = AWSClientRuntime.SigV4Config(unsignedBody: true)
 stack.finalizeStep.intercept(position: .before, middleware: AWSClientRuntime.SigV4Middleware(config: sigv4Config))"""
         val writer = SwiftWriter("testName")
-        val serviceShape = ServiceShape.builder()
-            .id("com.test#Example")
-            .version("1.0")
-            .addTrait(SigV4Trait.builder().name("ExampleService").build())
-            .build()
         val operationShape = OperationShape.builder()
             .id("com.test#ExampleOperation")
             .addTrait(UnsignedPayloadTrait())
             .build()
-        val model = Model.builder().addShape(serviceShape).addShape(operationShape).build()
-        val context = model.newTestContext(generator = AWSRestJson1ProtocolGenerator()).ctx
         val opStackName = "stack"
         val sut = AWSSigningMiddleware()
 
-        sut.render(context.model, context.symbolProvider, writer, operationShape, opStackName, MiddlewareRenderableExecutionContext.CLIENT)
+        sut.render(writer, operationShape, opStackName)
 
         val contents = writer.toString()
         contents.shouldContainOnlyOnce(expectedContents)
@@ -101,20 +92,13 @@ stack.finalizeStep.intercept(position: .before, middleware: AWSClientRuntime.Sig
 let sigv4Config = AWSClientRuntime.SigV4Config(unsignedBody: false)
 stack.finalizeStep.intercept(position: .before, middleware: AWSClientRuntime.SigV4Middleware(config: sigv4Config))"""
         val writer = SwiftWriter("testName")
-        val serviceShape = ServiceShape.builder()
-            .id("com.test#Example")
-            .version("1.0")
-            .addTrait(SigV4Trait.builder().name("ExampleService").build())
-            .build()
         val operationShape = OperationShape.builder()
             .id("com.test#ExampleOperation")
             .build()
-        val model = Model.builder().addShape(serviceShape).addShape(operationShape).build()
-        val context = model.newTestContext(generator = AWSRestJson1ProtocolGenerator()).ctx
         val opStackName = "stack"
         val sut = AWSSigningMiddleware()
 
-        sut.render(context.model, context.symbolProvider, writer, operationShape, opStackName, MiddlewareRenderableExecutionContext.CLIENT)
+        sut.render(writer, operationShape, opStackName)
 
         val contents = writer.toString()
         contents.shouldContainOnlyOnce(expectedContents)
@@ -127,23 +111,16 @@ stack.finalizeStep.intercept(position: .before, middleware: AWSClientRuntime.Sig
 let sigv4Config = AWSClientRuntime.SigV4Config(expiration: expiration, unsignedBody: true)
 stack.finalizeStep.intercept(position: .before, middleware: AWSClientRuntime.SigV4Middleware(config: sigv4Config))"""
         val writer = SwiftWriter("testName")
-        val serviceShape = ServiceShape.builder()
-            .id("com.test#Example")
-            .version("1.0")
-            .addTrait(SigV4Trait.builder().name("ExampleService").build())
-            .build()
         val operationShape = OperationShape.builder()
             .id("com.test#ExampleOperation")
             .addTrait(UnsignedPayloadTrait())
             .build()
-        val model = Model.builder().addShape(serviceShape).addShape(operationShape).build()
-        val context = model.newTestContext(generator = AWSRestJson1ProtocolGenerator()).ctx
         val opStackName = "stack"
         val sut = AWSSigningMiddleware {
             "expiration: expiration, unsignedBody: true"
         }
 
-        sut.render(context.model, context.symbolProvider, writer, operationShape, opStackName, MiddlewareRenderableExecutionContext.PRESIGNER)
+        sut.render(writer, operationShape, opStackName)
 
         val contents = writer.toString()
         contents.shouldContainOnlyOnce(expectedContents)
@@ -156,22 +133,15 @@ stack.finalizeStep.intercept(position: .before, middleware: AWSClientRuntime.Sig
 let sigv4Config = AWSClientRuntime.SigV4Config(expiration: expiration, unsignedBody: false)
 stack.finalizeStep.intercept(position: .before, middleware: AWSClientRuntime.SigV4Middleware(config: sigv4Config))"""
         val writer = SwiftWriter("testName")
-        val serviceShape = ServiceShape.builder()
-            .id("com.test#Example")
-            .version("1.0")
-            .addTrait(SigV4Trait.builder().name("ExampleService").build())
-            .build()
         val operationShape = OperationShape.builder()
             .id("com.test#ExampleOperation")
             .build()
-        val model = Model.builder().addShape(serviceShape).addShape(operationShape).build()
-        val context = model.newTestContext(generator = AWSRestJson1ProtocolGenerator()).ctx
         val opStackName = "stack"
         val sut = AWSSigningMiddleware {
             "expiration: expiration, unsignedBody: false"
         }
 
-        sut.render(context.model, context.symbolProvider, writer, operationShape, opStackName, MiddlewareRenderableExecutionContext.PRESIGNER)
+        sut.render(writer, operationShape, opStackName)
 
         val contents = writer.toString()
         contents.shouldContainOnlyOnce(expectedContents)

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/AWSXAmzTargetMiddlewareTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/AWSXAmzTargetMiddlewareTests.kt
@@ -22,7 +22,6 @@ import software.amazon.smithy.swift.codegen.SwiftDelegator
 import software.amazon.smithy.swift.codegen.SwiftSettings
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
-import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderableExecutionContext
 
 class AWSXAmzTargetMiddlewareTests {
     @Test
@@ -55,9 +54,9 @@ stack.serializeStep.intercept(position: .before, middleware: AWSClientRuntime.XA
             .addShape(errorShape)
             .build()
         val context = model.newTestContext("com.test#ExampleServiceShapeName", AwsJson1_0_ProtocolGenerator()).ctx
-        val sut = AWSXAmzTargetMiddleware(context.service)
+        val sut = AWSXAmzTargetMiddleware(context.model, context.symbolProvider, context.service)
 
-        sut.render(context.model, context.symbolProvider, writer, operationShape, opStackName, MiddlewareRenderableExecutionContext.CLIENT)
+        sut.render(writer, operationShape, opStackName)
 
         val contents = writer.toString()
         contents.shouldContainOnlyOnce(expectedContents)


### PR DESCRIPTION
Removing MiddlewareRenderableExecutionContext -- instead, we can instantiate each renderable middleware with any extra context that is needed.

corresponding:
https://github.com/awslabs/smithy-swift/pull/357

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.