### PR TITLE
bug: Fix `Package.swift` on Xcode 14

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -63,6 +63,39 @@ let AWS_CRT_SWIFT_DIR = "\(LOCAL_BASE_DIR)/aws-crt-swift"
 let SMITHY_SWIFT_DIR = "\(LOCAL_BASE_DIR)/smithy-swift"
 let LOCAL_RELEASE_SWIFT_DIR = "\(AWS_SDK_SWIFT_DIR)/\(RELEASE)"
 
+let fileManager = FileManager.default
+let awsSDKSwiftDir = fileManager.homeDirectoryForCurrentUser.appendingPathComponent(AWS_SDK_SWIFT_DIR)
+let awsCRTSwiftDir = fileManager.homeDirectoryForCurrentUser.appendingPathComponent(AWS_CRT_SWIFT_DIR)
+let smithySwiftDir = fileManager.homeDirectoryForCurrentUser.appendingPathComponent(SMITHY_SWIFT_DIR)
+
+let localReleaseSwiftSDKDir = fileManager.homeDirectoryForCurrentUser.appendingPathComponent(LOCAL_RELEASE_SWIFT_DIR)
+
+private extension Package {
+
+    func setupDependencies() -> Package {
+        dependencies += [
+            .package(name: "AwsCrt", path: "\(awsCRTSwiftDir.path)"),
+            .package(name: "ClientRuntime", path: "\(smithySwiftDir.appendingPathComponent("Packages").path)")
+        ]
+        let sdksToIncludeInTargets = try! FileManager.default.contentsOfDirectory(atPath: "\(localReleaseSwiftSDKDir.path)")
+        includeTargets(package: self, releasedSDKs: sdksToIncludeInTargets)
+        return self
+    }
+
+    private func includeTargets(package: Package, releasedSDKs: [String]) {
+        var libs: [PackageDescription.Product] = []
+        var targets: [PackageDescription.Target] = []
+        for sdkName in releasedSDKs {
+            libs.append(.library(name: sdkName, targets: [sdkName]))
+            targets.append(.target(name: sdkName,
+                                   dependencies: [.product(name: "ClientRuntime", package: "ClientRuntime"), "AWSClientRuntime"],
+                                   path: "./\(RELEASE)/\(sdkName)"))
+        }
+        package.products += libs
+        package.targets += targets
+    }
+}
+
 let package = Package(
     name: "AWSSwiftSDK",
     platforms: [
@@ -91,37 +124,4 @@ let package = Package(
             path: "./AWSClientRuntime/Tests"
         )
     ]
-)
-
-let fileManager = FileManager.default
-let awsSDKSwiftDir = fileManager.homeDirectoryForCurrentUser.appendingPathComponent(AWS_SDK_SWIFT_DIR)
-let awsCRTSwiftDir = fileManager.homeDirectoryForCurrentUser.appendingPathComponent(AWS_CRT_SWIFT_DIR)
-let smithySwiftDir = fileManager.homeDirectoryForCurrentUser.appendingPathComponent(SMITHY_SWIFT_DIR)
-
-let localReleaseSwiftSDKDir = fileManager.homeDirectoryForCurrentUser.appendingPathComponent(LOCAL_RELEASE_SWIFT_DIR)
-
-func setupDependencies() {
-    package.dependencies += [
-        .package(name: "AwsCrt", path: "\(awsCRTSwiftDir.path)"),
-        .package(name: "ClientRuntime", path: "\(smithySwiftDir.appendingPathComponent("Packages").path)")
-    ]
-    let sdksToIncludeInTargets = try! FileManager.default.contentsOfDirectory(atPath: "\(localReleaseSwiftSDKDir.path)")
-    includeTargets(sdksToIncludeInTargets)
-}
-
-func includeTargets(_ releasedSDKs: [String]) {
-    var libs: [PackageDescription.Product] = []
-    var targets: [PackageDescription.Target] = []
-    for sdkName in releasedSDKs {
-        libs.append(.library(name: sdkName, targets: [sdkName]))
-        targets.append(.target(name: sdkName,
-                               dependencies: [.product(name: "ClientRuntime", package: "ClientRuntime"), "AWSClientRuntime"],
-                               path: "./\(RELEASE)/\(sdkName)"))
-    }
-    package.products += libs
-    package.targets += targets
-}
-
-setupDependencies()
-
-
+).setupDependencies()


### PR DESCRIPTION
## Description of changes
When loading the `Package.swift` file on Xcode 14, the `setupDependencies()` method call at the bottom of `Package.swift` was not getting executed, and the auto-generated libraries were not being created.

I am not certain of the reason; it seems that Xcode 14 stops interpreting `Package.swift` once the `package` global variable has been defined.  In any case, converting `setupDependencies()` from a free function to a method extended upon the `Package` class fixes the problem & still works with Xcode 13 as well.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.