### PR TITLE
fix: Update package names in `Package.swift` to match modern Swift convention

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.5
 
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/Package.swift
+++ b/Package.swift
@@ -85,8 +85,8 @@ private extension Package {
 
     func setupDependencies() -> Package {
         dependencies += [
-            .package(name: "AwsCrt", path: awsCRTSwiftDir.path),
-            .package(name: "ClientRuntime", path: smithySwiftDir.path)
+            .package(name: "aws-crt-swift", path: awsCRTSwiftDir.path),
+            .package(name: "smithy-swift", path: smithySwiftDir.path)
         ]
 
         let sdksToIncludeInTargets = try! FileManager.default.contentsOfDirectory(atPath: localReleaseSwiftSDKDir.path)
@@ -103,7 +103,7 @@ private extension Package {
         for sdkName in releasedSDKs {
             libs.append(.library(name: sdkName, targets: [sdkName]))
             targets.append(.target(name: sdkName,
-                                   dependencies: [.product(name: "ClientRuntime", package: "ClientRuntime"), "AWSClientRuntime"],
+                                   dependencies: [.product(name: "ClientRuntime", package: "smithy-swift"), "AWSClientRuntime"],
                                    path: "./\(RELEASE)/\(sdkName)"))
         }
         package.products += libs
@@ -124,8 +124,8 @@ let package = Package(
         .target(
             name: "AWSClientRuntime",
             dependencies: [
-                .product(name: "ClientRuntime", package: "ClientRuntime"),
-                .product(name: "AwsCommonRuntimeKit", package: "AwsCrt")
+                .product(name: "ClientRuntime", package: "smithy-swift"),
+                .product(name: "AwsCommonRuntimeKit", package: "aws-crt-swift")
             ],
             path: "./AWSClientRuntime/Sources"
         ),
@@ -133,8 +133,8 @@ let package = Package(
             name: "AWSClientRuntimeTests",
             dependencies: [
                 "AWSClientRuntime",
-                .product(name: "SmithyTestUtil", package: "ClientRuntime"),
-                .product(name: "ClientRuntime", package: "ClientRuntime")
+                .product(name: "SmithyTestUtil", package: "smithy-swift"),
+                .product(name: "ClientRuntime", package: "smithy-swift")
             ],
             path: "./AWSClientRuntime/Tests"
         )

--- a/Package.swift
+++ b/Package.swift
@@ -67,33 +67,32 @@ let AWS_SDK_SWIFT_DIR = "\(LOCAL_BASE_DIR)/\(AWS_SDK_SWIFT_PACKAGE_NAME)"
 let AWS_CRT_SWIFT_DIR = "\(LOCAL_BASE_DIR)/\(AWS_CRT_SWIFT_PACKAGE_NAME)"
 let SMITHY_SWIFT_DIR = "\(LOCAL_BASE_DIR)/\(SMITHY_SWIFT_PACKAGE_NAME)"
 
-let homePath = FileManager.default.homeDirectoryForCurrentUser
+let homeDirectoryFileURL = FileManager.default.homeDirectoryForCurrentUser
 let env = ProcessInfo.processInfo.environment
 
-let awsSDKSwiftDir: URL
-let smithySwiftPath, awsCRTSwiftPath: String
+let awsSDKSwiftFileURL, smithySwiftFileURL, awsCRTSwiftFileURL: URL
 if let awsSDKSwiftCIPath = env["AWS_SDK_SWIFT_CI_DIR"], let awsCRTSwiftCIPath = env["AWS_CRT_SWIFT_CI_DIR"],
     let smithySwiftCIPath = env["SMITHY_SWIFT_CI_DIR"] {
-    awsSDKSwiftDir = URL(fileURLWithPath: awsSDKSwiftCIPath)
-    smithySwiftPath = smithySwiftCIPath
-    awsCRTSwiftPath = awsCRTSwiftCIPath
+    awsSDKSwiftFileURL = URL(fileURLWithPath: awsSDKSwiftCIPath)
+    smithySwiftFileURL = URL(fileURLWithPath: smithySwiftCIPath)
+    awsCRTSwiftFileURL = URL(fileURLWithPath: awsCRTSwiftCIPath)
 } else {
-    awsSDKSwiftDir = homePath.appendingPathComponent(AWS_SDK_SWIFT_DIR)
-    smithySwiftPath = homePath.appendingPathComponent(SMITHY_SWIFT_DIR).path
-    awsCRTSwiftPath = homePath.appendingPathComponent(AWS_CRT_SWIFT_DIR).path
+    awsSDKSwiftFileURL = homeDirectoryFileURL.appendingPathComponent(AWS_SDK_SWIFT_DIR)
+    smithySwiftFileURL = homeDirectoryFileURL.appendingPathComponent(SMITHY_SWIFT_DIR)
+    awsCRTSwiftFileURL = homeDirectoryFileURL.appendingPathComponent(AWS_CRT_SWIFT_DIR)
 }
 
-let localReleaseSwiftSDKDir = awsSDKSwiftDir.appendingPathComponent(RELEASE)
+let localReleaseSwiftSDKFileURL = awsSDKSwiftFileURL.appendingPathComponent(RELEASE)
 
 private extension Package {
 
     func setupDependencies() -> Package {
         dependencies += [
-            .package(path: smithySwiftPath),
-            .package(path: awsCRTSwiftPath)
+            .package(path: smithySwiftFileURL.path),
+            .package(path: awsCRTSwiftFileURL.path)
         ]
 
-        let sdksToIncludeInTargets = try! FileManager.default.contentsOfDirectory(atPath: localReleaseSwiftSDKDir.path)
+        let sdksToIncludeInTargets = try! FileManager.default.contentsOfDirectory(atPath: localReleaseSwiftSDKFileURL.path)
             .filter { target in
                 !target.hasPrefix(".")
             }

--- a/scripts/generatePackageSwift.swift
+++ b/scripts/generatePackageSwift.swift
@@ -26,7 +26,7 @@ func generateHeader() {
     let header = """
     // swift-tools-version:5.5
     import PackageDescription
-    import class Foundation.FileManager
+
     """
     print(header)
 }
@@ -56,8 +56,8 @@ func generateProducts(_ releasedSDKs: [String]) {
 func generateDependencies(versions: VersionDeps) {
     let dependencies = """
     dependencies: [
-        .package(name: "AwsCrt", url: "https://github.com/awslabs/aws-crt-swift.git", .exact("\(versions.awsCRTSwiftVersion)")),
-        .package(name: "ClientRuntime", url: "https://github.com/awslabs/smithy-swift.git", .exact("\(versions.clientRuntimeVersion)"))
+        .package(url: "https://github.com/awslabs/aws-crt-swift.git", .exact("\(versions.awsCRTSwiftVersion)")),
+        .package(url: "https://github.com/awslabs/smithy-swift.git", .exact("\(versions.clientRuntimeVersion)"))
     ],
 """
     print(dependencies)
@@ -69,8 +69,8 @@ func generateTargets(_ releasedSDKs: [String]) {
         .target(
             name: "AWSClientRuntime",
             dependencies: [
-                .product(name: "ClientRuntime", package: "ClientRuntime"),
-                .product(name: "AwsCommonRuntimeKit", package: "AwsCrt")
+                .product(name: "ClientRuntime", package: "smithy-swift"),
+                .product(name: "AwsCommonRuntimeKit", package: "aws-crt-swift")
             ],
             path: "./AWSClientRuntime/Sources"
         ),
@@ -78,17 +78,17 @@ func generateTargets(_ releasedSDKs: [String]) {
             name: "AWSClientRuntimeTests",
             dependencies: [
                 "AWSClientRuntime",
-                .product(name: "SmithyTestUtil", package: "ClientRuntime"),
-                .product(name: "ClientRuntime", package: "ClientRuntime")
+                .product(name: "SmithyTestUtil", package: "smithy-swift"),
+                .product(name: "ClientRuntime", package: "smithy-swift")
             ],
             path: "./AWSClientRuntime/Tests"
         ),
 """
     print(targetsBeginning)
     for sdk in releasedSDKs {
-        print("        .target(name: \"\(sdk)\", dependencies: [.product(name: \"ClientRuntime\", package: \"ClientRuntime\"), \"AWSClientRuntime\"], path: \"./release/\(sdk)\"),")
+        print("        .target(name: \"\(sdk)\", dependencies: [.product(name: \"ClientRuntime\", package: \"smithy-swift\"), \"AWSClientRuntime\"], path: \"./release/\(sdk)\"),")
     }
-    print("        ]")
+    print("    ]")
     
 }
 


### PR DESCRIPTION
## Description of changes
In [SE-0226](https://github.com/apple/swift-evolution/blob/main/proposals/0226-package-manager-target-based-dep-resolution.md), declaring the name of Swift packages in a package's manifest was deprecated.  Instead, the name of a package is inferred from the last path component of the package's URL.  (The purpose of this was to speed & simplify the resolution of dependencies by allowing the resolution of a target's dependencies without having to clone all its sub-dependencies to see what package contains what name.)

The latest version of Xcode relies on this naming convention for certain features, including package edit mode.  Specifically, the IDE will not properly resolve dependencies when packages are referred to by specific names that do not match the inferred names.

This PR changes the package manifest to no longer use explicit package names, relying instead on the last component of the URL or local path where the package resides.  This allows Xcode to successfully resolve all dependencies with packages in edit mode.

Also:
- Update `Package.swift` to adopt `swift-tools-version:5.5` (from 5.4).  5.5 is already required by `aws-crt-swift` so it is required to build the AWS SDK anyway.
- `Package.swift` code cleanup, including renaming some variables to be more descriptive of their contents and extracting package names to variables.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.