### PR TITLE
fix: add pre sign urls for s3 put object

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/presignable/PresignableUrlIntegration.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/presignable/PresignableUrlIntegration.kt
@@ -149,7 +149,7 @@ class PresignableUrlIntegration(private val presignedOperations: Map<String, Set
         operationMiddlewareCopy.removeMiddleware(op, MiddlewareStep.FINALIZESTEP, "AWSSigningMiddleware")
         operationMiddlewareCopy.appendMiddleware(op, AWSSigningMiddleware(::customSigningParameters, context.model, context.symbolProvider))
 
-        if(op.id.toString() != "com.amazonaws.s3#PutObject") {
+        if (op.id.toString() != "com.amazonaws.s3#PutObject") {
             operationMiddlewareCopy.removeMiddleware(op, MiddlewareStep.SERIALIZESTEP, "OperationInputBodyMiddleware")
             operationMiddlewareCopy.appendMiddleware(op, InputTypeGETQueryItemMiddlewareRenderable(inputSymbol))
         }

--- a/codegen/smithy-aws-swift-codegen/src/main/resources/META-INF/services/software.amazon.smithy.swift.codegen.integration.SwiftIntegration
+++ b/codegen/smithy-aws-swift-codegen/src/main/resources/META-INF/services/software.amazon.smithy.swift.codegen.integration.SwiftIntegration
@@ -9,6 +9,6 @@ software.amazon.smithy.aws.swift.codegen.customization.glacier.GlacierChecksum
 software.amazon.smithy.aws.swift.codegen.customization.BoxServices
 software.amazon.smithy.aws.swift.codegen.customization.PresignableModelIntegration
 software.amazon.smithy.aws.swift.codegen.customization.machinelearning.PredictEndpointIntegration
-software.amazon.smithy.aws.swift.codegen.customization.presignable.PresignableGetIntegration
+software.amazon.smithy.aws.swift.codegen.customization.presignable.PresignableUrlIntegration
 software.amazon.smithy.aws.swift.codegen.customization.DisabledAuth
 software.amazon.smithy.aws.swift.codegen.PresignerGenerator


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
This adds pre sign urls for s3 put object.
Corresponding PR: https://github.com/awslabs/smithy-swift/pull/411

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.