### PR TITLE
chore: bump version dependency of client runtime to 0.1.1

### DIFF
--- a/versionDependencies.plist
+++ b/versionDependencies.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>clientRuntimeVersion</key>
-	<string>0.1.0</string>
+	<string>0.1.1</string>
 	<key>awsCRTSwiftVersion</key>
 	<string>0.1.0</string>
 </dict>


### PR DESCRIPTION


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.