### PR TITLE
feat: add s3 get object presigner

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/InputTypeGETQueryItemMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/InputTypeGETQueryItemMiddleware.kt
@@ -1,9 +1,11 @@
-package software.amazon.smithy.aws.swift.codegen.customization.polly
+package software.amazon.smithy.aws.swift.codegen.customization
 
 import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.model.shapes.IntegerShape
 import software.amazon.smithy.model.shapes.ListShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.shapes.TimestampShape
 import software.amazon.smithy.swift.codegen.ClientRuntimeTypes.Core.URLQueryItem
 import software.amazon.smithy.swift.codegen.Middleware
 import software.amazon.smithy.swift.codegen.SwiftTypes
@@ -12,7 +14,7 @@ import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.steps.OperationSerializeStep
 import software.amazon.smithy.swift.codegen.model.isEnum
 
-class PollySynthesizeSpeechGETQueryItemMiddleware(
+class InputTypeGETQueryItemMiddleware(
     private val ctx: ProtocolGenerator.GenerationContext,
     inputSymbol: Symbol,
     outputSymbol: Symbol,
@@ -27,8 +29,12 @@ class PollySynthesizeSpeechGETQueryItemMiddleware(
             val memberName = ctx.symbolProvider.toMemberName(member)
             val queryKey = member.memberName
 
+            val memberTargetShape = ctx.model.expectShape(member.target)
+            if (memberTargetShape is IntegerShape || memberTargetShape is TimestampShape) {
+                // TODO: We should support all types in our presignable operations
+                continue
+            }
             writer.openBlock("if let $memberName = input.operationInput.$memberName {", "}") {
-                val memberTargetShape = ctx.model.expectShape(member.target)
                 when (memberTargetShape) {
                     is ListShape -> {
                         val rawValueIfNeeded = rawValueIfNeeded(memberTargetShape.member.target)

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/presignable/PresignableGetIntegration.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/presignable/PresignableGetIntegration.kt
@@ -2,6 +2,7 @@ package software.amazon.smithy.aws.swift.codegen.customization.presignable
 
 import software.amazon.smithy.aws.swift.codegen.AWSClientRuntimeTypes
 import software.amazon.smithy.aws.swift.codegen.PresignableOperation
+import software.amazon.smithy.aws.swift.codegen.customization.InputTypeGETQueryItemMiddleware
 import software.amazon.smithy.aws.swift.codegen.middleware.AWSSigningMiddleware
 import software.amazon.smithy.aws.swift.codegen.middleware.InputTypeGETQueryItemMiddlewareRenderable
 import software.amazon.smithy.aws.traits.auth.UnsignedPayloadTrait
@@ -178,15 +179,14 @@ class PresignableGetIntegration(private val presignedOperations: Map<String, Set
             .build()
         delegator.useShapeWriter(headerMiddlewareSymbol) { writer ->
             writer.addImport(SwiftDependency.CLIENT_RUNTIME.target)
-            val queryItemMiddleware =
-                software.amazon.smithy.aws.swift.codegen.customization.InputTypeGETQueryItemMiddleware(
-                    ctx,
-                    inputSymbol,
-                    outputSymbol,
-                    outputErrorSymbol,
-                    inputShape,
-                    writer
-                )
+            val queryItemMiddleware = InputTypeGETQueryItemMiddleware(
+                ctx,
+                inputSymbol,
+                outputSymbol,
+                outputErrorSymbol,
+                inputShape,
+                writer
+            )
             MiddlewareGenerator(writer, queryItemMiddleware).generate()
         }
     }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/InputTypeGETQueryItemMiddlewareRenderable.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/InputTypeGETQueryItemMiddlewareRenderable.kt
@@ -1,14 +1,15 @@
 package software.amazon.smithy.aws.swift.codegen.middleware
 
+import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.middleware.MiddlewarePosition
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareRenderable
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareStep
 
-class SynthesizeSpeechInputGETQueryItemMiddleware : MiddlewareRenderable {
+class InputTypeGETQueryItemMiddlewareRenderable(inputSymbol: Symbol) : MiddlewareRenderable {
 
-    override val name = "SynthesizeSpeechInputGETQueryItemMiddleware"
+    override val name = "${inputSymbol.name}GETQueryItemMiddleware"
 
     override val middlewareStep = MiddlewareStep.SERIALIZESTEP
 

--- a/codegen/smithy-aws-swift-codegen/src/main/resources/META-INF/services/software.amazon.smithy.swift.codegen.integration.SwiftIntegration
+++ b/codegen/smithy-aws-swift-codegen/src/main/resources/META-INF/services/software.amazon.smithy.swift.codegen.integration.SwiftIntegration
@@ -8,6 +8,6 @@ software.amazon.smithy.aws.swift.codegen.customization.glacier.GlacierChecksum
 software.amazon.smithy.aws.swift.codegen.customization.BoxServices
 software.amazon.smithy.aws.swift.codegen.customization.PresignableModelIntegration
 software.amazon.smithy.aws.swift.codegen.customization.machinelearning.PredictEndpointIntegration
-software.amazon.smithy.aws.swift.codegen.customization.polly.PollyGetPresignerIntegration
+software.amazon.smithy.aws.swift.codegen.customization.presignable.PresignableGetIntegration
 software.amazon.smithy.aws.swift.codegen.customization.sts.DisabledAuth
 software.amazon.smithy.aws.swift.codegen.PresignerGenerator


### PR DESCRIPTION
Adding a presigner for S3's Get Object -- kind of quick and dirty in that we aren't supporting a the input type's that are of type `Date` nor `Int` -- added a TODO for this.


Tested with a quick and dirty hello world app:
```
struct MySpecialEndpointResolver: EndpointResolver {
    func resolve(serviceId: String, region: String) throws -> AWSEndpoint {
        return AWSEndpoint(endpoint: Endpoint(host: "s3.amazonaws.com"))
    }
}
func genPresignedUrlForS3GetObject() throws{
    let s3Config = try S3Client.S3ClientConfiguration( endpointResolver: MySpecialEndpointResolver(), region: "us-west-2")
    let input = GetObjectInput(bucket: "<INSERT YOUR BUCKET>", key: "<key>")
    guard let url = input.presignURL(config: s3Config, expiration: 10000) else {
        print("exiting")
        exit(1)
    }
    print(url)
}
try genPresignedUrlForS3GetObject()
```

(note you may not need `MySpecialEndpointResolver` if you are executing in us-east-1)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.