### PR TITLE
fix: change credential provider to be async with future

### DIFF
--- a/AWSClientRuntime/Sources/Auth/AWSCredentialsProvider.swift
+++ b/AWSClientRuntime/Sources/Auth/AWSCredentialsProvider.swift
@@ -53,16 +53,18 @@ public class AWSCredentialsProvider: CredentialsProvider {
         return AWSCredentialsProvider(awsCredentialsProvider: credsProvider)
     }
     
-    public func getCredentials() throws -> AWSCredentials {
+    public func getCredentials() throws -> SdkFuture<AWSCredentials> {
         let credentials = crtCredentialsProvider.getCredentials()
         let result = try credentials.get()
         guard let accessKey = result.getAccessKey(),
               let secret = result.getSecret() else {
             throw ClientError.authError("Unable to get credentials.  Required: accessKey, secret.")
         }
-        return AWSCredentials(accessKey: accessKey,
-                              secret: secret,
-                              expirationTimeout: result.getExpirationTimeout(),
-                              sessionToken: result.getSessionToken())
+        let future = SdkFuture<AWSCredentials>()
+        future.fulfill(AWSCredentials(accessKey: accessKey,
+                                      secret: secret,
+                                      expirationTimeout: result.getExpirationTimeout(),
+                                      sessionToken: result.getSessionToken()))
+        return future
     }
 }

--- a/AWSClientRuntime/Sources/Auth/CredentialsProvider.swift
+++ b/AWSClientRuntime/Sources/Auth/CredentialsProvider.swift
@@ -4,8 +4,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
+
+import ClientRuntime
         
 public protocol CredentialsProvider {
     /// Resolves `AWSCredentials` through custom means
-    func getCredentials() throws -> AWSCredentials
+    func getCredentials() throws -> SdkFuture<AWSCredentials>
 }

