### PR TITLE
updates RetryerMiddleware to removed uneeded defer block

### DIFF
--- a/AWSClientRuntime/Sources/Middlewares/RetryerMiddleware.swift
+++ b/AWSClientRuntime/Sources/Middlewares/RetryerMiddleware.swift
@@ -53,7 +53,6 @@ public struct RetryerMiddleware<Output: HttpResponseBinding,
           Self.MInput == H.Input,
           Self.MOutput == H.Output,
           Self.Context == H.Context {
-              defer { retryer.releaseToken(token: token)}
               do {
                   let serviceResponse = try await next.handle(context: context, input: input)
                   retryer.recordSuccess(token: token)


### PR DESCRIPTION
this change eliminates a redundant call to releaseToken

Related: https://github.com/awslabs/aws-crt-swift/issues/66