### PR TITLE
chore: update smithyVersion to use exact version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 # codegen
-smithyVersion=[1.26.4]
+smithyVersion=1.26.4
 smithyGradleVersion=0.6.0
 
 smithySwiftVersion = 0.1.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->

N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

Instead of using the version range style `[1.26.4]` for `smithyVersion`, use the exact version style `1.26.4`.

## New/existing dependencies impact assessment, if applicable

No new dependencies were added to this change.
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.