### PR TITLE
chore: fix ec2 protocol codegen tests

### DIFF
--- a/AWSClientRuntime/Sources/Protocols/Ec2Query/Ec2QueryError.swift
+++ b/AWSClientRuntime/Sources/Protocols/Ec2Query/Ec2QueryError.swift
@@ -16,7 +16,12 @@ public struct Ec2QueryError {
         if case .data(let data) = httpResponse.body,
            let responseBody = data {
             let decoded: Ec2Response = try XMLDecoder().decode(responseBody: responseBody)
-
+            self.errorCode = decoded.errors.error.code
+            self.message = decoded.errors.error.message
+            self.requestId = decoded.requestId
+            return
+        } else if case .stream(let byteStream) = httpResponse.body {
+            let decoded: Ec2Response = try XMLDecoder().decode(responseBody: byteStream.toBytes().toData())
             self.errorCode = decoded.errors.error.code
             self.message = decoded.errors.error.message
             self.requestId = decoded.requestId

--- a/codegen/Package.swift
+++ b/codegen/Package.swift
@@ -38,6 +38,9 @@ appendTstTarget(name: "RestXmlTestSDKTests", path: "\(baseDir)/rest-xml", depend
 appendLibTarget(name: "RestXmlWithNamespaceTestSDK", path: "\(baseDir)/rest-xml-xmlns")
 appendTstTarget(name: "RestXmlWithNamespaceTestSDKTests", path: "\(baseDir)/rest-xml-xmlns", dependency: "RestXmlWithNamespaceTestSDK")
 
+appendLibTarget(name: "Ec2QueryTestSDK", path: "\(baseDir)/ec2-query")
+appendTstTarget(name: "Ec2QueryTestSDKTests", path: "\(baseDir)/ec2-query", dependency: "Ec2QueryTestSDK")
+
 appendLibTarget(name: "AWSQueryTestSDK", path: "\(baseDir)/aws-query")
 appendTstTarget(name: "AWSQueryTestSDKTests", path: "\(baseDir)/aws-query", dependency: "AWSQueryTestSDK")
 

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/ec2query/httpResponse/AWSEc2QueryHttpResponseTraitWithoutPayload.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/ec2query/httpResponse/AWSEc2QueryHttpResponseTraitWithoutPayload.kt
@@ -64,6 +64,7 @@ class AWSEc2QueryHttpResponseTraitWithoutPayload(
     }
 
     fun renderWithoutErrorResponseContainer(outputShapeName: String, bodyMembersWithoutQueryTrait: Set<String>) {
+        writer.addImport(AWSClientRuntimeTypes.EC2Query.Ec2NarrowedResponse)
         writer.write("let output: \$N<${outputShapeName}Body> = try responseDecoder.decode(responseBody: data)", AWSClientRuntimeTypes.EC2Query.Ec2NarrowedResponse)
         bodyMembersWithoutQueryTrait.sorted().forEach {
             writer.write("self.$it = output.errors.error.$it")


### PR DESCRIPTION
Fixes ec2 protocol codegen tests
- missing an import statement
- force add the body middleware (similiar to what we do for aws query)
- re-enable tests
- add stream parsing logic in awsclient runtime
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.