### PR TITLE
fix: Add waiters generated test for AND and for number equality & inequality

### DIFF
--- a/codegen/protocol-test-codegen-local/Tests/swift-codegen/WaitersTests/OutputMatcherTests.swift
+++ b/codegen/protocol-test-codegen-local/Tests/swift-codegen/WaitersTests/OutputMatcherTests.swift
@@ -239,7 +239,7 @@ class OutputMatcherTests: XCTestCase {
         XCTAssertNil(match)
     }
 
-    // MARK: - Contains with non-literal, optional search param
+    // MARK: - Contains non-literal, optional search param
 
     // JMESPath expression: "contains(dataMap.*, stringProperty)"
     // JMESPath comparator: "booleanEquals"
@@ -255,6 +255,26 @@ class OutputMatcherTests: XCTestCase {
     func test_containsNonLiteral_acceptorDoesNotMatchWhenStringPropertyIsNotFound() async throws {
         let output = GetWidgetOutputResponse(dataMap: ["a": "abc", "b": "xyz"], stringProperty: "def")
         let subject = try WaitersClient.containsFieldMatcherWaiterConfig().acceptors[0]
+        let match = subject.evaluate(input: anInput, result: .success(output))
+        XCTAssertNil(match)
+    }
+
+    // MARK: - Contains AND expression and number equality/inequality comparison
+
+    // JMESPath expression: "length(dataMap) == `3` && length(stringArrayProperty) != `3`"
+    // JMESPath comparator: "booleanEquals"
+    // JMESPath expected value: "true"
+
+    func test_andInequality_acceptorMatchesWhenCountsAreThreeAndNotThree() async throws {
+        let output = GetWidgetOutputResponse(dataMap: ["a": "a", "b": "b", "c": "c"], stringArrayProperty: ["a", "b"])
+        let subject = try WaitersClient.andInequalityMatcherWaiterConfig().acceptors[0]
+        let match = subject.evaluate(input: anInput, result: .success(output))
+        XCTAssertEqual(match, .success(.success(output)))
+    }
+
+    func test_andInequality_acceptorDoesNotMatchWhenCountsAreNotThreeAndThree() async throws {
+        let output = GetWidgetOutputResponse(dataMap: ["a": "a", "b": "b"], stringArrayProperty: ["a", "b", "c"])
+        let subject = try WaitersClient.andInequalityMatcherWaiterConfig().acceptors[0]
         let match = subject.evaluate(input: anInput, result: .success(output))
         XCTAssertNil(match)
     }

--- a/codegen/protocol-test-codegen-local/model/main.smithy
+++ b/codegen/protocol-test-codegen-local/model/main.smithy
@@ -352,6 +352,21 @@ service Waiters {
             }
         ]
     }
+    AndInequalityMatcher: {
+        documentation: "Matches when there are three elements in dataMap but not three in stringArrayProperty"
+        acceptors: [
+            {
+                state: "success"
+                matcher: {
+                    output: {
+                        path: "length(dataMap) == `3` && length(stringArrayProperty) != `3`"
+                        expected: "true"
+                        comparator: "booleanEquals"
+                    }
+                }
+            }
+        ]
+    }
 )
 operation GetWidget {
     input: WidgetInput,


### PR DESCRIPTION
## Description of changes
Adds a generated waiter that uses an AND expression plus number equality & inequality.  Provides test coverage for issues in smithy-swift PRs:
https://github.com/awslabs/smithy-swift/pull/493
https://github.com/awslabs/smithy-swift/pull/494

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.