### PR TITLE
fix: Always use pinned version of CRT

### DIFF
--- a/scripts/generatePackageSwift.swift
+++ b/scripts/generatePackageSwift.swift
@@ -106,7 +106,10 @@ func generateDependencies(_ deps: PackageDeps) {
     let crtSwiftDependency = dependency(
         url: "https://github.com/awslabs/aws-crt-swift",
         version: deps.awsCRTSwiftVersion,
-        branch: deps.awsCRTSwiftBranch, 
+        // if the branch is main, then don't use it. 
+        // this will fallback to the version
+        // REMOVE THIS ONCE WE FIX BUILD ERRORS CAUSED BY main
+        branch: deps.awsCRTSwiftBranch == "main" ? nil : deps.awsCRTSwiftBranch, 
         path: deps.awsCRTSwiftPath
     )
     let clientRuntimeDependency = dependency(

--- a/scripts/generatePackageSwift.swift
+++ b/scripts/generatePackageSwift.swift
@@ -55,7 +55,10 @@ func getPackageDependencies() -> PackageDeps? {
     // If env vars are set for package paths in the AWS CRT Builder script, use them
     // unless generating the manifest for release
     if let awsCRTSwiftCIPath = env["AWS_CRT_SWIFT_CI_DIR"], let smithySwiftCIPath = env["SMITHY_SWIFT_CI_DIR"] {
-        deps.awsCRTSwiftPath = awsCRTSwiftCIPath
+        // Forcing the CRT path to be nil
+        // this will fallback to the version
+        // REMOVE THIS ONCE WE FIX BUILD ERRORS CAUSED BY main
+        // deps.awsCRTSwiftPath = awsCRTSwiftCIPath
         deps.clientRuntimePath = smithySwiftCIPath
     }
     return deps
@@ -106,10 +109,7 @@ func generateDependencies(_ deps: PackageDeps) {
     let crtSwiftDependency = dependency(
         url: "https://github.com/awslabs/aws-crt-swift",
         version: deps.awsCRTSwiftVersion,
-        // if the branch is main, then don't use it. 
-        // this will fallback to the version
-        // REMOVE THIS ONCE WE FIX BUILD ERRORS CAUSED BY main
-        branch: deps.awsCRTSwiftBranch == "main" ? nil : deps.awsCRTSwiftBranch, 
+        branch: deps.awsCRTSwiftBranch, 
         path: deps.awsCRTSwiftPath
     )
     let clientRuntimeDependency = dependency(

--- a/scripts/generatePackageSwift.swift
+++ b/scripts/generatePackageSwift.swift
@@ -55,10 +55,7 @@ func getPackageDependencies() -> PackageDeps? {
     // If env vars are set for package paths in the AWS CRT Builder script, use them
     // unless generating the manifest for release
     if let awsCRTSwiftCIPath = env["AWS_CRT_SWIFT_CI_DIR"], let smithySwiftCIPath = env["SMITHY_SWIFT_CI_DIR"] {
-        // Forcing the CRT path to be nil
-        // this will fallback to the version
-        // REMOVE THIS ONCE WE FIX BUILD ERRORS CAUSED BY main
-        // deps.awsCRTSwiftPath = awsCRTSwiftCIPath
+        deps.awsCRTSwiftPath = awsCRTSwiftCIPath
         deps.clientRuntimePath = smithySwiftCIPath
     }
     return deps
@@ -109,8 +106,10 @@ func generateDependencies(_ deps: PackageDeps) {
     let crtSwiftDependency = dependency(
         url: "https://github.com/awslabs/aws-crt-swift",
         version: deps.awsCRTSwiftVersion,
-        branch: deps.awsCRTSwiftBranch, 
-        path: deps.awsCRTSwiftPath
+        // Forcing the CRT to use the version
+        // REMOVE THIS ONCE WE FIX BUILD ERRORS CAUSED BY main
+        branch: nil, //deps.awsCRTSwiftBranch, 
+        path: nil //deps.awsCRTSwiftPath
     )
     let clientRuntimeDependency = dependency(
         url: "https://github.com/awslabs/smithy-swift",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
To get things building again, we're forcing CI to always use the pinned version of CRT.
We can revert this once we fix up the build errors.

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.