### PR TITLE
fix: json protocols with HttpBody

### DIFF
--- a/AWSClientRuntime/Sources/Middlewares/EndpointResolverMiddleware.swift
+++ b/AWSClientRuntime/Sources/Middlewares/EndpointResolverMiddleware.swift
@@ -19,51 +19,52 @@ public struct EndpointResolverMiddleware<OperationStackOutput: HttpResponseBindi
                           input: SdkHttpRequestBuilder,
                           next: H) async throws -> OperationOutput<OperationStackOutput>
     where H: Handler,
-    Self.MInput == H.Input,
-    Self.MOutput == H.Output,
-    Self.Context == H.Context {
-        
-        guard let region = context.getRegion(), !region.isEmpty else {
-            throw SdkError<OperationStackError>.client(ClientError.unknownError(("Region is unable to be resolved")))
-        }
-        
-        do {
-            let awsEndpoint = try endpointResolver.resolve(serviceId: serviceId,
-                                                           region: region)
-            var host = ""
-            if let overrideHost = context.getHost() {
-                host = overrideHost
-            } else {
-                host = "\(context.getHostPrefix() ?? "")\(awsEndpoint.endpoint.host)"
-            }
-            
-            if let protocolType = awsEndpoint.endpoint.protocolType {
-                input.withProtocol(protocolType)
-            }
-            
-            var updatedContext = context
-            
-            if let signingRegion = awsEndpoint.signingRegion {
-                updatedContext.attributes.set(key: HttpContext.signingRegion, value: signingRegion)
-            }
-            
-            if let signingName = awsEndpoint.signingName {
-                updatedContext.attributes.set(key: HttpContext.signingName, value: signingName)
-            }
-            
-            input.withMethod(context.getMethod())
-                .withHost(host)
-                .withPort(awsEndpoint.endpoint.port)
-                .withPath(context.getPath())
-                // TODO: investigate if this header should be the same host value as
-                // the actual host and where this header should be set
-                .withHeader(name: "Host", value: host)
-            
-            return try await next.handle(context: updatedContext, input: input)
-        } catch {
-            throw SdkError<OperationStackError>.client(ClientError.unknownError(("Endpoint is unable to be resolved")))
-        }
-    }
+          Self.MInput == H.Input,
+          Self.MOutput == H.Output,
+          Self.Context == H.Context {
+              
+              guard let region = context.getRegion(), !region.isEmpty else {
+                  throw SdkError<OperationStackError>.client(ClientError.unknownError(("Region is unable to be resolved")))
+              }
+              var awsEndpoint: AWSEndpoint
+              do {
+                  awsEndpoint = try endpointResolver.resolve(serviceId: serviceId,
+                                                             region: region)
+              } catch {
+                  throw SdkError<OperationStackError>.client(ClientError.unknownError(("Endpoint is unable to be resolved")))
+              }
+              var host = ""
+              if let overrideHost = context.getHost() {
+                  host = overrideHost
+              } else {
+                  host = "\(context.getHostPrefix() ?? "")\(awsEndpoint.endpoint.host)"
+              }
+              
+              if let protocolType = awsEndpoint.endpoint.protocolType {
+                  input.withProtocol(protocolType)
+              }
+              
+              var updatedContext = context
+              
+              if let signingRegion = awsEndpoint.signingRegion {
+                  updatedContext.attributes.set(key: HttpContext.signingRegion, value: signingRegion)
+              }
+              
+              if let signingName = awsEndpoint.signingName {
+                  updatedContext.attributes.set(key: HttpContext.signingName, value: signingName)
+              }
+              
+              input.withMethod(context.getMethod())
+                  .withHost(host)
+                  .withPort(awsEndpoint.endpoint.port)
+                  .withPath(context.getPath())
+              // TODO: investigate if this header should be the same host value as
+              // the actual host and where this header should be set
+                  .withHeader(name: "Host", value: host)
+              
+              return try await next.handle(context: updatedContext, input: input)
+              
+          }
     
     public typealias MInput = SdkHttpRequestBuilder
     public typealias MOutput = OperationOutput<OperationStackOutput>

