### PR TITLE
chore: Update CRT builder & macOS/Xcode to latest

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  BUILDER_VERSION: v0.9.13
+  BUILDER_VERSION: v0.9.18
   BUILDER_SOURCE: releases
   # host owned by CRT team to host aws-crt-builder releases. Contact their on-call with any issues
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
@@ -24,9 +24,9 @@ env:
 
 jobs:
   ios-compat:
-    runs-on: macos-11
+    runs-on: macos-12
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.2.1.app
+      DEVELOPER_DIR: /Applications/Xcode_14.0.app
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v2


### PR DESCRIPTION
## Description of changes
Update CI build images & tools to latest versions.
- Github runner image updated from `macos-11` to `macos-12`.
- Xcode updated from `13.2.1` to `14.0`
- CRT builder updated from `0.9.13` to `0.9.18`

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.