### PR TITLE
fix!: Updates `expiration` paramater in `presign` functions to `TimeInterval` type.

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGenerator.kt
@@ -68,11 +68,12 @@ class PresignerGenerator : SwiftIntegration {
 
         writer.addImport(AWSClientConfiguration)
         writer.addImport(SdkHttpRequest)
+        writer.addFoundationImport()
 
         val httpBindingResolver = protocolGenerator.getProtocolHttpBindingResolver(protocolGeneratorContext, protocolGenerator.defaultContentType)
 
         writer.openBlock("extension $inputType {", "}") {
-            writer.openBlock("public func presign(config: \$N, expiration: \$N) async throws -> \$T {", "}", serviceConfig.typeProtocol, SwiftTypes.Int64, SdkHttpRequest) {
+            writer.openBlock("public func presign(config: \$N, expiration: Foundation.TimeInterval) async throws -> \$T {", "}", serviceConfig.typeProtocol, SdkHttpRequest) {
                 writer.write("let serviceName = \"${ctx.settings.sdkId}\"")
                 writer.write("let input = self")
                 val operationStackName = "operation"

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGenerator.kt
@@ -12,6 +12,7 @@ import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.swift.codegen.ClientRuntimeTypes.Http.SdkHttpRequest
 import software.amazon.smithy.swift.codegen.ClientRuntimeTypes.Middleware.NoopHandler
+import software.amazon.smithy.swift.codegen.FoundationTypes
 import software.amazon.smithy.swift.codegen.SwiftDelegator
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.core.CodegenContext
@@ -67,12 +68,12 @@ class PresignerGenerator : SwiftIntegration {
 
         writer.addImport(AWSClientConfiguration)
         writer.addImport(SdkHttpRequest)
-        writer.addFoundationImport()
+        writer.addIndividualTypeImport("typealias", "Foundation", "TimeInterval")
 
         val httpBindingResolver = protocolGenerator.getProtocolHttpBindingResolver(protocolGeneratorContext, protocolGenerator.defaultContentType)
 
         writer.openBlock("extension $inputType {", "}") {
-            writer.openBlock("public func presign(config: \$N, expiration: Foundation.TimeInterval) async throws -> \$T {", "}", serviceConfig.typeProtocol, SdkHttpRequest) {
+            writer.openBlock("public func presign(config: \$N, expiration: \$N) async throws -> \$T {", "}", serviceConfig.typeProtocol, FoundationTypes.TimeInterval, SdkHttpRequest) {
                 writer.write("let serviceName = \"${ctx.settings.sdkId}\"")
                 writer.write("let input = self")
                 val operationStackName = "operation"

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGenerator.kt
@@ -13,7 +13,6 @@ import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.swift.codegen.ClientRuntimeTypes.Http.SdkHttpRequest
 import software.amazon.smithy.swift.codegen.ClientRuntimeTypes.Middleware.NoopHandler
 import software.amazon.smithy.swift.codegen.SwiftDelegator
-import software.amazon.smithy.swift.codegen.SwiftTypes
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.core.CodegenContext
 import software.amazon.smithy.swift.codegen.core.toProtocolGenerationContext

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/presignable/PresignableUrlIntegration.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/presignable/PresignableUrlIntegration.kt
@@ -88,14 +88,14 @@ class PresignableUrlIntegration(private val presignedOperations: Map<String, Set
 
         writer.addImport(AWSClientRuntimeTypes.Core.AWSClientConfiguration)
         writer.addImport(ClientRuntimeTypes.Http.SdkHttpRequest)
+        writer.addFoundationImport()
 
         val httpBindingResolver = protocolGenerator.getProtocolHttpBindingResolver(protocolGeneratorContext, protocolGenerator.defaultContentType)
 
         writer.openBlock("extension $inputType {", "}") {
             writer.openBlock(
-                "public func presignURL(config: \$N, expiration: \$N) async throws -> \$T {", "}",
+                "public func presignURL(config: \$N, expiration: Foundation.TimeInterval) async throws -> \$T {", "}",
                 serviceConfig.typeProtocol,
-                SwiftTypes.Int64,
                 ClientRuntimeTypes.Core.URL
             ) {
                 writer.write("let serviceName = \"${ctx.settings.sdkId}\"")

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/presignable/PresignableUrlIntegration.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/presignable/PresignableUrlIntegration.kt
@@ -17,7 +17,6 @@ import software.amazon.smithy.swift.codegen.MiddlewareGenerator
 import software.amazon.smithy.swift.codegen.SwiftDelegator
 import software.amazon.smithy.swift.codegen.SwiftDependency
 import software.amazon.smithy.swift.codegen.SwiftSettings
-import software.amazon.smithy.swift.codegen.SwiftTypes
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.core.CodegenContext
 import software.amazon.smithy.swift.codegen.core.toProtocolGenerationContext

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/presignable/PresignableUrlIntegration.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/presignable/PresignableUrlIntegration.kt
@@ -13,6 +13,7 @@ import software.amazon.smithy.model.knowledge.OperationIndex
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.swift.codegen.ClientRuntimeTypes
+import software.amazon.smithy.swift.codegen.FoundationTypes
 import software.amazon.smithy.swift.codegen.MiddlewareGenerator
 import software.amazon.smithy.swift.codegen.SwiftDelegator
 import software.amazon.smithy.swift.codegen.SwiftDependency
@@ -87,14 +88,15 @@ class PresignableUrlIntegration(private val presignedOperations: Map<String, Set
 
         writer.addImport(AWSClientRuntimeTypes.Core.AWSClientConfiguration)
         writer.addImport(ClientRuntimeTypes.Http.SdkHttpRequest)
-        writer.addFoundationImport()
+        writer.addIndividualTypeImport("typealias", "Foundation", "TimeInterval")
 
         val httpBindingResolver = protocolGenerator.getProtocolHttpBindingResolver(protocolGeneratorContext, protocolGenerator.defaultContentType)
 
         writer.openBlock("extension $inputType {", "}") {
             writer.openBlock(
-                "public func presignURL(config: \$N, expiration: Foundation.TimeInterval) async throws -> \$T {", "}",
+                "public func presignURL(config: \$N, expiration: \$N) async throws -> \$T {", "}",
                 serviceConfig.typeProtocol,
+                FoundationTypes.TimeInterval,
                 ClientRuntimeTypes.Core.URL
             ) {
                 writer.write("let serviceName = \"${ctx.settings.sdkId}\"")

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGeneratorTests.kt
@@ -18,9 +18,10 @@ class PresignerGeneratorTests {
             """
             import AWSClientRuntime
             import ClientRuntime
+            import Foundation
             
             extension GetFooInput {
-                public func presign(config: ExampleClientConfigurationProtocol, expiration: Swift.Int64) async throws -> ClientRuntime.SdkHttpRequest? {
+                public func presign(config: ExampleClientConfigurationProtocol, expiration: Foundation.TimeInterval) async throws -> ClientRuntime.SdkHttpRequest? {
                     let serviceName = "example"
                     let input = self
                     let encoder = ClientRuntime.JSONEncoder()
@@ -73,9 +74,10 @@ class PresignerGeneratorTests {
             """
             import AWSClientRuntime
             import ClientRuntime
+            import Foundation
             
             extension PostFooInput {
-                public func presign(config: ExampleClientConfigurationProtocol, expiration: Swift.Int64) async throws -> ClientRuntime.SdkHttpRequest? {
+                public func presign(config: ExampleClientConfigurationProtocol, expiration: Foundation.TimeInterval) async throws -> ClientRuntime.SdkHttpRequest? {
                     let serviceName = "example"
                     let input = self
                     let encoder = ClientRuntime.JSONEncoder()
@@ -131,9 +133,10 @@ class PresignerGeneratorTests {
             """
             import AWSClientRuntime
             import ClientRuntime
+            import Foundation
             
             extension PutFooInput {
-                public func presign(config: ExampleClientConfigurationProtocol, expiration: Swift.Int64) async throws -> ClientRuntime.SdkHttpRequest? {
+                public func presign(config: ExampleClientConfigurationProtocol, expiration: Foundation.TimeInterval) async throws -> ClientRuntime.SdkHttpRequest? {
                     let serviceName = "example"
                     let input = self
                     let encoder = ClientRuntime.JSONEncoder()
@@ -191,9 +194,10 @@ class PresignerGeneratorTests {
 
             import AWSClientRuntime
             import ClientRuntime
+            import Foundation
 
             extension PutObjectInput {
-                public func presign(config: S3ClientConfigurationProtocol, expiration: Swift.Int64) async throws -> ClientRuntime.SdkHttpRequest? {
+                public func presign(config: S3ClientConfigurationProtocol, expiration: Foundation.TimeInterval) async throws -> ClientRuntime.SdkHttpRequest? {
                     let serviceName = "S3"
                     let input = self
                     let encoder = ClientRuntime.JSONEncoder()

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGeneratorTests.kt
@@ -18,7 +18,7 @@ class PresignerGeneratorTests {
             """
             import AWSClientRuntime
             import ClientRuntime
-            import Foundation
+            import typealias Foundation.TimeInterval
             
             extension GetFooInput {
                 public func presign(config: ExampleClientConfigurationProtocol, expiration: Foundation.TimeInterval) async throws -> ClientRuntime.SdkHttpRequest? {
@@ -74,7 +74,7 @@ class PresignerGeneratorTests {
             """
             import AWSClientRuntime
             import ClientRuntime
-            import Foundation
+            import typealias Foundation.TimeInterval
             
             extension PostFooInput {
                 public func presign(config: ExampleClientConfigurationProtocol, expiration: Foundation.TimeInterval) async throws -> ClientRuntime.SdkHttpRequest? {
@@ -133,7 +133,7 @@ class PresignerGeneratorTests {
             """
             import AWSClientRuntime
             import ClientRuntime
-            import Foundation
+            import typealias Foundation.TimeInterval
             
             extension PutFooInput {
                 public func presign(config: ExampleClientConfigurationProtocol, expiration: Foundation.TimeInterval) async throws -> ClientRuntime.SdkHttpRequest? {
@@ -194,7 +194,7 @@ class PresignerGeneratorTests {
 
             import AWSClientRuntime
             import ClientRuntime
-            import Foundation
+            import typealias Foundation.TimeInterval
 
             extension PutObjectInput {
                 public func presign(config: S3ClientConfigurationProtocol, expiration: Foundation.TimeInterval) async throws -> ClientRuntime.SdkHttpRequest? {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
After the upgrade to CRT 0.5.0+, the type of expiration changed from Int64 to TimeInterval.
Therefore, services that define presign functions (such as S3) fail to build because of the type mistmatch.

IMO it makes sense to update the type exposed in the functions to TimeInterval since TimeInterval is a better way to describe a value that should be in seconds.

## Issue \#
#804 

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.