### PR TITLE
fix: Pin smithy to 1.26.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,4 +141,3 @@ SDKLoggingSystem.add(logHandlerFactory: S3ClientLogHandlerFactory(logLevel: .deb
 SDKLoggingSystem.add(logHandlerFactory: CRTClientEngineLogHandlerFactory(logLevel: .info))
 SDKLoggingSystem.initialize()
 ```
-

--- a/README.md
+++ b/README.md
@@ -141,3 +141,4 @@ SDKLoggingSystem.add(logHandlerFactory: S3ClientLogHandlerFactory(logLevel: .deb
 SDKLoggingSystem.add(logHandlerFactory: CRTClientEngineLogHandlerFactory(logLevel: .info))
 SDKLoggingSystem.initialize()
 ```
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 # codegen
-smithyVersion=[1.26.0,1.27.0[
+smithyVersion=[1.26.2]
 smithyGradleVersion=0.6.0
 
 smithySwiftVersion = 0.1.0


### PR DESCRIPTION
## Issue \#
Related to #721 

## Description of changes
Pinning to Smithy 1.26.2 because latest (1.26.3) causes protocol test failures, which we will address in a subsequent PR.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.