### PR TITLE
fix: Use smithy-swift package manifest in root of project

### DIFF
--- a/AWSClientRuntime/Package.swift
+++ b/AWSClientRuntime/Package.swift
@@ -42,11 +42,11 @@ if let smithySwiftDir = ProcessInfo.processInfo.environment["SMITHY_SWIFT_CI_DIR
    let crtDir = ProcessInfo.processInfo.environment["AWS_CRT_SWIFT_CI_DIR"] {
     package.dependencies += [
         .package(name: "AwsCrt", path: "\(crtDir)"),
-        .package(name: "ClientRuntime", path: "\(smithySwiftDir)/Packages")
+        .package(name: "ClientRuntime", path: "\(smithySwiftDir)")
     ]
 } else {
     package.dependencies += [
         .package(name: "AwsCrt", path: "~/Projects/Amplify/SwiftSDK/aws-crt-swift"),
-        .package(name: "ClientRuntime", path: "~/Projects/Amplify/SwiftSDK/smithy-swift/Packages")
+        .package(name: "ClientRuntime", path: "~/Projects/Amplify/SwiftSDK/smithy-swift")
     ]
 }

--- a/AWSClientRuntime/Package.swift
+++ b/AWSClientRuntime/Package.swift
@@ -41,8 +41,8 @@ let package = Package(
 if let smithySwiftDir = ProcessInfo.processInfo.environment["SMITHY_SWIFT_CI_DIR"],
    let crtDir = ProcessInfo.processInfo.environment["AWS_CRT_SWIFT_CI_DIR"] {
     package.dependencies += [
-        .package(name: "AwsCrt", path: "\(crtDir)"),
-        .package(name: "ClientRuntime", path: "\(smithySwiftDir)")
+        .package(name: "AwsCrt", path: crtDir),
+        .package(name: "ClientRuntime", path: smithySwiftDir)
     ]
 } else {
     package.dependencies += [

--- a/Package.swift
+++ b/Package.swift
@@ -103,7 +103,7 @@ let localReleaseSwiftSDKDir = fileManager.homeDirectoryForCurrentUser.appendingP
 func setupDependencies() {
     package.dependencies += [
         .package(name: "AwsCrt", path: "\(awsCRTSwiftDir.path)"),
-        .package(name: "ClientRuntime", path: "\(smithySwiftDir.appendingPathComponent("Packages").path)")
+        .package(name: "ClientRuntime", path: "\(smithySwiftDir.path)")
     ]
     let sdksToIncludeInTargets = try! FileManager.default.contentsOfDirectory(atPath: "\(localReleaseSwiftSDKDir.path)")
     includeTargets(sdksToIncludeInTargets)

--- a/Package.swift
+++ b/Package.swift
@@ -74,10 +74,10 @@ private extension Package {
 
     func setupDependencies() -> Package {
         dependencies += [
-            .package(name: "AwsCrt", path: "\(awsCRTSwiftDir.path)"),
-            .package(name: "ClientRuntime", path: "\(smithySwiftDir.path)")
+            .package(name: "AwsCrt", path: awsCRTSwiftDir.path),
+            .package(name: "ClientRuntime", path: smithySwiftDir.path)
         ]
-        let sdksToIncludeInTargets = try! FileManager.default.contentsOfDirectory(atPath: "\(localReleaseSwiftSDKDir.path)")
+        let sdksToIncludeInTargets = try! FileManager.default.contentsOfDirectory(atPath: localReleaseSwiftSDKDir.path)
         includeTargets(package: self, releasedSDKs: sdksToIncludeInTargets)
         return self
     }

--- a/codegen/Package.swift
+++ b/codegen/Package.swift
@@ -98,12 +98,12 @@ func appendTstTarget(name: String, path: String, dependency: String) {
 if let smithySwiftDir = ProcessInfo.processInfo.environment["SMITHY_SWIFT_CI_DIR"],
    let sdkDir = ProcessInfo.processInfo.environment["AWS_SDK_SWIFT_CI_DIR"] {
     package.dependencies += [
-        .package(name: "ClientRuntime", path: "\(smithySwiftDir)/Packages"),
+        .package(name: "ClientRuntime", path: "\(smithySwiftDir)"),
         .package(name: "AWSClientRuntime", path: "\(sdkDir)/AWSClientRuntime"),
     ]
 } else {
     package.dependencies += [
-        .package(name: "ClientRuntime", path: "~/Projects/Amplify/SwiftSDK/smithy-swift/Packages"),
+        .package(name: "ClientRuntime", path: "~/Projects/Amplify/SwiftSDK/smithy-swift"),
         .package(name: "AWSClientRuntime", path: "~/Projects/Amplify/SwiftSDK/aws-sdk-swift/AWSClientRuntime"),
     ]
 }

--- a/codegen/Package.swift
+++ b/codegen/Package.swift
@@ -98,7 +98,7 @@ func appendTstTarget(name: String, path: String, dependency: String) {
 if let smithySwiftDir = ProcessInfo.processInfo.environment["SMITHY_SWIFT_CI_DIR"],
    let sdkDir = ProcessInfo.processInfo.environment["AWS_SDK_SWIFT_CI_DIR"] {
     package.dependencies += [
-        .package(name: "ClientRuntime", path: "\(smithySwiftDir)"),
+        .package(name: "ClientRuntime", path: smithySwiftDir),
         .package(name: "AWSClientRuntime", path: "\(sdkDir)/AWSClientRuntime"),
     ]
 } else {


### PR DESCRIPTION
## Description of changes
https://github.com/awslabs/smithy-swift/pull/437 deletes a duplicate `Package.swift` file that was contained in a subfolder of the main project.  This project was making reference to the now-deleted `Package.swift` to import the `ClientRuntime` library in the following places:
- `Package.swift` located in the project root directory
- `Package.swift` located in the `AWSClientRuntime/` subfolder
- `Package.swift` located in the `codegen/` subfolder

This project now imports `ClientRuntime` using only the `Package.swift` file in the root of the `smithy-swift` project.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change, but one dependency (`smithy-swift`) is imported differently.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.