### PR TITLE
chore: Use Github macOS runner for swiftlint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
       - name: Run swiftlint on AWSClientRuntime
-        run: swiftlint lint --reporter github-actions-logging --path ./AWSClientRuntime
+        run: swiftlint lint --reporter github-actions-logging AWSClientRuntime

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,11 +20,9 @@ jobs:
         run: |
           ./gradlew ktlint
   swiftlint:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-      - name: Swift Lint ClientRuntime
-        uses: norio-nomura/action-swiftlint@3.1.0
-        with:
-          args: --path ./AWSClientRuntime
+      - name: Run swiftlint on AWSClientRuntime
+        run: swiftlint lint --reporter github-actions-logging --path ./AWSClientRuntime

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
       - name: Run swiftlint on AWSClientRuntime
-        run: swiftlint lint --reporter github-actions-logging AWSClientRuntime
+        run: cd AWSClientRuntime && swiftlint lint --reporter github-actions-logging .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
       - name: Run swiftlint on AWSClientRuntime
-        run: cd AWSClientRuntime && swiftlint lint --reporter github-actions-logging .
+        run: swiftlint --config AWSClientRuntime/.swiftlint.yml --reporter github-actions-logging AWSClientRuntime

--- a/AWSClientRuntime/Sources/IMDS/IMDSClient.swift
+++ b/AWSClientRuntime/Sources/IMDS/IMDSClient.swift
@@ -12,7 +12,8 @@ import ClientRuntime
 ///
 /// This client supports fetching tokens, retrying failures, and token caching according to the specified TTL.
 /// NOTE: This client ONLY supports IMDSv2. It will not fallback to IMDSv1.
-/// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#instance-metadata-transition-to-version-2 for more information.
+/// See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html#instance-metadata-transition-to-version-2
+/// for more information.
 public class IMDSClient {
     let crtIMDSClient: CRTIMDSClient
     private let sharedDefaultIO: SDKDefaultIO = SDKDefaultIO.shared


### PR DESCRIPTION
## Description of changes
Use the latest Github macOS runner for linting Swift instead of the third-party Github action previously used.

Github macOS runners already includes latest `SwiftLint` (currently `0.49.1`):
https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md

This is an interim change, to get access to latest SwiftLint quickly.  In the long term, Swift linting should be moved back to a Linux runner.  This ticket tracks that task: https://github.com/awslabs/aws-sdk-swift/issues/677

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.