### PR TITLE
chore: adding level of indirection for Bundle

### DIFF
--- a/AWSClientRuntime/Sources/Config/Bundle.swift
+++ b/AWSClientRuntime/Sources/Config/Bundle.swift
@@ -5,14 +5,26 @@
 // SPDX-License-Identifier: Apache-2.0
 //
         
+public protocol BundleProtocol {
+    func object(forInfoDictionaryKey key: String) -> Any?
+}
+
 #if os(iOS) || os(watchOS) || os(tvOS)
 import Foundation.NSBundle
+
 public typealias Bundle = Foundation.Bundle
+
+extension Bundle: BundleProtocol {
+    // No implementation needed
+}
 #else
 public struct Bundle {
-    func object(forInfoDictionaryKey key: String) -> Any? {
+    public static var main: BundleProtocol = NoopBundle()
+}
+
+public struct NoopBundle: BundleProtocol {
+    public func object(forInfoDictionaryKey key: String) -> Any? {
         return nil
     }
-    public static var main: Bundle = Bundle()
 }
 #endif

--- a/AWSClientRuntime/Sources/Config/BundleConfiguration.swift
+++ b/AWSClientRuntime/Sources/Config/BundleConfiguration.swift
@@ -11,7 +11,7 @@ struct BundleConfiguration {
         case missingKey, invalidValue
     }
 
-    static func value<T>(bundle: Bundle, for key: String) throws -> T where T: LosslessStringConvertible {
+    static func value<T>(bundle: BundleProtocol, for key: String) throws -> T where T: LosslessStringConvertible {
         guard let object = bundle.object(forInfoDictionaryKey: key) else {
             throw Error.missingKey
         }

--- a/AWSClientRuntime/Sources/Regions/BundleRegionProvider.swift
+++ b/AWSClientRuntime/Sources/Regions/BundleRegionProvider.swift
@@ -9,11 +9,11 @@ import ClientRuntime
 
 public struct BundleRegionProvider: RegionProvider {
     private let logger: SwiftLogger
-    private let bundle: Bundle
+    private let bundle: BundleProtocol
     private let regionKey: String
     private let maxSizeRegion = 38
 
-    public init(bundle: Bundle = Bundle.main, regionKey: String = "AWS_REGION") {
+    public init(bundle: BundleProtocol = Bundle.main, regionKey: String = "AWS_REGION") {
         self.logger = SwiftLogger(label: "BundleRegionProvider")
         self.bundle = bundle
         self.regionKey = regionKey


### PR DESCRIPTION
Working around swiftlint instantiating `Bundle()` directly in this commit: https://github.com/awslabs/aws-sdk-swift/commit/4649f0c352f5110a92054de4066252101429578d#
- this eliminates the false positive around directly instantiating `Bundle()`
- Because it is a false positive, pushing this code in is not required, but if we feel it adds to readability, we should push this in.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.