### PR TITLE
fix: AWS Swift SDK can now pin to the version 0.1.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -309,8 +309,8 @@ let package = Package(
         .library(name: "AWSXRay", targets: ["AWSXRay"]),
     ],
     dependencies: [
-        .package(name: "AwsCrt", url: "https://github.com/awslabs/aws-crt-swift.git", from: "0.1.1"),
-        .package(name: "ClientRuntime", url: "https://github.com/awslabs/smithy-swift.git", from: "0.1.3")
+        .package(name: "AwsCrt", url: "https://github.com/awslabs/aws-crt-swift.git", exact: "0.1.1"),
+        .package(name: "ClientRuntime", url: "https://github.com/awslabs/smithy-swift.git", exact: "0.1.3")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -309,8 +309,8 @@ let package = Package(
         .library(name: "AWSXRay", targets: ["AWSXRay"]),
     ],
     dependencies: [
-        .package(name: "AwsCrt", url: "https://github.com/awslabs/aws-crt-swift.git", exact: "0.1.1"),
-        .package(name: "ClientRuntime", url: "https://github.com/awslabs/smithy-swift.git", exact: "0.1.3")
+        .package(name: "AwsCrt", url: "https://github.com/awslabs/aws-crt-swift.git", .exact("0.1.1")),
+        .package(name: "ClientRuntime", url: "https://github.com/awslabs/smithy-swift.git", .exact("0.1.3"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-swift/issues/545

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This change pins the underlying AwsCrt and ClientRuntime to the supported version 

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.