### PR TITLE
fix: Allow empty lists to be serialized for Aws queries and Ec2 queries

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/AwsQueryFormURLEncodeCustomizations.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/AwsQueryFormURLEncodeCustomizations.kt
@@ -17,4 +17,8 @@ class AwsQueryFormURLEncodeCustomizations : FormURLEncodeCustomizable {
     override fun customNameTraitGenerator(memberShape: Shape, defaultName: String): String {
         return XMLNameTraitGenerator.construct(memberShape, defaultName).toString()
     }
+
+    override fun shouldSerializeEmptyLists(): Boolean {
+        return true
+    }
 }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/ec2query/Ec2QueryFormURLEncodeCustomizations.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/ec2query/Ec2QueryFormURLEncodeCustomizations.kt
@@ -16,4 +16,7 @@ class Ec2QueryFormURLEncodeCustomizations : FormURLEncodeCustomizable {
     override fun customNameTraitGenerator(memberShape: Shape, defaultName: String): String {
         return Ec2QueryNameTraitGenerator.construct(memberShape, defaultName).toString()
     }
+    override fun shouldSerializeEmptyLists(): Boolean {
+        return true
+    }
 }

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/BlobEncodeGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/BlobEncodeGeneratorTests.kt
@@ -36,6 +36,10 @@ class BlobEncodeGeneratorTests {
                                 try container.encode(blob0.base64EncodedString(), forKey: ClientRuntime.Key("BlobListFlattened.\(index0.advanced(by: 1))"))
                             }
                         }
+                        else {
+                            var blobListFlattenedContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("blobListFlattened"))
+                            try blobListFlattenedContainer.encode("", forKey: ClientRuntime.Key(""))
+                        }
                     }
                     if let blobMap = blobMap {
                         var blobMapContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("BlobMap"))

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/BlobEncodeGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/BlobEncodeGeneratorTests.kt
@@ -25,9 +25,15 @@ class BlobEncodeGeneratorTests {
                 public func encode(to encoder: Swift.Encoder) throws {
                     var container = encoder.container(keyedBy: ClientRuntime.Key.self)
                     if let blobList = blobList {
-                        var blobListContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("BlobList"))
-                        for (index0, blob0) in blobList.enumerated() {
-                            try blobListContainer.encode(blob0.base64EncodedString(), forKey: ClientRuntime.Key("member.\(index0.advanced(by: 1))"))
+                        if !blobList.isEmpty {
+                            var blobListContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("BlobList"))
+                            for (index0, blob0) in blobList.enumerated() {
+                                try blobListContainer.encode(blob0.base64EncodedString(), forKey: ClientRuntime.Key("member.\(index0.advanced(by: 1))"))
+                            }
+                        }
+                        else {
+                            var blobListContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("BlobList"))
+                            try blobListContainer.encode("", forKey: ClientRuntime.Key(""))
                         }
                     }
                     if let blobListFlattened = blobListFlattened {
@@ -37,7 +43,7 @@ class BlobEncodeGeneratorTests {
                             }
                         }
                         else {
-                            var blobListFlattenedContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("blobListFlattened"))
+                            var blobListFlattenedContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("BlobListFlattened"))
                             try blobListFlattenedContainer.encode("", forKey: ClientRuntime.Key(""))
                         }
                     }

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/ListEncodeFormURLGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/ListEncodeFormURLGeneratorTests.kt
@@ -25,9 +25,15 @@ class ListEncodeFormURLGeneratorTests {
                 public func encode(to encoder: Swift.Encoder) throws {
                     var container = encoder.container(keyedBy: ClientRuntime.Key.self)
                     if let complexListArg = complexListArg {
-                        var complexListArgContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("ComplexListArg"))
-                        for (index0, greetingstruct0) in complexListArg.enumerated() {
-                            try complexListArgContainer.encode(greetingstruct0, forKey: ClientRuntime.Key("member.\(index0.advanced(by: 1))"))
+                        if !complexListArg.isEmpty {
+                            var complexListArgContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("ComplexListArg"))
+                            for (index0, greetingstruct0) in complexListArg.enumerated() {
+                                try complexListArgContainer.encode(greetingstruct0, forKey: ClientRuntime.Key("member.\(index0.advanced(by: 1))"))
+                            }
+                        }
+                        else {
+                            var complexListArgContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("ComplexListArg"))
+                            try complexListArgContainer.encode("", forKey: ClientRuntime.Key(""))
                         }
                     }
                     if let flattenedListArg = flattenedListArg {
@@ -38,7 +44,7 @@ class ListEncodeFormURLGeneratorTests {
                             }
                         }
                         else {
-                            var flattenedListArgContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("flattenedListArg"))
+                            var flattenedListArgContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("FlattenedListArg"))
                             try flattenedListArgContainer.encode("", forKey: ClientRuntime.Key(""))
                         }
                     }
