### PR TITLE
fix: Use the IDLv2 ClientOptional trait instead of Box

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -90,6 +90,9 @@ private extension Package {
         ]
 
         let sdksToIncludeInTargets = try! FileManager.default.contentsOfDirectory(atPath: localReleaseSwiftSDKDir.path)
+            .filter { target in
+                !target.hasPrefix(".DS_Store")
+            }
         includeTargets(package: self, releasedSDKs: sdksToIncludeInTargets)
         return self
     }

--- a/Package.swift
+++ b/Package.swift
@@ -91,7 +91,7 @@ private extension Package {
 
         let sdksToIncludeInTargets = try! FileManager.default.contentsOfDirectory(atPath: localReleaseSwiftSDKDir.path)
             .filter { target in
-                !target.hasPrefix(".DS_Store")
+                !target.hasPrefix(".")
             }
         includeTargets(package: self, releasedSDKs: sdksToIncludeInTargets)
         return self

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/BoxServicesTest.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/BoxServicesTest.kt
@@ -6,11 +6,11 @@ import software.amazon.smithy.aws.swift.codegen.awsjson.AwsJson1_0_ProtocolGener
 import software.amazon.smithy.aws.swift.codegen.customization.BoxServices
 import software.amazon.smithy.aws.swift.codegen.newTestContext
 import software.amazon.smithy.aws.swift.codegen.toSmithyModel
+import software.amazon.smithy.model.knowledge.NullableIndex
+import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.StructureShape
-import software.amazon.smithy.model.traits.BoxTrait
 import software.amazon.smithy.swift.codegen.model.AddOperationShapes
 import software.amazon.smithy.swift.codegen.model.expectShape
-import software.amazon.smithy.swift.codegen.model.hasTrait
 
 class BoxServicesTest {
     @Test
@@ -50,13 +50,15 @@ class BoxServicesTest {
 
         // get the synthetic input which is the one that will be transformed
         val struct = transformed.expectShape<StructureShape>("smithy.swift.synthetic#FooInput")
-        val intMember = struct.getMember("int")
-        val boolMember = struct.getMember("bool")
-        val longMember = struct.getMember("long")
-        val notPrimitiveMember = struct.getMember("notPrimitive")
-        assertTrue(intMember.get().hasTrait<BoxTrait>())
-        assertTrue(boolMember.get().hasTrait<BoxTrait>())
-        assertTrue(longMember.get().hasTrait<BoxTrait>())
-        assertTrue(notPrimitiveMember.get().hasTrait<BoxTrait>())
+        val intMember = struct.getMember("int").get() as MemberShape
+        val boolMember = struct.getMember("bool").get() as MemberShape
+        val longMember = struct.getMember("long").get() as MemberShape
+        val notPrimitiveMember = struct.getMember("notPrimitive").get() as MemberShape
+        val nullableIndex = NullableIndex.of(transformed)
+
+        assertTrue(nullableIndex.isMemberNullable(intMember, NullableIndex.CheckMode.CLIENT_ZERO_VALUE_V1))
+        assertTrue(nullableIndex.isMemberNullable(boolMember, NullableIndex.CheckMode.CLIENT_ZERO_VALUE_V1))
+        assertTrue(nullableIndex.isMemberNullable(longMember, NullableIndex.CheckMode.CLIENT_ZERO_VALUE_V1))
+        assertTrue(nullableIndex.isMemberNullable(notPrimitiveMember, NullableIndex.CheckMode.CLIENT_ZERO_VALUE_V1))
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 # codegen
-smithyVersion=1.22.0
+smithyVersion=[1.25.0,1.26.0[
 smithyGradleVersion=0.6.0
 
 smithySwiftVersion = 0.1.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description of changes

Changed the way we convert all the members of a service to boxed. The way this was done will not work properly with IDLv2 which does no longer relay on the `Box` trait to determine whether or not a member is nullable. This change aligns with the pull request submitted to the swift-sdk [#444](https://github.com/awslabs/smithy-swift/pull/444) that makes the corresponding changes in the SDK itself.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.