### PR TITLE
chore: update max region size

### DIFF
--- a/AWSClientRuntime/Sources/Regions/BundleRegionProvider.swift
+++ b/AWSClientRuntime/Sources/Regions/BundleRegionProvider.swift
@@ -11,7 +11,7 @@ public struct BundleRegionProvider: RegionProvider {
     private let logger: SwiftLogger
     private let bundle: Bundle
     private let regionKey: String
-    private let maxSizeRegion = 20
+    private let maxSizeRegion = 38
 
     public init(bundle: Bundle = Bundle.main, regionKey: String = "AWS_REGION") {
         self.logger = SwiftLogger(label: "BundleRegionProvider")


### PR DESCRIPTION
The longest current region size I found had 15 characters (`us-isob-east-1`) -- i multiplied this by 2.5 and got 37.5 and rounded up to 38.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.