### PR TITLE
Add JDK setup step to development instructions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ import class Foundation.FileManager
  In order to use setup local development:
 
  1. Install a Java 18 JDK if one is not already installed to your system.
-   The OpenJDK-based Amazon Corretto JDK is available at https://aws.amazon.com/corretto.
+   The OpenJDK-based Amazon Corretto JDK is available at https://aws.amazon.com/corretto .
 
  2. Create a folder:
    mkdir -p ~/Projects/Amplify/SwiftSDK

--- a/Package.swift
+++ b/Package.swift
@@ -18,16 +18,20 @@ import class Foundation.FileManager
 
 
  In order to use setup local development:
- 1. Create a folder:
+
+ 1. Install a Java 18 JDK if one is not already installed to your system.
+   The OpenJDK-based Amazon Corretto JDK is available at https://aws.amazon.com/corretto.
+
+ 2. Create a folder:
    mkdir -p ~/Projects/Amplify/SwiftSDK
    cd ~/Projects/Amplify/SwiftSDK
 
- 2. Checkout projects:
+ 3. Checkout projects:
    git clone https://github.com/awslabs/aws-sdk-swift.git
    git clone https://github.com/awslabs/smithy-swift.git
    git clone https://github.com/awslabs/aws-crt-swift.git --recursive
 
- 3.  Build
+ 4.  Build
    cd ~/Projects/Amplify/SwiftSDK/aws-sdk-swift
    echo "compositeProjects=$HOME/Projects/Amplify/SwiftSDK/smithy-swift" >> local.properties
    ./gradlew -p codegen/sdk-codegen build


### PR DESCRIPTION
## Description of changes
Adds a setup step to install a Java 18 JDK before building the project.  This is a documentation change only.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.