### PR TITLE
chore: update smithy version to 1.22.0

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_0_ProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_0_ProtocolGenerator.kt
@@ -14,7 +14,6 @@ import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.swift.codegen.integration.HttpBindingResolver
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
-import software.amazon.smithy.swift.codegen.integration.codingKeys.CodingKeysCustomizationJsonName
 import software.amazon.smithy.swift.codegen.integration.codingKeys.DefaultCodingKeysCustomizable
 import software.amazon.smithy.swift.codegen.integration.codingKeys.DefaultCodingKeysGenerator
 import software.amazon.smithy.swift.codegen.integration.httpResponse.HttpResponseGenerator

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_0_ProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_0_ProtocolGenerator.kt
@@ -15,6 +15,7 @@ import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.swift.codegen.integration.HttpBindingResolver
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.codingKeys.CodingKeysCustomizationJsonName
+import software.amazon.smithy.swift.codegen.integration.codingKeys.DefaultCodingKeysCustomizable
 import software.amazon.smithy.swift.codegen.integration.codingKeys.DefaultCodingKeysGenerator
 import software.amazon.smithy.swift.codegen.integration.httpResponse.HttpResponseGenerator
 import software.amazon.smithy.swift.codegen.integration.middlewares.ContentTypeMiddleware
@@ -22,7 +23,7 @@ import software.amazon.smithy.swift.codegen.integration.middlewares.OperationInp
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareStep
 
 open class AwsJson1_0_ProtocolGenerator : AWSHttpBindingProtocolGenerator() {
-    override val codingKeysGenerator = DefaultCodingKeysGenerator(CodingKeysCustomizationJsonName())
+    override val codingKeysGenerator = DefaultCodingKeysGenerator(DefaultCodingKeysCustomizable())
     override val defaultContentType = "application/x-amz-json-1.0"
     override val defaultTimestampFormat = TimestampFormatTrait.Format.EPOCH_SECONDS
     override val protocol: ShapeId = AwsJson1_0Trait.ID

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_1_ProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_1_ProtocolGenerator.kt
@@ -14,7 +14,7 @@ import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.swift.codegen.integration.HttpBindingResolver
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
-import software.amazon.smithy.swift.codegen.integration.codingKeys.CodingKeysCustomizationJsonName
+import software.amazon.smithy.swift.codegen.integration.codingKeys.DefaultCodingKeysCustomizable
 import software.amazon.smithy.swift.codegen.integration.codingKeys.DefaultCodingKeysGenerator
 import software.amazon.smithy.swift.codegen.integration.httpResponse.HttpResponseGenerator
 import software.amazon.smithy.swift.codegen.integration.middlewares.ContentTypeMiddleware
@@ -22,7 +22,7 @@ import software.amazon.smithy.swift.codegen.integration.middlewares.OperationInp
 import software.amazon.smithy.swift.codegen.middleware.MiddlewareStep
 
 class AwsJson1_1_ProtocolGenerator : AWSHttpBindingProtocolGenerator() {
-    override val codingKeysGenerator = DefaultCodingKeysGenerator(CodingKeysCustomizationJsonName())
+    override val codingKeysGenerator = DefaultCodingKeysGenerator(DefaultCodingKeysCustomizable())
     override val defaultContentType = "application/x-amz-json-1.1"
     override val defaultTimestampFormat = TimestampFormatTrait.Format.EPOCH_SECONDS
     override val protocol: ShapeId = AwsJson1_1Trait.ID

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 kotlin.code.style=official
 
 # codegen
-smithyVersion=1.13.1
+smithyVersion=1.22.0
 smithyGradleVersion=0.5.3
 
-smithySwiftVersion = 0.1.0
+smithySwiftVersion = 0.2.4
 
 # kotlin
 kotlinVersion=1.5.31

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ kotlin.code.style=official
 
 # codegen
 smithyVersion=1.22.0
-smithyGradleVersion=0.5.3
+smithyGradleVersion=0.6.0
 
 smithySwiftVersion = 0.1.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ kotlin.code.style=official
 smithyVersion=1.22.0
 smithyGradleVersion=0.5.3
 
-smithySwiftVersion = 0.2.4
+smithySwiftVersion = 0.1.0
 
 # kotlin
 kotlinVersion=1.5.31


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
(https://github.com/awslabs/aws-sdk-swift/pull/597 is failing due to unresolved shape `smithy.api#Unit` which was introduced in https://github.com/awslabs/smithy/pull/980/)

## Description of changes
- `JsonName` trait now has no effect in AwsJson1_0 and AwsJson1_1, this change is supported by https://github.com/awslabs/smithy-swift/pull/425

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.