--- a/AWSClientRuntime/Tests/Protocols/RestXML/Models/Errors/ComplexXMLNestedErrorData+Codable.swift
+++ b/AWSClientRuntime/Tests/Protocols/RestXML/Models/Errors/ComplexXMLNestedErrorData+Codable.swift
@@ -9,7 +9,7 @@
 
 import ClientRuntime
 
-extension ComplexXMLNestedErrorData: Codable, Reflection {
+extension ComplexXMLNestedErrorData: Codable {
     enum CodingKeys: String, CodingKey {
         case foo = "Foo"
     }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_0_ProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_0_ProtocolGenerator.kt
@@ -34,6 +34,7 @@ open class AwsJson1_0_ProtocolGenerator : AWSHttpBindingProtocolGenerator() {
     )
     override val serdeContext = serdeContextJSON
     override val shouldRenderEncodableConformance: Boolean = true
+    override val shouldRenderDecodableBodyStructForInputShapes: Boolean = true
     override fun getProtocolHttpBindingResolver(ctx: ProtocolGenerator.GenerationContext, defaultContentType: String):
         HttpBindingResolver = AwsJsonHttpBindingResolver(ctx, defaultContentType)
 

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_0_ProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_0_ProtocolGenerator.kt
@@ -18,6 +18,7 @@ import software.amazon.smithy.swift.codegen.integration.codingKeys.CodingKeysCus
 import software.amazon.smithy.swift.codegen.integration.codingKeys.DefaultCodingKeysGenerator
 import software.amazon.smithy.swift.codegen.integration.httpResponse.HttpResponseGenerator
 import software.amazon.smithy.swift.codegen.integration.middlewares.ContentTypeMiddleware
+import software.amazon.smithy.swift.codegen.integration.middlewares.OperationInputBodyMiddleware
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareStep
 
 open class AwsJson1_0_ProtocolGenerator : AWSHttpBindingProtocolGenerator() {
@@ -32,6 +33,7 @@ open class AwsJson1_0_ProtocolGenerator : AWSHttpBindingProtocolGenerator() {
         AWSJsonHttpResponseBindingErrorGenerator()
     )
     override val serdeContext = serdeContextJSON
+    override val shouldRenderEncodableConformance: Boolean = true
     override fun getProtocolHttpBindingResolver(ctx: ProtocolGenerator.GenerationContext, defaultContentType: String):
         HttpBindingResolver = AwsJsonHttpBindingResolver(ctx, defaultContentType)
 
@@ -39,6 +41,10 @@ open class AwsJson1_0_ProtocolGenerator : AWSHttpBindingProtocolGenerator() {
         super.addProtocolSpecificMiddleware(ctx, operation)
 
         operationMiddleware.appendMiddleware(operation, AWSXAmzTargetMiddleware(ctx.model, ctx.symbolProvider, ctx.service))
+        // Original instance of OperationInputBodyMiddleware checks if there is an HTTP Body, but for AWSJson protocols
+        // we always need to have an InputBodyMiddleware
+        operationMiddleware.removeMiddleware(operation, MiddlewareStep.SERIALIZESTEP, "OperationInputBodyMiddleware")
+        operationMiddleware.appendMiddleware(operation, OperationInputBodyMiddleware(ctx.model, ctx.symbolProvider, true))
 
         val resolver = getProtocolHttpBindingResolver(ctx, defaultContentType)
         operationMiddleware.removeMiddleware(operation, MiddlewareStep.SERIALIZESTEP, "ContentTypeMiddleware")

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_1_ProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_1_ProtocolGenerator.kt
@@ -34,6 +34,7 @@ class AwsJson1_1_ProtocolGenerator : AWSHttpBindingProtocolGenerator() {
     )
     override val serdeContext = serdeContextJSON
     override val shouldRenderEncodableConformance: Boolean = true
+    override val shouldRenderDecodableBodyStructForInputShapes: Boolean = true
     override fun getProtocolHttpBindingResolver(ctx: ProtocolGenerator.GenerationContext, defaultContentType: String):
         HttpBindingResolver = AwsJsonHttpBindingResolver(ctx, defaultContentType)
 

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/RestJsonProtocolGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/RestJsonProtocolGeneratorTests.kt
@@ -22,7 +22,7 @@ class RestJsonProtocolGeneratorTests {
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            extension SmokeTestInput: Swift.Encodable, ClientRuntime.Reflection {
+            extension SmokeTestInput: Swift.Encodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case payload1
                     case payload2
@@ -53,7 +53,7 @@ class RestJsonProtocolGeneratorTests {
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            extension ExplicitBlobInput: Swift.Encodable, ClientRuntime.Reflection {
+            extension ExplicitBlobInput: Swift.Encodable {
                 enum CodingKeys: Swift.String, Swift.CodingKey {
                     case payload1
                 }

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/BlobEncodeGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/BlobEncodeGeneratorTests.kt
@@ -21,7 +21,7 @@ class BlobEncodeGeneratorTests {
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            extension BlobInputParamsInput: Swift.Encodable, ClientRuntime.Reflection {
+            extension BlobInputParamsInput: Swift.Encodable {
                 public func encode(to encoder: Swift.Encoder) throws {
                     var container = encoder.container(keyedBy: ClientRuntime.Key.self)
                     if let blobList = blobList {

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/ListEncodeFormURLGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/ListEncodeFormURLGeneratorTests.kt
@@ -21,7 +21,7 @@ class ListEncodeFormURLGeneratorTests {
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            extension QueryListsInput: Swift.Encodable, ClientRuntime.Reflection {
+            extension QueryListsInput: Swift.Encodable {
                 public func encode(to encoder: Swift.Encoder) throws {
                     var container = encoder.container(keyedBy: ClientRuntime.Key.self)
                     if let complexListArg = complexListArg {

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/MapEncodeFormURLGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/MapEncodeFormURLGeneratorTests.kt
@@ -22,7 +22,7 @@ class MapEncodeFormURLGeneratorTests {
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            extension QueryMapsInput: Swift.Encodable, ClientRuntime.Reflection {
+            extension QueryMapsInput: Swift.Encodable {
                 public func encode(to encoder: Swift.Encoder) throws {
                     var container = encoder.container(keyedBy: ClientRuntime.Key.self)
                     if let complexMapArg = complexMapArg {

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/QueryIdempotencyTokenAutoFillGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/QueryIdempotencyTokenAutoFillGeneratorTests.kt
@@ -22,7 +22,7 @@ class QueryIdempotencyTokenAutoFillGeneratorTests {
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            extension QueryIdempotencyTokenAutoFillInput: Swift.Encodable, ClientRuntime.Reflection {
+            extension QueryIdempotencyTokenAutoFillInput: Swift.Encodable {
                 public func encode(to encoder: Swift.Encoder) throws {
                     var container = encoder.container(keyedBy: ClientRuntime.Key.self)
                     if let token = token {

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/TimestampGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/TimestampGeneratorTests.kt
@@ -22,7 +22,7 @@ class TimestampGeneratorTests {
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            extension QueryTimestampsInput: Swift.Encodable, ClientRuntime.Reflection {
+            extension QueryTimestampsInput: Swift.Encodable {
                 public func encode(to encoder: Swift.Encoder) throws {
                     var container = encoder.container(keyedBy: ClientRuntime.Key.self)
                     if let epochMember = epochMember {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->
This closes #541 and #524 and fixes an issue where we were not sending an empty json object across the wire for aws json protocols nor were we generating protocol tests correctly to test for it.

Corresponding PR: https://github.com/awslabs/smithy-swift/pull/408


## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.