@@ -55,15 +61,27 @@ class ListEncodeFormURLGeneratorTests {
                         }
                     }
                     if let listArg = listArg {
-                        var listArgContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("ListArg"))
-                        for (index0, string0) in listArg.enumerated() {
-                            try listArgContainer.encode(string0, forKey: ClientRuntime.Key("member.\(index0.advanced(by: 1))"))
+                        if !listArg.isEmpty {
+                            var listArgContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("ListArg"))
+                            for (index0, string0) in listArg.enumerated() {
+                                try listArgContainer.encode(string0, forKey: ClientRuntime.Key("member.\(index0.advanced(by: 1))"))
+                            }
+                        }
+                        else {
+                            var listArgContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("ListArg"))
+                            try listArgContainer.encode("", forKey: ClientRuntime.Key(""))
                         }
                     }
                     if let listArgWithXmlNameMember = listArgWithXmlNameMember {
-                        var listArgWithXmlNameMemberContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("ListArgWithXmlNameMember"))
-                        for (index0, string0) in listArgWithXmlNameMember.enumerated() {
-                            try listArgWithXmlNameMemberContainer.encode(string0, forKey: ClientRuntime.Key("item.\(index0.advanced(by: 1))"))
+                        if !listArgWithXmlNameMember.isEmpty {
+                            var listArgWithXmlNameMemberContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("ListArgWithXmlNameMember"))
+                            for (index0, string0) in listArgWithXmlNameMember.enumerated() {
+                                try listArgWithXmlNameMemberContainer.encode(string0, forKey: ClientRuntime.Key("item.\(index0.advanced(by: 1))"))
+                            }
+                        }
+                        else {
+                            var listArgWithXmlNameMemberContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("ListArgWithXmlNameMember"))
+                            try listArgWithXmlNameMemberContainer.encode("", forKey: ClientRuntime.Key(""))
                         }
                     }
                     if let flatTsList = flatTsList {
@@ -79,9 +97,15 @@ class ListEncodeFormURLGeneratorTests {
                         }
                     }
                     if let tsList = tsList {
-                        var tsListContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("tsList"))
-                        for (index0, timestamp0) in tsList.enumerated() {
-                            try tsListContainer.encode(TimestampWrapper(timestamp0, format: .epochSeconds), forKey: ClientRuntime.Key("member.\(index0.advanced(by: 1))"))
+                        if !tsList.isEmpty {
+                            var tsListContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("tsList"))
+                            for (index0, timestamp0) in tsList.enumerated() {
+                                try tsListContainer.encode(TimestampWrapper(timestamp0, format: .epochSeconds), forKey: ClientRuntime.Key("member.\(index0.advanced(by: 1))"))
+                            }
+                        }
+                        else {
+                            var tsListContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("tsList"))
+                            try tsListContainer.encode("", forKey: ClientRuntime.Key(""))
                         }
                     }
                     try container.encode("QueryLists", forKey:ClientRuntime.Key("Action"))

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/ListEncodeFormURLGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/ListEncodeFormURLGeneratorTests.kt
@@ -37,6 +37,10 @@ class ListEncodeFormURLGeneratorTests {
                                 try flattenedListArgContainer0.encode(string0, forKey: ClientRuntime.Key(""))
                             }
                         }
+                        else {
+                            var flattenedListArgContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("flattenedListArg"))
+                            try flattenedListArgContainer.encode("", forKey: ClientRuntime.Key(""))
+                        }
                     }
                     if let flattenedListArgWithXmlName = flattenedListArgWithXmlName {
                         if !flattenedListArgWithXmlName.isEmpty {
@@ -44,6 +48,10 @@ class ListEncodeFormURLGeneratorTests {
                                 var flattenedListArgWithXmlNameContainer0 = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("Hi.\(index0.advanced(by: 1))"))
                                 try flattenedListArgWithXmlNameContainer0.encode(string0, forKey: ClientRuntime.Key(""))
                             }
+                        }
+                        else {
+                            var flattenedListArgWithXmlNameContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("Hi"))
+                            try flattenedListArgWithXmlNameContainer.encode("", forKey: ClientRuntime.Key(""))
                         }
                     }
                     if let listArg = listArg {
@@ -64,6 +72,10 @@ class ListEncodeFormURLGeneratorTests {
                                 var flatTsListContainer0 = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("flatTsList.\(index0.advanced(by: 1))"))
                                 try flatTsListContainer0.encode(TimestampWrapper(timestamp0, format: .epochSeconds), forKey: ClientRuntime.Key(""))
                             }
+                        }
+                        else {
+                            var flatTsListContainer = container.nestedContainer(keyedBy: ClientRuntime.Key.self, forKey: ClientRuntime.Key("flatTsList"))
+                            try flatTsListContainer.encode("", forKey: ClientRuntime.Key(""))
                         }
                     }
                     if let tsList = tsList {


### PR DESCRIPTION
This PR allows empty lists to be serialized for Aws and Ec2 queries. 
This PR is in response to this change https://github.com/awslabs/smithy/pull/1444 in the latest (1.26.1) smithy version

## Issue \#
#665 

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.