### PR TITLE
fix: Language metadata to render extras properly

### DIFF
--- a/AWSClientRuntime/Sources/Http/LanguageMetadata.swift
+++ b/AWSClientRuntime/Sources/Http/LanguageMetadata.swift
@@ -21,11 +21,11 @@ public struct LanguageMetadata {
 
 extension LanguageMetadata: CustomStringConvertible {
     public var description: String {
-        let extrasMetaData = !extras.isEmpty
+        let extrasMetadata = !extras.isEmpty
             ? extras.map {
                 " md/\($0.key.sanitizeForUserAgentToken())/\($0.value.sanitizeForUserAgentToken())"
             }.joined()
             : ""
-        return "lang/swift/\(sanitizedVersion)\(extrasMetaData)"
+        return "lang/swift/\(sanitizedVersion)\(extrasMetadata)"
     }
 }

--- a/AWSClientRuntime/Sources/Http/LanguageMetadata.swift
+++ b/AWSClientRuntime/Sources/Http/LanguageMetadata.swift
@@ -9,7 +9,10 @@ import ClientRuntime
 public struct LanguageMetadata {
     let version: String
     let extras: [String: String]
-    
+    var sanitizedVersion: String {
+        return version.sanitizeForUserAgentToken()
+    }
+
     public init(version: String = swiftVersion, extras: [String: String] = [String: String]()) {
         self.version = version
         self.extras = extras
@@ -18,7 +21,11 @@ public struct LanguageMetadata {
 
 extension LanguageMetadata: CustomStringConvertible {
     public var description: String {
-        return !extras.isEmpty ? "lang/swift/\(version)\(extras.map {" md/\($0.key)/\($0.value.sanitizeForUserAgentToken())"})"
-            : "lang/swift/\(version)"
+        let extrasMetaData = !extras.isEmpty
+            ? extras.map {
+                " md/\($0.key.sanitizeForUserAgentToken())/\($0.value.sanitizeForUserAgentToken())"
+            }.joined()
+            : ""
+        return "lang/swift/\(sanitizedVersion)\(extrasMetaData)"
     }
 }

--- a/AWSClientRuntime/Tests/Http/LanguageMetadataTests.swift
+++ b/AWSClientRuntime/Tests/Http/LanguageMetadataTests.swift
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
         
-
 import XCTest
 @testable import AWSClientRuntime
 

--- a/AWSClientRuntime/Tests/Http/LanguageMetadataTests.swift
+++ b/AWSClientRuntime/Tests/Http/LanguageMetadataTests.swift
@@ -1,0 +1,42 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+        
+
+import XCTest
+@testable import AWSClientRuntime
+
+class LanguageMetadataTests: XCTestCase {
+    func testHappyPath() {
+        let sut = LanguageMetadata(version: "5.0")
+
+        XCTAssertEqual("lang/swift/5.0", sut.description)
+    }
+    
+    func testHappyPathWithSingleExtra() {
+        let sut = LanguageMetadata(version: "5.1", extras: ["test1": "4.3"])
+
+        XCTAssertEqual("lang/swift/5.1 md/test1/4.3", sut.description)
+    }
+
+    func testHappyPathWithMultipleExtras() {
+        let sut = LanguageMetadata(version: "5.2", extras: ["test1": "4.4",
+                                                            "test2": "9.0.1"])
+
+        let option1 = "lang/swift/5.2 md/test1/4.4 md/test2/9.0.1" == sut.description
+        let option2 = "lang/swift/5.2 md/test2/9.0.1 md/test1/4.4" == sut.description
+        XCTAssert(option1 || option2)
+    }
+
+    func testHappyPathWithMultipleExtrasSanitize() {
+        let sut = LanguageMetadata(version: "4👍.2", extras: ["test🍺3": "4.1",
+                                                            "test🍙4": "9.0.🍘2"])
+
+        let option1 = "lang/swift/4.2 md/test3/4.1 md/test4/9.0.2" == sut.description
+        let option2 = "lang/swift/4.2 md/test4/9.0.2 md/test3/4.1" == sut.description
+        XCTAssert(option1 || option2)
+    }
+}


### PR DESCRIPTION
Prior to doing this, we were improperly generating user agent strings because `.map{}` generates an `[String]` rather than `String` -- so, we need this update to properly generate a user agent string.  Also, I added some unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.