### PR TITLE
fix: Add main branch trigger for CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
## Description of changes
Commits to main are currently only being linted; CI is not run on them.
This PR adds a main branch trigger for the CI workflow, same as `smithy-swift`:
https://github.com/awslabs/smithy-swift/blob/main/.github/workflows/continuous-integration.yml#L5

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.