### PR TITLE
fix: eliminate latency of instantiation of client on iOS with explicit region

### DIFF
--- a/AWSClientRuntime/Sources/AWSClientConfiguration.swift
+++ b/AWSClientRuntime/Sources/AWSClientConfiguration.swift
@@ -10,7 +10,7 @@ public protocol AWSRuntimeConfiguration {
     var region: String? { get set }
     var signingRegion: String? {get set}
     var endpointResolver: EndpointResolver {get set}
-    var regionResolver: RegionResolver {get set}
+    var regionResolver: RegionResolver? {get set}
     var frameworkMetadata: FrameworkMetadata? {get set}
 }
 

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/RestJsonProtocolGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/RestJsonProtocolGeneratorTests.kt
@@ -121,7 +121,7 @@ class RestJsonProtocolGeneratorTests {
                     public var endpointResolver: AWSClientRuntime.EndpointResolver
                     public var frameworkMetadata: AWSClientRuntime.FrameworkMetadata?
                     public var region: Swift.String?
-                    public var regionResolver: AWSClientRuntime.RegionResolver
+                    public var regionResolver: AWSClientRuntime.RegionResolver?
                     public var signingRegion: Swift.String?
             
                     public init(
@@ -133,10 +133,17 @@ class RestJsonProtocolGeneratorTests {
                         signingRegion: Swift.String? = nil,
                         runtimeConfig: ClientRuntime.SDKRuntimeConfiguration
                     ) throws {
-                        self.regionResolver = regionResolver ?? DefaultRegionResolver()
-                        let defaultRegion = self.regionResolver.resolveRegion()
-                        self.region = region ?? defaultRegion
-                        self.signingRegion = signingRegion ?? defaultRegion
+                        if let region = region {
+                            self.region = region
+                            self.regionResolver = nil
+                            self.signingRegion = signingRegion ?? region
+                        } else {
+                            let resolvedRegionResolver = regionResolver ?? DefaultRegionResolver()
+                            let region = resolvedRegionResolver.resolveRegion()
+                            self.region = region
+                            self.regionResolver = resolvedRegionResolver
+                            self.signingRegion = signingRegion ?? region
+                        }
                         self.endpointResolver = endpointResolver ?? DefaultEndpointResolver()
                         if let credProvider = credentialsProvider {
                             self.credentialsProvider = try AWSClientRuntime.AWSCredentialsProvider.fromCustom(credProvider)


### PR DESCRIPTION
Updated the way we determine region such that if a user passes in an explicit region, we do not instantiate the DefaultRegionResolver, and therefore avoid instantiating the IMDSRegionResolver.
```
                        if let region = region {
                            self.region = region
                            self.regionResolver = nil
                            self.signingRegion = signingRegion ?? region
                        } else {
                            let resolvedRegionResolver = regionResolver ?? DefaultRegionResolver()
                            let region = resolvedRegionResolver.resolveRegion()
                            self.region = region
                            self.regionResolver = resolvedRegionResolver
                            self.signingRegion = signingRegion ?? region
                        }
```                        

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.