### PR TITLE
fix: prefer EndpointResolver Bucket for S3 in http label, AccountId for S3Control host label

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/EndpointResolverMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/EndpointResolverMiddleware.kt
@@ -93,7 +93,7 @@ class EndpointResolverMiddleware(
             .indent()
             .write(".withHost(host)")
             .write(".withPort(awsEndpoint.endpoint.port)")
-            .write(".withPath(context.getPath())")
+            .write(".withPath(awsEndpoint.endpoint.path.appendingPathComponent(context.getPath()))")
             .write(""".withHeader(name: "Host", value: host)""")
             .dedent()
             .write("")

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/model/AWSEndpointTraitTransformer.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/model/AWSEndpointTraitTransformer.kt
@@ -36,10 +36,11 @@ class AWSEndpointTraitTransformer : SwiftIntegration {
                                     val inputShape = model.expectShape(input)
                                     val members = inputShape.members() ?: emptyList()
                                     members.forEach { member ->
-                                        if (member.hasTrait<ContextParamTrait>()
-                                            && member.hasTrait<HostLabelTrait>()
-                                            && member.memberName == "AccountId"
-                                            && hostPrefix == "{AccountId}.") {
+                                        if (member.hasTrait<ContextParamTrait>() &&
+                                            member.hasTrait<HostLabelTrait>() &&
+                                            member.memberName == "AccountId" &&
+                                            hostPrefix == "{AccountId}."
+                                        ) {
                                             shapeBuilder.removeTrait(endpointTrait.toShapeId())
                                         }
                                     }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/model/AWSEndpointTraitTransformer.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/model/AWSEndpointTraitTransformer.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.aws.swift.codegen.model
+
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.traits.EndpointTrait
+import software.amazon.smithy.model.traits.HostLabelTrait
+import software.amazon.smithy.model.transform.ModelTransformer
+import software.amazon.smithy.rulesengine.traits.ContextParamTrait
+import software.amazon.smithy.swift.codegen.SwiftSettings
+import software.amazon.smithy.swift.codegen.getOrNull
+import software.amazon.smithy.swift.codegen.integration.SwiftIntegration
+import software.amazon.smithy.swift.codegen.model.getTrait
+import software.amazon.smithy.swift.codegen.model.hasTrait
+
+/**
+ * This integration is responsible for removing the EndpointTrait from the operation
+ * - For S3 Control, if hostPrefix is {AccountId}., then remove the Endpoint Trait because it is already handled
+ *      within the EndpointResolver
+ */
+class AWSEndpointTraitTransformer : SwiftIntegration {
+    override fun preprocessModel(model: Model, settings: SwiftSettings): Model {
+        return when (settings.service.namespace) {
+            "com.amazonaws.s3control" -> {
+                ModelTransformer.create().mapShapes(model) { shape ->
+                    when (shape) {
+                        is OperationShape -> {
+                            val shapeBuilder = shape.toBuilder()
+                            shape.getTrait<EndpointTrait>()?.let { endpointTrait ->
+                                val hostPrefix = endpointTrait.hostPrefix.toString()
+                                shape.input.getOrNull()?.let { input ->
+                                    val inputShape = model.expectShape(input)
+                                    val members = inputShape.members() ?: emptyList()
+                                    members.forEach { member ->
+                                        if (member.hasTrait<ContextParamTrait>()
+                                            && member.hasTrait<HostLabelTrait>()
+                                            && member.memberName == "AccountId"
+                                            && hostPrefix == "{AccountId}.") {
+                                            shapeBuilder.removeTrait(endpointTrait.toShapeId())
+                                        }
+                                    }
+                                }
+                            }
+                            shapeBuilder.build()
+                        }
+
+                        else -> shape
+                    }
+                }
+            }
+
+            else -> model
+        }
+    }
+}

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/model/AWSEndpointTraitTransformer.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/model/AWSEndpointTraitTransformer.kt
@@ -8,15 +8,11 @@ package software.amazon.smithy.aws.swift.codegen.model
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.traits.EndpointTrait
-import software.amazon.smithy.model.traits.HostLabelTrait
 import software.amazon.smithy.model.transform.ModelTransformer
-import software.amazon.smithy.rulesengine.traits.ContextParamTrait
 import software.amazon.smithy.rulesengine.traits.StaticContextParamsTrait
 import software.amazon.smithy.swift.codegen.SwiftSettings
-import software.amazon.smithy.swift.codegen.getOrNull
 import software.amazon.smithy.swift.codegen.integration.SwiftIntegration
 import software.amazon.smithy.swift.codegen.model.getTrait
-import software.amazon.smithy.swift.codegen.model.hasTrait
 
 /**
  * This integration is responsible for removing the EndpointTrait from the operation

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/model/AWSHttpTraitTransformer.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/model/AWSHttpTraitTransformer.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.aws.swift.codegen.model
+
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.pattern.UriPattern
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.traits.HttpLabelTrait
+import software.amazon.smithy.model.traits.HttpTrait
+import software.amazon.smithy.model.transform.ModelTransformer
+import software.amazon.smithy.rulesengine.traits.ContextParamTrait
+import software.amazon.smithy.swift.codegen.SwiftSettings
+import software.amazon.smithy.swift.codegen.getOrNull
+import software.amazon.smithy.swift.codegen.integration.SwiftIntegration
+import software.amazon.smithy.swift.codegen.model.getTrait
+import software.amazon.smithy.swift.codegen.model.hasTrait
+
+/**
+ * This integration is responsible for updating the `@httpLabel` trait to the input shape of an operation
+ * - For S3, if the HttpLabel is /{BucketName}{Suffix} then update the trait with /{Suffix} because
+ *      the bucket name is already handled within the EndpointResolver
+ */
+class AWSHttpTraitTransformer : SwiftIntegration {
+    override fun preprocessModel(model: Model, settings: SwiftSettings): Model {
+        return when (settings.service.namespace) {
+            "com.amazonaws.s3" -> {
+                ModelTransformer.create().mapShapes(model) { shape ->
+                    when (shape) {
+                        is OperationShape -> {
+                            val shapeBuilder = shape.toBuilder()
+                            shape.input.getOrNull()?.let { input ->
+                                val inputShape = model.expectShape(input.toShapeId())
+                                shape.getTrait<HttpTrait>()?.let { httpTrait ->
+                                    val uriPattern = httpTrait.uri.toString()
+                                    val httpTraitBuilder = httpTrait.toBuilder()
+                                    val members = inputShape.members() ?: emptyList()
+                                    members.forEach { member ->
+                                        if (member.hasTrait<ContextParamTrait>()
+                                            && member.hasTrait<HttpLabelTrait>()
+                                            && member.memberName == "Bucket"
+                                            && uriPattern.startsWith("/{Bucket}")) {
+                                            var newPattern = uriPattern.substring("/{Bucket}".length)
+                                            if (!newPattern.startsWith("/")) {
+                                                newPattern = "/$newPattern"
+                                            }
+                                            httpTraitBuilder.uri(UriPattern.parse(newPattern))
+                                            shapeBuilder.addTrait(httpTraitBuilder.build())
+                                        }
+                                    }
+                                }
+                            }
+                            shapeBuilder.build()
+                        }
+
+                        else -> shape
+                    }
+                }
+            }
+
+            else -> model
+        }
+    }
+}
+

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/model/AWSHttpTraitTransformer.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/model/AWSHttpTraitTransformer.kt
@@ -38,10 +38,11 @@ class AWSHttpTraitTransformer : SwiftIntegration {
                                     val httpTraitBuilder = httpTrait.toBuilder()
                                     val members = inputShape.members() ?: emptyList()
                                     members.forEach { member ->
-                                        if (member.hasTrait<ContextParamTrait>()
-                                            && member.hasTrait<HttpLabelTrait>()
-                                            && member.memberName == "Bucket"
-                                            && uriPattern.startsWith("/{Bucket}")) {
+                                        if (member.hasTrait<ContextParamTrait>() &&
+                                            member.hasTrait<HttpLabelTrait>() &&
+                                            member.memberName == "Bucket" &&
+                                            uriPattern.startsWith("/{Bucket}")
+                                        ) {
                                             var newPattern = uriPattern.substring("/{Bucket}".length)
                                             if (!newPattern.startsWith("/")) {
                                                 newPattern = "/$newPattern"
@@ -64,4 +65,3 @@ class AWSHttpTraitTransformer : SwiftIntegration {
         }
     }
 }
-

--- a/codegen/smithy-aws-swift-codegen/src/main/resources/META-INF/services/software.amazon.smithy.swift.codegen.integration.SwiftIntegration
+++ b/codegen/smithy-aws-swift-codegen/src/main/resources/META-INF/services/software.amazon.smithy.swift.codegen.integration.SwiftIntegration
@@ -14,3 +14,5 @@ software.amazon.smithy.aws.swift.codegen.customization.DisabledAuth
 software.amazon.smithy.aws.swift.codegen.PresignerGenerator
 software.amazon.smithy.aws.swift.codegen.model.AWSClientContextParamsTransformer
 software.amazon.smithy.aws.swift.codegen.customization.ServiceGeneratorIntegration
+software.amazon.smithy.aws.swift.codegen.model.AWSHttpTraitTransformer
+software.amazon.smithy.aws.swift.codegen.model.AWSEndpointTraitTransformer

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/EndpointResolverMiddlewareTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/EndpointResolverMiddlewareTests.kt
@@ -79,7 +79,7 @@ class EndpointResolverMiddlewareTests {
                     input.withMethod(context.getMethod())
                         .withHost(host)
                         .withPort(awsEndpoint.endpoint.port)
-                        .withPath(context.getPath())
+                        .withPath(awsEndpoint.endpoint.path.appendingPathComponent(context.getPath()))
                         .withHeader(name: "Host", value: host)
             
                     return try await next.handle(context: updatedContext, input: input)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->

## Description of changes

### S3 Bucket deduplication

`Bucket` in the HTTP URI is now a `contextParam` hence rules engine takes care of adding the bucket to the URI to either host name or path depending on the bucket location `forceStylePath` configuration. Therefore, SDK must not add the bucket to the URI outside of the rules engine.

```json
"com.amazonaws.s3#GetObject": {
    "type": "operation",
    "input": {
        "target": "com.amazonaws.s3#GetObjectRequest"
    },
    "output": {
        "target": "com.amazonaws.s3#GetObjectOutput"
    },
    "traits": {
        "aws.protocols#httpChecksum": {
            "requestValidationModeMember": "ChecksumMode",
            "responseAlgorithms": [
                "CRC32",
                "CRC32C",
                "SHA256",
                "SHA1"
            ]
        },
        "smithy.api#http": {
            "method": "GET",
            "uri": "/{Bucket}/{Key+}?x-id=GetObject",
            "code": 200
        }
    }
},
```

```json
"com.amazonaws.s3#GetObjectRequest": {
    "type": "structure",
    "members": {
        "Bucket": {
            "target": "com.amazonaws.s3#BucketName",
            "traits": {
                "smithy.api#httpLabel": {},
                "smithy.api#required": {},
                "smithy.rules#contextParam": {
                    "name": "Bucket"
                }
            }
        },
```

### S3 Control AccountId deduplication

`AccountId` hostPrefix is now a `staticContextParams` hence rules engine takes care of adding `AccountId` to the host name. This is enabled by setting `RequiresAccountId` param in staticContextParams to `true`. Therefore, SDK must not add the `AccountId` to the host name outside of the rules engine.

```json
"com.amazonaws.s3control#CreateAccessPoint": {
    "type": "operation",
    "input": {
        "target": "com.amazonaws.s3control#CreateAccessPointRequest"
    },
    "output": {
        "target": "com.amazonaws.s3control#CreateAccessPointResult"
    },
    "traits": {
        "smithy.api#endpoint": {
            "hostPrefix": "{AccountId}."
        },
        "smithy.api#http": {
            "method": "PUT",
            "uri": "/v20180820/accesspoint/{Name}",
            "code": 200
        },
        "smithy.rules#staticContextParams": {
            "RequiresAccountId": {
                "value": true
            }
        }
    }
}
```

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.