### PR TITLE
fix: remove guard for auth scheme for operations such as STS GetCallerIdentity to continue execution

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/EndpointResolverMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/EndpointResolverMiddleware.kt
@@ -53,14 +53,9 @@ class EndpointResolverMiddleware(
         writer.write("let endpoint = try endpointResolver.resolve(params: endpointParams)")
             .write("")
 
-        writer.openBlock("""guard let authScheme = endpoint.authScheme(name: "sigv4") else {""", "}") {
-            writer.write(
-                "throw \$N.client(ClientError.unknownError((\"Unable to resolve endpoint. Unsupported auth scheme.\")))",
-                errorType
-            )
-        }.write("")
+        writer.write("""let authScheme = endpoint.authScheme(name: "sigv4")""")
 
-        writer.write("""let awsEndpoint = AWSEndpoint(endpoint: endpoint, signingName: authScheme["signingName"] as? String, signingRegion: authScheme["signingRegion"] as? String)""")
+        writer.write("""let awsEndpoint = AWSEndpoint(endpoint: endpoint, signingName: authScheme?["signingName"] as? String, signingRegion: authScheme?["signingRegion"] as? String)""")
             .write("")
 
         writer.write("""var host = """"")

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/EndpointResolverMiddlewareTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/EndpointResolverMiddlewareTests.kt
@@ -47,11 +47,8 @@ class EndpointResolverMiddlewareTests {
                 {
                     let endpoint = try endpointResolver.resolve(params: endpointParams)
             
-                    guard let authScheme = endpoint.authScheme(name: "sigv4") else {
-                        throw ClientRuntime.SdkError<OperationStackError>.client(ClientError.unknownError(("Unable to resolve endpoint. Unsupported auth scheme.")))
-                    }
-            
-                    let awsEndpoint = AWSEndpoint(endpoint: endpoint, signingName: authScheme["signingName"] as? String, signingRegion: authScheme["signingRegion"] as? String)
+                    let authScheme = endpoint.authScheme(name: "sigv4")
+                    let awsEndpoint = AWSEndpoint(endpoint: endpoint, signingName: authScheme?["signingName"] as? String, signingRegion: authScheme?["signingRegion"] as? String)
             
                     var host = ""
                     if let hostOverride = context.getHost() {

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/AWSQueryOperationStackTest.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/AWSQueryOperationStackTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.aws.swift.codegen.awsquery
+
+import io.kotest.matchers.string.shouldContainOnlyOnce
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.aws.swift.codegen.TestContext
+import software.amazon.smithy.aws.swift.codegen.TestContextGenerator
+import software.amazon.smithy.aws.swift.codegen.TestContextGenerator.Companion.getFileContents
+import software.amazon.smithy.aws.swift.codegen.shouldSyntacticSanityCheck
+import software.amazon.smithy.aws.traits.protocols.AwsQueryTrait
+
+class AWSQueryOperationStackTest {
+    @Test
+    fun `operation stack has required middlewares`() {
+        val context = setupTests("awsquery/query-empty-input-output.smithy", "aws.protocoltests.query#AwsQuery")
+        val contents = getFileContents(context.manifest, "/Example/AwsQueryClient.swift")
+        contents.shouldSyntacticSanityCheck()
+        val expectedContents =
+            """
+    public func noInputAndOutput(input: NoInputAndOutputInput) async throws -> NoInputAndOutputOutputResponse
+    {
+        let context = ClientRuntime.HttpContextBuilder()
+                      .withEncoder(value: encoder)
+                      .withDecoder(value: decoder)
+                      .withMethod(value: .post)
+                      .withServiceName(value: serviceName)
+                      .withOperation(value: "noInputAndOutput")
+                      .withIdempotencyTokenGenerator(value: config.idempotencyTokenGenerator)
+                      .withLogger(value: config.logger)
+                      .withCredentialsProvider(value: config.credentialsProvider)
+                      .withRegion(value: config.region)
+        var operation = ClientRuntime.OperationStack<NoInputAndOutputInput, NoInputAndOutputOutputResponse, NoInputAndOutputOutputError>(id: "noInputAndOutput")
+        operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<NoInputAndOutputInput, NoInputAndOutputOutputResponse, NoInputAndOutputOutputError>())
+        operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<NoInputAndOutputInput, NoInputAndOutputOutputResponse>())
+        let endpointParams = EndpointParams()
+        operation.buildStep.intercept(position: .before, middleware: EndpointResolverMiddleware<NoInputAndOutputOutputResponse, NoInputAndOutputOutputError>(endpointResolver: config.endpointResolver, endpointParams: endpointParams))
+        let apiMetadata = AWSClientRuntime.APIMetadata(serviceId: serviceName, version: "1.0.0")
+        operation.buildStep.intercept(position: .before, middleware: AWSClientRuntime.UserAgentMiddleware(metadata: AWSClientRuntime.AWSUserAgentMetadata.fromEnv(apiMetadata: apiMetadata, frameworkMetadata: config.frameworkMetadata)))
+        operation.serializeStep.intercept(position: .after, middleware: ClientRuntime.SerializableBodyMiddleware<NoInputAndOutputInput, NoInputAndOutputOutputResponse>())
+        operation.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<NoInputAndOutputInput, NoInputAndOutputOutputResponse>(contentType: "application/x-www-form-urlencoded"))
+        operation.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
+        operation.finalizeStep.intercept(position: .after, middleware: AWSClientRuntime.RetryerMiddleware<NoInputAndOutputOutputResponse, NoInputAndOutputOutputError>(retryer: config.retryer))
+        operation.deserializeStep.intercept(position: .before, middleware: ClientRuntime.LoggerMiddleware<NoInputAndOutputOutputResponse, NoInputAndOutputOutputError>(clientLogMode: config.clientLogMode))
+        operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.DeserializeMiddleware<NoInputAndOutputOutputResponse, NoInputAndOutputOutputError>())
+        let result = try await operation.handleMiddleware(context: context.build(), input: input, next: client.getHandler())
+        return result
+    }"""
+        contents.shouldContainOnlyOnce(expectedContents)
+    }
+
+    private fun setupTests(smithyFile: String, serviceShapeId: String): TestContext {
+        val context = TestContextGenerator.initContextFrom(smithyFile, serviceShapeId, AwsQueryTrait.ID, "awsquery", "awsquery")
+        val generator = AwsQueryProtocolGenerator()
+        generator.generateCodableConformanceForNestedTypes(context.ctx)
+        generator.generateSerializers(context.ctx)
+        context.ctx.delegator.flushWriters()
+        return context
+    }
+}

--- a/codegen/smithy-aws-swift-codegen/src/test/resources/software.amazon.smithy.aws.swift.codegen/awsquery/query-empty-input-output.smithy
+++ b/codegen/smithy-aws-swift-codegen/src/test/resources/software.amazon.smithy.aws.swift.codegen/awsquery/query-empty-input-output.smithy
@@ -1,0 +1,29 @@
+$version: "1.0"
+
+namespace aws.protocoltests.query
+
+use aws.api#service
+use aws.protocols#awsQuery
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+@service(sdkId: "Query Protocol")
+@awsQuery
+@xmlNamespace(uri: "https://example.com/")
+service AwsQuery {
+    version: "2020-01-08",
+    operations: [
+        NoInputAndOutput
+    ]
+}
+
+operation NoInputAndOutput {
+    input: NoInputAndOutputInput,
+    output: NoInputAndOutputOutput
+}
+
+@input
+structure NoInputAndOutputInput {}
+
+@output
+structure NoInputAndOutputOutput {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->

Fixes https://github.com/awslabs/aws-sdk-swift/issues/619

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
With endpoint 2.0, this change was added to make sure there is auth scheme present always which wasn't the right assumption for some operation like GetCallerIdentity. This change removes this restrictions.

Companion PR https://github.com/awslabs/smithy-swift/pull/465

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.