### PR TITLE
Add stability policy to SDK docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The **AWS SDK for Swift** is a pure Swift SDK for AWS services.
 
-**The AWS SDK for Kotlin is currently in developer preview and is intended strictly for feedback purposes only. Do not use this SDK for production workloads. Refer to the SDK [stability](docs/stability.md) guidelines for more detail.**
+**The AWS SDK for Swift is currently in developer preview and is intended strictly for feedback purposes only. Do not use this SDK for production workloads. Refer to the SDK [stability](docs/stability.md) guidelines for more detail.**
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The **AWS SDK for Swift** is a pure Swift SDK for AWS services.
 
-**WARNING: Releases prior to 1.0.0 may contain bugs and no guarantee is made about API stability. They are not intended for use in production!**
+**The AWS SDK for Kotlin is currently in developer preview and is intended strictly for feedback purposes only. Do not use this SDK for production workloads. Refer to the SDK [stability](docs/stability.md) guidelines for more detail.**
 
 ## License
 

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -1,0 +1,25 @@
+# Stability of the AWS SDK for Kotlin
+
+For information about maintenance and support of SDK major versions and their underlying dependencies, see the
+following in the AWS SDKs and Tools Shared Configuration and Credentials Reference Guide:
+
+* [AWS SDKs and Tools Maintenance Policy](https://docs.aws.amazon.com/credref/latest/refdocs/maint-policy.html)
+* [AWS SDKs and Tools Version Support Matrix](https://docs.aws.amazon.com/credref/latest/refdocs/version-support-matrix.html)
+
+## Qualifiers
+
+Qualifiers for published artifacts
+
+**`-alpha`** indicates:
+
+* The SDK is not meant for production workloads. It is released solely for the purpose of getting feedback.
+* The SDK is not yet feature complete. It may contain bugs and performance issues.
+* Expect migration issues as APIs/types change.
+
+**`-beta`** indicates:
+
+* The SDK is not meant for production workloads. 
+* The SDK is feature complete. It may still contain bugs and performance issues.
+* The APIs/types are mostly stabilized. It is still possible that future releases may cause migration issues.
+
+NOTE: This corresponds to the "Developer Preview" phase of the maintenance policy linked above.

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -1,4 +1,4 @@
-# Stability of the AWS SDK for Kotlin
+# Stability of the AWS SDK for Swift
 
 For information about maintenance and support of SDK major versions and their underlying dependencies, see the
 following in the AWS SDKs and Tools Shared Configuration and Credentials Reference Guide:


### PR DESCRIPTION
## Description of changes
Add a stability policy for AWS SDK for Swift releases & add a link to it in the main README doc

## New/existing dependencies impact assessment, if applicable
No change; docs only

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.