--- a/AWSClientRuntime/Sources/Auth/CredentialsProviderCRTAdapter.swift
+++ b/AWSClientRuntime/Sources/Auth/CredentialsProviderCRTAdapter.swift
@@ -20,7 +20,8 @@ struct CredentialsProviderCRTAdapter: CRTCredentialsProvider {
     
     func getCredentials(credentialCallbackData: CRTCredentialsProviderCallbackData) {
         do {
-            let credentials = try credentialsProvider.getCredentials()
+            let credentialsResult = try credentialsProvider.getCredentials()
+            let credentials = try credentialsResult.get()
             let emptyError = AWSError(errorCode: 0)
             let crtCredentials = credentials.toCRTType()
             credentialCallbackData.onCredentialsResolved?(crtCredentials, CRTError.crtError(emptyError))
@@ -29,6 +30,5 @@ struct CredentialsProviderCRTAdapter: CRTCredentialsProvider {
             
             credentialCallbackData.onCredentialsResolved?(nil, CRTError.crtError(AWSError(errorCode: -1)))
         }
-        
     }
 }

--- a/AWSClientRuntime/Sources/Middlewares/SigV4Middleware.swift
+++ b/AWSClientRuntime/Sources/Middlewares/SigV4Middleware.swift
@@ -55,8 +55,8 @@ public struct SigV4Middleware<OperationStackOutput: HttpResponseBinding,
         let signedBodyValue: AWSSignedBodyValue = config.unsignedBody ? .unsignedPayload : .empty
         
         do {
-            let credentials = try credentialsProvider.getCredentials()
-            
+            let credentialsResult = try credentialsProvider.getCredentials()
+            let credentials = try credentialsResult.get()
             let signingConfig = AWSSigningConfig(credentials: credentials,
                                                  expiration: config.expiration,
                                                  signedBodyHeader: config.signedBodyHeader,

--- a/AWSClientRuntime/Sources/Signing/AWSSigV4Signer.swift
+++ b/AWSClientRuntime/Sources/Signing/AWSSigV4Signer.swift
@@ -18,8 +18,8 @@ public class AWSSigV4Signer {
                                       date: ClientRuntime.Date,
                                       expiration: Int64) -> ClientRuntime.URL? {
         do {
-            let credentials = try credentialsProvider.getCredentials()
-            
+            let credentialsResult = try credentialsProvider.getCredentials()
+            let credentials = try credentialsResult.get()
             let flags = SigningFlags(useDoubleURIEncode: true,
                                      shouldNormalizeURIPath: true,
                                      omitSessionToken: false)

--- a/AWSClientRuntime/Tests/Auth/AWSCredentialProviderTests.swift
+++ b/AWSClientRuntime/Tests/Auth/AWSCredentialProviderTests.swift
@@ -14,14 +14,46 @@ class AWSCredentialProviderTests: XCTestCase {
     
     func testYouCanUseCustomCredentialsProvider() throws {
         let awsCredsProvider = try AWSCredentialsProvider.fromCustom(MyCustomCredentialsProvider())
-        let credentials = try awsCredsProvider.getCredentials()
+        let credentialsResult = try awsCredsProvider.getCredentials()
+        let credentials = try credentialsResult.get()
+        XCTAssertEqual(credentials.accessKey, "MYACCESSKEY")
+        XCTAssertEqual(credentials.secret, "sekrit")
+    }
+    
+    func testYouCanUseCustomCredentialsProviderFromDiffThread() throws {
+        let awsCredsProvider = try AWSCredentialsProvider.fromCustom(MyCustomThreadTestCredentialsProvider())
+        let credentialsResult = try awsCredsProvider.getCredentials()
+        let credentials = try credentialsResult.get()
         XCTAssertEqual(credentials.accessKey, "MYACCESSKEY")
         XCTAssertEqual(credentials.secret, "sekrit")
     }
 }
 
 struct MyCustomCredentialsProvider: CredentialsProvider {
-    func getCredentials() throws -> AWSCredentials {
-        return AWSCredentials(accessKey: "MYACCESSKEY", secret: "sekrit", expirationTimeout: 30)
+    func getCredentials() throws -> SdkFuture<AWSCredentials> {
+        let future = SdkFuture<AWSCredentials>()
+        future.fulfill(AWSCredentials(accessKey: "MYACCESSKEY", secret: "sekrit", expirationTimeout: 30))
+        return future
+    }
+}
+
+struct MyCustomThreadTestCredentialsProvider: CredentialsProvider {
+    func getCredentials() throws -> SdkFuture<AWSCredentials> {
+        let group = DispatchGroup()
+        let future = SdkFuture<AWSCredentials>()
+        let sleepVal = Int.random(in: 1...4)
+        for _ in 0...1000 {
+            group.enter()
+
+            DispatchQueue.global().async {
+                usleep(useconds_t(sleepVal))
+                future.fulfill(AWSCredentials(accessKey: "MYACCESSKEY", secret: "sekrit", expirationTimeout: 30))
+                group.leave()
+            }
+        }
+        
+        let result = group.wait(timeout: DispatchTime.now() + 10)
+        XCTAssert(result == .success)
+        return future
     }
 }

--- a/AWSClientRuntime/Tests/Auth/AWSCredentialProviderTests.swift
+++ b/AWSClientRuntime/Tests/Auth/AWSCredentialProviderTests.swift
@@ -19,58 +19,12 @@ class AWSCredentialProviderTests: XCTestCase {
         XCTAssertEqual(credentials.accessKey, "MYACCESSKEY")
         XCTAssertEqual(credentials.secret, "sekrit")
     }
-    
-    func testYouCanUseCustomCredentialsProviderFromDiffThread() throws {
-        let awsCredsProvider = try AWSCredentialsProvider.fromCustom(MyCustomThreadTestCredentialsProvider())
-        let credentialsResult = try awsCredsProvider.getCredentials()
-        let credentials = try credentialsResult.get()
-        XCTAssertEqual(credentials.accessKey, "MYACCESSKEY")
-        XCTAssertEqual(credentials.secret, "sekrit")
-    }
-    
-    func testCredentialsProviderIsNonBlocking() throws {
-        let awsCredsProvider = try AWSCredentialsProvider.fromCustom(MyCustomThreadTestCredentialsProvider())
-        let expectation = XCTestExpectation(description: "credentials received")
-        DispatchQueue.global().async {
-            do {
-                let credentialsResult = try awsCredsProvider.getCredentials()
-                let credentials = try credentialsResult.get()
-                XCTAssertEqual(credentials.accessKey, "MYACCESSKEY")
-                XCTAssertEqual(credentials.secret, "sekrit")
-                expectation.fulfill()
-            } catch let err {
-                XCTFail(err.localizedDescription)
-            }
-        }
-        let thisCodeShouldStillRun = true
-        XCTAssertTrue(thisCodeShouldStillRun)
-        wait(for: [expectation], timeout: 20.0)
-    }
 }
 
 struct MyCustomCredentialsProvider: CredentialsProvider {
     func getCredentials() throws -> SdkFuture<AWSCredentials> {
         let future = SdkFuture<AWSCredentials>()
         future.fulfill(AWSCredentials(accessKey: "MYACCESSKEY", secret: "sekrit", expirationTimeout: 30))
-        return future
-    }
-}
-
-struct MyCustomThreadTestCredentialsProvider: CredentialsProvider {
-    func getCredentials() throws -> SdkFuture<AWSCredentials> {
-        let group = DispatchGroup()
-        let future = SdkFuture<AWSCredentials>()
-        for _ in 0...1000 {
-            group.enter()
-            DispatchQueue.global().async {
-                usleep(useconds_t(1000))
-                future.fulfill(AWSCredentials(accessKey: "MYACCESSKEY", secret: "sekrit", expirationTimeout: 30))
-                group.leave()
-            }
-        }
-        
-        let result = group.wait(timeout: DispatchTime.now() + 10)
-        XCTAssert(result == .success)
         return future
     }
 }

--- a/AWSClientRuntime/Tests/Sigv4/SigV4SigningTests.swift
+++ b/AWSClientRuntime/Tests/Sigv4/SigV4SigningTests.swift
@@ -17,8 +17,10 @@ class Sigv4SigningTests: XCTestCase {
     }
 
     struct MyCustomCredentialsProvider: CredentialsProvider {
-        func getCredentials() throws -> AWSCredentials {
-            return AWSCredentials(accessKey: "AKIDEXAMPLE", secret: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY", expirationTimeout: 30)
+        func getCredentials() throws -> SdkFuture<AWSCredentials> {
+            let future = SdkFuture<AWSCredentials>()
+            future.fulfill(AWSCredentials(accessKey: "AKIDEXAMPLE", secret: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY", expirationTimeout: 30))
+            return future
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This PR allows the exposed protocol for a custom credentials provider to be async using a Future instead of a closure.
## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.