### PR TITLE
chore: Update smithy-swift & aws-crt-swift; pin to latest versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -731,7 +731,7 @@ case (false, true):
     ]
 case (false, false):
     package.dependencies += [
-        .package(url: "https://github.com/awslabs/smithy-swift", branch: "main"),
-        .package(url: "https://github.com/awslabs/aws-crt-swift", branch: "main")
+        .package(url: "https://github.com/awslabs/smithy-swift", .exact("0.10.0")),
+        .package(url: "https://github.com/awslabs/aws-crt-swift", .exact("0.5.3"))
     ]
 }

--- a/packageDependencies.plist
+++ b/packageDependencies.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>clientRuntimeVersion</key>
-	<string>0.9.0</string>
+	<string>0.10.0</string>
 	<key>awsCRTSwiftVersion</key>
-	<string>0.5.2</string>
+	<string>0.5.3</string>
 	<key>clientRuntimeBranch</key>
 	<string>main</string>
 	<key>awsCRTSwiftBranch</key>


### PR DESCRIPTION
## Description of changes
- Update smithy-swift to 0.10.0
- Update aws-crt-swift to 0.5.3
- Pin versions in generated manifest

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.