### PR TITLE
feat: region resolver via bundle

### DIFF
--- a/AWSClientRuntime/Sources/Config/Bundle.swift
+++ b/AWSClientRuntime/Sources/Config/Bundle.swift
@@ -1,0 +1,18 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+        
+#if os(iOS) || os(watchOS) || os(tvOS)
+import Foundation.NSBundle
+public typealias Bundle = Foundation.Bundle
+#else
+public struct Bundle {
+    func object(forInfoDictionaryKey key: String) -> Any? {
+        return nil
+    }
+    public static var main: Bundle = Bundle()
+}
+#endif

--- a/AWSClientRuntime/Sources/Config/BundleConfiguration.swift
+++ b/AWSClientRuntime/Sources/Config/BundleConfiguration.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import Foundation
+import Foundation.NSBundle
 
 // Adapted from: https://nshipster.com/xcconfig/
 struct BundleConfiguration {

--- a/AWSClientRuntime/Sources/Config/BundleConfiguration.swift
+++ b/AWSClientRuntime/Sources/Config/BundleConfiguration.swift
@@ -1,0 +1,30 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+// Adapted from: https://nshipster.com/xcconfig/
+struct BundleConfiguration {
+    enum Error: Swift.Error {
+        case missingKey, invalidValue
+    }
+
+    static func value<T>(bundle: Foundation.Bundle, for key: String) throws -> T where T: LosslessStringConvertible {
+        guard let object = bundle.object(forInfoDictionaryKey: key) else {
+            throw Error.missingKey
+        }
+        switch object {
+        case let value as T:
+            return value
+        case let string as String:
+            guard let value = T(string) else { fallthrough }
+            return value
+        default:
+            throw Error.invalidValue
+        }
+    }
+}

--- a/AWSClientRuntime/Sources/Config/BundleConfiguration.swift
+++ b/AWSClientRuntime/Sources/Config/BundleConfiguration.swift
@@ -5,15 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import Foundation.NSBundle
-
 // Adapted from: https://nshipster.com/xcconfig/
 struct BundleConfiguration {
     enum Error: Swift.Error {
         case missingKey, invalidValue
     }
 
-    static func value<T>(bundle: Foundation.Bundle, for key: String) throws -> T where T: LosslessStringConvertible {
+    static func value<T>(bundle: Bundle, for key: String) throws -> T where T: LosslessStringConvertible {
         guard let object = bundle.object(forInfoDictionaryKey: key) else {
             throw Error.missingKey
         }

--- a/AWSClientRuntime/Sources/Regions/BundleRegionProvider.swift
+++ b/AWSClientRuntime/Sources/Regions/BundleRegionProvider.swift
@@ -6,15 +6,14 @@
 //
 import AwsCommonRuntimeKit
 import ClientRuntime
-import Foundation.NSBundle
 
 public struct BundleRegionProvider: RegionProvider {
     private let logger: SwiftLogger
-    private let bundle: Foundation.Bundle
+    private let bundle: Bundle
     private let regionKey: String
     private let maxSizeRegion = 20
 
-    public init(bundle: Foundation.Bundle = Bundle.main, regionKey: String = "AWS_REGION") {
+    public init(bundle: Bundle = Bundle.main, regionKey: String = "AWS_REGION") {
         self.logger = SwiftLogger(label: "BundleRegionProvider")
         self.bundle = bundle
         self.regionKey = regionKey

--- a/AWSClientRuntime/Sources/Regions/BundleRegionProvider.swift
+++ b/AWSClientRuntime/Sources/Regions/BundleRegionProvider.swift
@@ -12,7 +12,8 @@ public struct BundleRegionProvider: RegionProvider {
     private let logger: SwiftLogger
     private let bundle: Foundation.Bundle
     private let regionKey: String
-    
+    private let maxSizeRegion = 20
+
     public init(bundle: Foundation.Bundle = Bundle.main, regionKey: String = "AWS_REGION") {
         self.logger = SwiftLogger(label: "BundleRegionProvider")
         self.bundle = bundle
@@ -22,7 +23,12 @@ public struct BundleRegionProvider: RegionProvider {
     public func resolveRegion() -> Future<String?> {
         let future = Future<String?>()
         #if os(iOS) || os(watchOS) || os(tvOS)
-        future.fulfill(region())
+        guard let region = region() else {
+            future.fulfill(nil)
+        }
+        return region.count > maxSizeRegion
+            ? future.fulfill(region.prefix(maxSizeRegion))
+            : future.fulfill(region)
         #else
         future.fulfill(nil)
         #endif

--- a/AWSClientRuntime/Sources/Regions/BundleRegionProvider.swift
+++ b/AWSClientRuntime/Sources/Regions/BundleRegionProvider.swift
@@ -1,0 +1,40 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+import AwsCommonRuntimeKit
+import ClientRuntime
+import Foundation.NSBundle
+
+public struct BundleRegionProvider: RegionProvider {
+    private let logger: SwiftLogger
+    private let bundle: Foundation.Bundle
+    private let regionKey: String
+    
+    public init(bundle: Foundation.Bundle = Bundle.main, regionKey: String = "AWS_REGION") {
+        self.logger = SwiftLogger(label: "BundleRegionProvider")
+        self.bundle = bundle
+        self.regionKey = regionKey
+    }
+    
+    public func resolveRegion() -> Future<String?> {
+        let future = Future<String?>()
+        #if os(iOS) || os(watchOS) || os(tvOS)
+        future.fulfill(region())
+        #else
+        future.fulfill(nil)
+        #endif
+        return future
+    }
+
+    func region() -> String? {
+        do {
+            return try BundleConfiguration.value(bundle: self.bundle, for: regionKey)
+        } catch {
+            logger.debug("\(error)")
+        }
+        return nil
+    }
+}

--- a/AWSClientRuntime/Sources/Regions/DefaultRegionResolver.swift
+++ b/AWSClientRuntime/Sources/Regions/DefaultRegionResolver.swift
@@ -11,7 +11,7 @@ public struct DefaultRegionResolver: RegionResolver {
     public let providers: [RegionProvider]
     let logger: SwiftLogger
 
-    public init(providers: [RegionProvider] = [EnvironmentRegionProvider(), ProfileRegionProvider(), IMDSRegionProvider()]) {
+    public init(providers: [RegionProvider] = [EnvironmentRegionProvider(), ProfileRegionProvider(), IMDSRegionProvider(), BundleRegionProvider()]) {
         // TODO: add more region resolvers i.e. System Properties, etc
         self.providers = providers
         self.logger = SwiftLogger(label: "DefaultRegionProvider")

--- a/AWSClientRuntime/Sources/Regions/DefaultRegionResolver.swift
+++ b/AWSClientRuntime/Sources/Regions/DefaultRegionResolver.swift
@@ -12,7 +12,6 @@ public struct DefaultRegionResolver: RegionResolver {
     let logger: SwiftLogger
 
     public init(providers: [RegionProvider] = [BundleRegionProvider(), EnvironmentRegionProvider(), ProfileRegionProvider(), IMDSRegionProvider()]) {
-        // TODO: add more region resolvers i.e. System Properties, etc
         self.providers = providers
         self.logger = SwiftLogger(label: "DefaultRegionProvider")
     }

--- a/AWSClientRuntime/Sources/Regions/DefaultRegionResolver.swift
+++ b/AWSClientRuntime/Sources/Regions/DefaultRegionResolver.swift
@@ -11,7 +11,7 @@ public struct DefaultRegionResolver: RegionResolver {
     public let providers: [RegionProvider]
     let logger: SwiftLogger
 
-    public init(providers: [RegionProvider] = [EnvironmentRegionProvider(), ProfileRegionProvider(), IMDSRegionProvider(), BundleRegionProvider()]) {
+    public init(providers: [RegionProvider] = [BundleRegionProvider(), EnvironmentRegionProvider(), ProfileRegionProvider(), IMDSRegionProvider()]) {
         // TODO: add more region resolvers i.e. System Properties, etc
         self.providers = providers
         self.logger = SwiftLogger(label: "DefaultRegionProvider")


### PR DESCRIPTION
To make use of `BundleRegionProvider` pulling the region from your bundle:
1.  Create an iOS project (or some sort of project which uses a Bundle)
2.  Add `<debug,production>.xcconfig` to each one of your targets (and assign appropriately)
3. So that the values of these variables are available during execution time of the code, you MUST, inside each of your .xcconfig files, define a variable like:

For Debug.xcconfig
```
AWS_REGION=us-west-2
```

For Production.xcconfig
```
AWS_REGION=us-east-1
```
4. In your Info.plist, add a **Key** with `AWS_REGION` of **Type** `String`, with value: `$(AWS_REGION)`.  For example:
```
	<key>AWS_REGION</key>
	<string>$(AWS_REGION)</string>
```

5.  Attempt to invoke the `BundleRegionProvider`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.