### PR TITLE
chore: Lint all PRs, regardless of base branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Description of changes
On the Github workflow for linting, remove the filter for base branch, so that PRs to any branch get linted.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.