### PR TITLE
fix: update client runtime version for Swift 5.6 support

### DIFF
--- a/versionDependencies.plist
+++ b/versionDependencies.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>clientRuntimeVersion</key>
-	<string>0.2.2</string>
+	<string>0.2.3</string>
 	<key>awsCRTSwiftVersion</key>
 	<string>0.2.2</string>
 </dict>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-swift/issues/557

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Bumps the ClientRuntime version to 0.2.3 to support Swift 5.6

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.