### PR TITLE
fix! Converts Expires members in S3 output structures to String shape

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/s3/S3Expires.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/s3/S3Expires.kt
@@ -9,8 +9,6 @@ import software.amazon.smithy.swift.codegen.model.defaultName
 import software.amazon.smithy.swift.codegen.model.expectShape
 
 class S3Expires : SwiftIntegration {
-    override val order: Byte
-        get() = 127
 
     override fun enabledForService(model: Model, settings: SwiftSettings): Boolean {
         return model.expectShape<ServiceShape>(settings.service).isS3
@@ -20,7 +18,7 @@ class S3Expires : SwiftIntegration {
         // Find all the members named "Expires" in all of the output structures
         // and change their shape from `Timestamp` to `String`
         val updates = model.structureShapes
-            .filter { it.defaultName().endsWith("OutputResponse") }
+            .filter { it.defaultName().endsWith("Output") }
             .flatMap { it.allMembers.values }
             .filter { it.memberName == "Expires" }
             .map {

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/s3/S3Expires.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/s3/S3Expires.kt
@@ -1,0 +1,35 @@
+package software.amazon.smithy.aws.swift.codegen.customization.s3
+
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.model.traits.ClientOptionalTrait
+import software.amazon.smithy.model.transform.ModelTransformer
+import software.amazon.smithy.swift.codegen.SwiftSettings
+import software.amazon.smithy.swift.codegen.integration.SwiftIntegration
+import software.amazon.smithy.swift.codegen.model.defaultName
+import software.amazon.smithy.swift.codegen.model.expectShape
+
+class S3Expires: SwiftIntegration {
+    override val order: Byte
+        get() = 127
+
+    override fun enabledForService(model: Model, settings: SwiftSettings): Boolean {
+        return model.expectShape<ServiceShape>(settings.service).isS3
+    }
+    
+    override fun preprocessModel(model: Model, settings: SwiftSettings): Model {
+        // Find all the members named "Expires" in all of the output structures
+        // and change their shape from `Timestamp` to `String`
+        val updates = model.structureShapes
+            .filter { it.defaultName().endsWith("OutputResponse") }
+            .flatMap { it.allMembers.values }
+            .filter { it.memberName == "Expires" }
+            .map {
+                val builder = it.toBuilder()
+                builder.target("smithy.api#String")
+                builder.build()
+            }
+        return ModelTransformer.create().replaceShapes(model, updates)
+    }
+}

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/s3/S3Expires.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/s3/S3Expires.kt
@@ -1,23 +1,21 @@
 package software.amazon.smithy.aws.swift.codegen.customization.s3
 
 import software.amazon.smithy.model.Model
-import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ServiceShape
-import software.amazon.smithy.model.traits.ClientOptionalTrait
 import software.amazon.smithy.model.transform.ModelTransformer
 import software.amazon.smithy.swift.codegen.SwiftSettings
 import software.amazon.smithy.swift.codegen.integration.SwiftIntegration
 import software.amazon.smithy.swift.codegen.model.defaultName
 import software.amazon.smithy.swift.codegen.model.expectShape
 
-class S3Expires: SwiftIntegration {
+class S3Expires : SwiftIntegration {
     override val order: Byte
         get() = 127
 
     override fun enabledForService(model: Model, settings: SwiftSettings): Boolean {
         return model.expectShape<ServiceShape>(settings.service).isS3
     }
-    
+
     override fun preprocessModel(model: Model, settings: SwiftSettings): Model {
         // Find all the members named "Expires" in all of the output structures
         // and change their shape from `Timestamp` to `String`

--- a/codegen/smithy-aws-swift-codegen/src/main/resources/META-INF/services/software.amazon.smithy.swift.codegen.integration.SwiftIntegration
+++ b/codegen/smithy-aws-swift-codegen/src/main/resources/META-INF/services/software.amazon.smithy.swift.codegen.integration.SwiftIntegration
@@ -1,6 +1,7 @@
 software.amazon.smithy.aws.swift.codegen.AddProtocols
 software.amazon.smithy.aws.swift.codegen.customization.s3.S3SigningConfig
 software.amazon.smithy.aws.swift.codegen.customization.s3.S3ErrorIntegration
+software.amazon.smithy.aws.swift.codegen.customization.s3.S3Expires
 software.amazon.smithy.aws.swift.codegen.customization.route53.Route53TrimHostedZone
 software.amazon.smithy.aws.swift.codegen.customization.apigateway.ApiGatewayAddAcceptHeader
 software.amazon.smithy.aws.swift.codegen.customization.glacier.GlacierAddVersionHeader

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/TestContextGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/TestContextGenerator.kt
@@ -36,7 +36,6 @@ class TestContextGenerator {
             val service = model.getShape(ShapeId.from(serviceShapeIdWithNamespace)).get().asServiceShape().get()
             val settings = buildDefaultSwiftSettingsObjectNode(serviceShapeIdWithNamespace)
             val swiftSettings = SwiftSettings.from(model, settings)
-            model = AddOperationShapes.execute(model, swiftSettings.getService(model), swiftSettings.moduleName)
 
             val pluginContext = PluginContext.builder()
                 .model(model)

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/TestContextGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/TestContextGenerator.kt
@@ -13,6 +13,7 @@ import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.node.ObjectNode
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.validation.ValidatedResultException
+import software.amazon.smithy.swift.codegen.CodegenVisitor
 import software.amazon.smithy.swift.codegen.SwiftCodegenPlugin
 import software.amazon.smithy.swift.codegen.SwiftDelegator
 import software.amazon.smithy.swift.codegen.SwiftSettings
@@ -41,7 +42,10 @@ class TestContextGenerator {
                 .fileManifest(manifest)
                 .settings(settings)
                 .build()
-            SwiftCodegenPlugin().execute(pluginContext)
+            
+            val codegen = CodegenVisitor(pluginContext)
+            codegen.execute()
+            model = codegen.model
 
             val integrations = mutableListOf<SwiftIntegration>()
             val provider = SwiftCodegenPlugin.createSymbolProvider(model, swiftSettings)

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/TestContextGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/TestContextGenerator.kt
@@ -18,7 +18,6 @@ import software.amazon.smithy.swift.codegen.SwiftDelegator
 import software.amazon.smithy.swift.codegen.SwiftSettings
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.SwiftIntegration
-import software.amazon.smithy.swift.codegen.model.AddOperationShapes
 import java.net.URL
 
 data class TestContext(

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/TestContextGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/TestContextGenerator.kt
@@ -42,7 +42,7 @@ class TestContextGenerator {
                 .fileManifest(manifest)
                 .settings(settings)
                 .build()
-            
+
             val codegen = CodegenVisitor(pluginContext)
             codegen.execute()
             model = codegen.model

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/S3ExpiresTest.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/S3ExpiresTest.kt
@@ -1,0 +1,96 @@
+package software.amazon.smithy.aws.swift.codegen.customizations
+
+import io.kotest.matchers.string.shouldContainOnlyOnce
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.aws.swift.codegen.TestContext
+import software.amazon.smithy.aws.swift.codegen.TestContextGenerator
+import software.amazon.smithy.aws.swift.codegen.restjson.AWSRestJson1ProtocolGenerator
+import software.amazon.smithy.aws.swift.codegen.shouldSyntacticSanityCheck
+import software.amazon.smithy.aws.traits.protocols.RestJson1Trait
+import software.amazon.smithy.swift.codegen.core.GenerationContext
+import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
+
+class S3ExpiresTest {
+
+    @Test
+    fun `001 test S3 output members named expires are changed to string type`() {
+        val context = setupTests("s3-expires.smithy", "com.amazonaws.s3#S3", "S3")
+        val contents = TestContextGenerator.getFileContents(context.manifest, "/Example/models/FooOutputResponse.swift")
+        contents.shouldSyntacticSanityCheck()
+        val expectedContents =
+            """
+            public struct FooOutputResponse: Swift.Equatable {
+                public var expires: Swift.String?
+                public var payload1: Swift.String?
+            
+                public init (
+                    expires: Swift.String? = nil,
+                    payload1: Swift.String? = nil
+                )
+                {
+                    self.expires = expires
+                    self.payload1 = payload1
+                }
+            }
+            """.trimIndent()
+        contents.shouldContainOnlyOnce(expectedContents)
+    }
+
+    @Test
+    fun `002 test S3 input members named expires are not changed`() {
+        val context = setupTests("s3-expires.smithy", "com.amazonaws.s3#S3", "S3")
+        val contents = TestContextGenerator.getFileContents(context.manifest, "/Example/models/FooInput.swift")
+        contents.shouldSyntacticSanityCheck()
+        val expectedContents =
+            """
+            public struct FooInput: Swift.Equatable {
+                public var expires: ClientRuntime.Date?
+                public var payload1: Swift.String?
+            
+                public init (
+                    expires: ClientRuntime.Date? = nil,
+                    payload1: Swift.String? = nil
+                )
+                {
+                    self.expires = expires
+                    self.payload1 = payload1
+                }
+            }
+            """.trimIndent()
+        contents.shouldContainOnlyOnce(expectedContents)
+    }
+
+    @Test
+    fun `003 test non-S3 output members named expires are not changed`() {
+        val context = setupTests("s3-expires.smithy", "com.amazonaws.s3#Bar", "Bar")
+        val contents = TestContextGenerator.getFileContents(context.manifest, "/Example/models/FooOutputResponse.swift")
+        contents.shouldSyntacticSanityCheck()
+        val expectedContents =
+            """
+            public struct FooOutputResponse: Swift.Equatable {
+                public var expires: ClientRuntime.Date?
+                public var payload1: Swift.String?
+            
+                public init (
+                    expires: ClientRuntime.Date? = nil,
+                    payload1: Swift.String? = nil
+                )
+                {
+                    self.expires = expires
+                    self.payload1 = payload1
+                }
+            }
+            """.trimIndent()
+        contents.shouldContainOnlyOnce(expectedContents)
+    }
+
+    private fun setupTests(smithyFile: String, serviceShapeId: String, sdkID: String): TestContext {
+        val context =
+            TestContextGenerator.initContextFrom(smithyFile, serviceShapeId, RestJson1Trait.ID, sdkID, sdkID)
+
+        val generator = AWSRestJson1ProtocolGenerator()
+        generator.generateProtocolUnitTests(context.ctx)
+        context.ctx.delegator.flushWriters()
+        return context
+    }
+}

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/S3ExpiresTest.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/S3ExpiresTest.kt
@@ -7,8 +7,6 @@ import software.amazon.smithy.aws.swift.codegen.TestContextGenerator
 import software.amazon.smithy.aws.swift.codegen.restjson.AWSRestJson1ProtocolGenerator
 import software.amazon.smithy.aws.swift.codegen.shouldSyntacticSanityCheck
 import software.amazon.smithy.aws.traits.protocols.RestJson1Trait
-import software.amazon.smithy.swift.codegen.core.GenerationContext
-import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 
 class S3ExpiresTest {
 

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/restxml/serde/S3UnwrappedXMLOutputTraitTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/restxml/serde/S3UnwrappedXMLOutputTraitTests.kt
@@ -23,7 +23,7 @@ class S3UnwrappedXMLOutputTraitTests {
             
                 public init (from decoder: Swift.Decoder) throws {
                     var containerValues = try decoder.unkeyedContainer()
-                    let locationConstraintDecoded = try containerValues.decodeIfPresent(BucketLocationConstraint.self)
+                    let locationConstraintDecoded = try containerValues.decodeIfPresent(RestXmlClientTypes.BucketLocationConstraint.self)
                     locationConstraint = locationConstraintDecoded
                 }
             }

--- a/codegen/smithy-aws-swift-codegen/src/test/resources/software.amazon.smithy.aws.swift.codegen/s3-expires.smithy
+++ b/codegen/smithy-aws-swift-codegen/src/test/resources/software.amazon.smithy.aws.swift.codegen/s3-expires.smithy
@@ -1,0 +1,40 @@
+$version: "1.0"
+namespace com.amazonaws.s3
+
+use aws.api#service
+use aws.protocols#restJson1
+use aws.auth#sigv4
+
+@service(sdkId: "S3")
+@restJson1
+service S3 {
+    version: "1.0.0",
+    operations: [
+        Foo
+    ]
+}
+
+@http(method: "POST", uri: "/foo")
+operation Foo {
+    input: FooInput
+    output: FooOutput
+}
+
+structure FooInput {
+    payload1: String,
+    Expires: Timestamp
+}
+
+structure FooOutput {
+    payload1: String,
+    Expires: Timestamp
+}
+
+@service(sdkId: "Bar")
+@restJson1
+service Bar {
+    version: "1.0.0",
+    operations: [
+        Foo
+    ]
+}


### PR DESCRIPTION
## Issue \#
fixes #200 

## Description of changes
This PR adds a customization during codegen, that will convert members to String shape. 
This is restricted to members named "Expires" on "Output" structures in the S3 service.

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.