### PR TITLE
fix: pin smithy and crt versions in 0.2.6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -320,8 +320,8 @@ let package = Package(
         .library(name: "AWSXRay", targets: ["AWSXRay"]),
     ],
     dependencies: [
-        .package(name: "AwsCrt", url: "https://github.com/awslabs/aws-crt-swift.git", from: "0.2.2"),
-        .package(name: "ClientRuntime", url: "https://github.com/awslabs/smithy-swift.git", from: "0.2.5")
+      .package(name: "AwsCrt", url: "https://github.com/awslabs/aws-crt-swift.git", .exact("0.2.2")),
+      .package(name: "ClientRuntime", url: "https://github.com/awslabs/smithy-swift.git", .exact("0.2.5"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

The SDK uses the `from` dependency version requirement for `ClientRuntime` and `CRT`.  This means that any consumer Package or application that depends on a specific version of the AWS SDK for Swift will have their transitive dependencies (`ClientRuntime` and `CRT`) updated with any new release. This is not ideal - it can lead to the improvements in those dependencies causing breaking behavioral changes for consumers. 

One such [improvement](https://github.com/awslabs/smithy-swift/pull/442) ended up breaking workarounds we had in place. While these changes are obviously very welcome, they shouldn't be forced on consumers that pin to a specific version of the AWS SDK for Swift.

We looked into fixing this ourselves here https://github.com/aws-amplify/amplify-ios/pull/2397. 
TL;DR pinning in a consuming package works when adding locally, but not remotely.

This PR changes `from` to `exact` for `release/0.2.6`; this unblocks us because we're pinning to it. Once merged, we'd need to update the `0.2.6` tag to point at the new commit. A separate PR should follow up with the necessary changes to `generatePackageSwift.swift` to ensure dependency versions are pinned in all releases going forward.

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->
N/A

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.