### PR TITLE
chore: improve developer experience with region resolver

### DIFF
--- a/AWSClientRuntime/Sources/Regions/DefaultRegionResolver.swift
+++ b/AWSClientRuntime/Sources/Regions/DefaultRegionResolver.swift
@@ -5,26 +5,32 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 import AwsCommonRuntimeKit
+import ClientRuntime
 
 public struct DefaultRegionResolver: RegionResolver {
     public let providers: [RegionProvider]
-    
+    let logger: SwiftLogger
+
     public init(providers: [RegionProvider] = [EnvironmentRegionProvider(), ProfileRegionProvider(), IMDSRegionProvider()]) {
         // TODO: add more region resolvers i.e. System Properties, etc
         self.providers = providers
+        self.logger = SwiftLogger(label: "DefaultRegionProvider")
     }
     
     public func resolveRegion() -> String? {
         for provider in providers {
             do {
                 // TODO: Verify that this does not block calling thread. If it does, we need to solve this similar to the way we solve this for the credentials provider
+                logger.debug("Attempting to resolve region with: \(String(describing: type(of: provider)))")
                 if let region = try provider.resolveRegion().get() {
+                    logger.debug("Resolved region with: \(String(describing: type(of: provider)))")
                     return region
                 }
             } catch {
                 return nil
             }
         }
+        logger.error("Unable to resolve region")
         return nil
     }
 }

--- a/AWSClientRuntime/Sources/Regions/DefaultRegionResolver.swift
+++ b/AWSClientRuntime/Sources/Regions/DefaultRegionResolver.swift
@@ -30,7 +30,7 @@ public struct DefaultRegionResolver: RegionResolver {
                 return nil
             }
         }
-        logger.error("Unable to resolve region")
+        logger.debug("Unable to resolve region")
         return nil
     }
 }

--- a/AWSClientRuntime/Sources/Regions/ProfileRegionResolver.swift
+++ b/AWSClientRuntime/Sources/Regions/ProfileRegionResolver.swift
@@ -30,17 +30,18 @@ public struct ProfileRegionProvider: RegionProvider {
 
         let profileCollection = profileCollection ?? CRTAWSProfileCollection(fromFile: path, source: .config)
         guard let profileCollection = profileCollection else {
-            logger.info("No default profile collection was found at the path of \(path)")
+            logger.debug("No default profile collection was found at the path of \(path)")
             future.fulfill(nil)
             return future
         }
         
         guard let profile = profileCollection.profile(for: profileName) else {
+            logger.debug("Unable to find profile: \(profileName) in \(path)")
             future.fulfill(nil)
             return future
         }
         guard let region = profile.getProperty(name: "region") else {
-            logger.info("Attempting to use \(profileName), but no region was found")
+            logger.debug("Attempting to use \(profileName), but no region was found")
             future.fulfill(nil)
             return future
         }


### PR DESCRIPTION
**Use case 1:**
* assume customer has logging disabled
* no region provider is properly configured, then customers will see:
```
<No output, SDK will be silent>
```

**Use case 2:**
* Assume customer has logging enabled to `debug` level: `SDKLoggingSystem.initialize(logLevel: .debug)`
* No region provider
Result is that customers will see:
```
2021-11-03T14:55:13-0700 debug DefaultRegionProvider : Attempting to resolve region with: EnvironmentRegionProvider
2021-11-03T14:55:13-0700 debug DefaultRegionProvider : Attempting to resolve region with: ProfileRegionProvider
2021-11-03T14:55:13-0700 debug ProfileRegionResolver : No default profile collection was found at the path of ~/.aws/config
2021-11-03T14:55:13-0700 debug DefaultRegionProvider : Attempting to resolve region with: IMDSRegionProvider
2021-11-03T14:55:14-0700 debug DefaultRegionProvider : Unable to resolve region
```

**Use case 3 (happy path, with debug)**
* Assume customer has logging enabled to `debug` level: `SDKLoggingSystem.initialize(logLevel: .debug)`
* credentials/config file is available
Users will see:
```
2021-11-03T14:55:56-0700 debug DefaultRegionProvider : Attempting to resolve region with: EnvironmentRegionProvider
2021-11-03T14:55:56-0700 debug DefaultRegionProvider : Attempting to resolve region with: ProfileRegionProvider
2021-11-03T14:55:56-0700 debug DefaultRegionProvider : Resolved region with: ProfileRegionProvider
```

**Use case 4 (happy path, without debug)**
* Assume customer has logging disabled
* credentials/config file is available
Users will see:
```
<No output, SDK will be silent>
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.