### PR TITLE
fix: remedy Swift Package Index build failures & timeouts

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,6 +1,4 @@
 version: 1
-external_links:
-  documentation: 'https://aws.amazon.com/sdk-for-swift'
 builder:
   configs:
   - platform: macosXcodebuild

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,22 @@
+version: 1
+external_links:
+  documentation: 'https://aws.amazon.com/sdk-for-swift'
+builder:
+  configs:
+  - platform: macosXcodebuild
+    target: AWSSTS
+  - platform: ios
+    target: AWSSTS
+  - platform: linux
+    swift_version: '5.5'
+    image: registry.gitlab.com/finestructure/spi-images:basic-5.5-latest
+    target: AWSSTS
+  - platform: linux
+    swift_version: '5.6'
+    image: registry.gitlab.com/finestructure/spi-images:basic-5.6-latest
+    target: AWSSTS
+  - platform: linux
+    swift_version: '5.7'
+    image: registry.gitlab.com/finestructure/spi-images:basic-5.7-latest
+    target: AWSSTS
+


### PR DESCRIPTION
## Issue \#
Fixes #708

## Description of changes
Our builds on Swift Package Index (SPI) either fail or timeout, resulting in the appearance that our package isn't compatible with any platform or Swift version.  I discussed how to fix with the SPI maintainers [here](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/discussions/2161).

This PR adds a `.spi.yml` config file for SPI that does the following:
- By default the builders are attempting to build all service clients in the SDK, resulting in build timeouts.  Specify `AWSSTS` target for all platforms, which is a small, representative service client that should build quickly and provide adequate proof of compatibility.
- Specify Swift version for Linux builds, and utilize SPI's Docker build containers which have `openssl-dev` pre-installed.

I have validated this config file per the instructions [here](https://swiftpackageindex.com/swiftpackageindex/spimanifest/0.13.0/documentation/spimanifest/validation).

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.