### PR TITLE
chore: Swiftlint rules change

### DIFF
--- a/AWSClientRuntime/.swiftlint.yml
+++ b/AWSClientRuntime/.swiftlint.yml
@@ -17,6 +17,8 @@ disabled_rules:
   - file_length
   - syntactic_sugar
   - unused_capture_list
+  - nesting
+  - large_tuple
 
 opt_in_rules:
   - empty_count


### PR DESCRIPTION
## Description of changes
Disable two SwiftLint rules for parity across projects.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.