### PR TITLE
fix: package.swift api updated for swift 5.5

### DIFF
--- a/codegen/Package.swift
+++ b/codegen/Package.swift
@@ -79,7 +79,7 @@ func appendLibTarget(name: String, path: String) {
 func appendTstTarget(name: String, path: String, dependency: String) {
     package.targets.append(.testTarget(name: name,
                                        dependencies:  [
-                                        ._byNameItem(name: dependency, condition: nil),
+                                        .byNameItem(name: dependency, condition: nil),
                                         .product(name: "SmithyTestUtil", package: "ClientRuntime")
                                        ],
                                        path: "\(path)/swift-codegen/\(name)")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Remove underscore for new api in swift 5.5
## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.