### PR TITLE
fix: pin crt and clientruntime versions

### DIFF
--- a/scripts/generatePackageSwift.swift
+++ b/scripts/generatePackageSwift.swift
@@ -56,8 +56,8 @@ func generateProducts(_ releasedSDKs: [String]) {
 func generateDependencies(versions: VersionDeps) {
     let dependencies = """
     dependencies: [
-        .package(name: "AwsCrt", url: "https://github.com/awslabs/aws-crt-swift.git", from: "\(versions.awsCRTSwiftVersion)"),
-        .package(name: "ClientRuntime", url: "https://github.com/awslabs/smithy-swift.git", from: "\(versions.clientRuntimeVersion)")
+        .package(name: "AwsCrt", url: "https://github.com/awslabs/aws-crt-swift.git", .exact("\(versions.awsCRTSwiftVersion)")),
+        .package(name: "ClientRuntime", url: "https://github.com/awslabs/smithy-swift.git", .exact("\(versions.clientRuntimeVersion)"))
     ],
 """
     print(dependencies)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Follow up PR to https://github.com/awslabs/aws-sdk-swift/pull/635.
This change ensures that the dependencies on `aws-crt-swift` and `smithy-swift` are pinned to exact versions by updating the template used to generate the Package manifest during the release process. 

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->
N/A

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.