### PR TITLE
fix: lifetime issue with cred provider

### DIFF
--- a/AWSClientRuntime/Sources/Auth/AWSCredentialsProvider.swift
+++ b/AWSClientRuntime/Sources/Auth/AWSCredentialsProvider.swift
@@ -7,6 +7,7 @@ import ClientRuntime
 
 public class AWSCredentialsProvider: CredentialsProvider {
     let crtCredentialsProvider: CRTAWSCredentialsProvider
+    private let sharedDefaultIO: SDKDefaultIO = SDKDefaultIO.shared
     
     init(awsCredentialsProvider: CRTAWSCredentialsProvider) {
         self.crtCredentialsProvider = awsCredentialsProvider

--- a/AWSClientRuntime/Sources/Auth/CredentialsProviderCRTAdapter.swift
+++ b/AWSClientRuntime/Sources/Auth/CredentialsProviderCRTAdapter.swift
@@ -12,6 +12,8 @@ struct CredentialsProviderCRTAdapter: CRTCredentialsProvider {
     var allocator: Allocator
     let credentialsProvider: CredentialsProvider
     let logger: SwiftLogger
+    private let sharedDefaultIO: SDKDefaultIO = SDKDefaultIO.shared
+    
     init(credentialsProvider: CredentialsProvider) {
         self.credentialsProvider = credentialsProvider
         self.logger = SwiftLogger(label: "CustomCredentialProvider")

--- a/AWSClientRuntime/Tests/Middlewares/Sha256TreeHashMiddlewareTests.swift
+++ b/AWSClientRuntime/Tests/Middlewares/Sha256TreeHashMiddlewareTests.swift
@@ -12,18 +12,7 @@ import SmithyTestUtil
 @testable import AWSClientRuntime
 
 class Sha256TreeHashMiddlewareTests: XCTestCase {
-    override func setUp() {
-        #if os(Linux)
-        AwsCommonRuntimeKit.initialize()
-        #endif
-    }
-    
-    override func tearDown() {
-        #if os(Linux)
-        AwsCommonRuntimeKit.cleanUp()
-        #endif
-    }
-    
+
     func testTreeHashAllZeroes() throws {
         let context = HttpContextBuilder().build()
         let expectation = XCTestExpectation(description: "closure was run")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This prevents a lifetime issue we had from happening with the aws credentials provider when instantiated by itself and doesn't cause the thread to block indefinitely while the crt is unable to clean up and properly shut down.
This closes #506 

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.