### PR TITLE
chore: Update doc generation to not include Models

### DIFF
--- a/scripts/generateDocs.sh
+++ b/scripts/generateDocs.sh
@@ -32,6 +32,10 @@ if [ -d ${OUTDIR_PREFIX} ]; then
     exit 1
 fi
 
+for todel in `find ${RELDIR} | grep "Models\.swift"`; do
+    rm -f ${todel}
+done
+
 for sdk in `ls ${RELDIR} | grep -e "^AWS"`; do
     OUTDIR="${OUTDIR_PREFIX}/${sdk}"
     echo "Generating ${sdk}: ${OUTDIR}"


### PR DESCRIPTION
- Generating documentation in html format is 1.3GB is too large and will adversely impact our repo
- We moved to markdown, which resulted in generation of the github pages site to timeout.
- Pairing down documentation to avoid generating documentation for all models and only include top level client calls.  If customers want to view documentation for specific input/output/error types, it seems sufficient that they can view this directly in XCode using DocC.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.