### PR TITLE
fix: Delete previous generated code before staging

### DIFF
--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -166,13 +166,15 @@ val discoveredServices: List<AwsService> by lazy { discoverServices() }
 val AwsService.outputDir: String
     get() = project.file("${project.buildDir}/smithyprojections/${project.name}/${projectionName}/swift-codegen").absolutePath
 
+val sourcesDir: String = rootProject.file("Sources/Services").absolutePath
+
 val AwsService.sourcesDir: String
-    get(){
-        return rootProject.file("Sources/Services").absolutePath
+    get() {
+        return sourcesDir
     }
 
 val AwsService.testsDir: String
-    get(){
+    get() {
         return rootProject.file("Tests/Services").absolutePath
     }
 
@@ -186,6 +188,7 @@ task("stageSdks") {
     group = "codegen"
     description = "relocate generated SDK(s) from build directory to Sources and Tests directories"
     doLast {
+        delete(rootProject.file(sourcesDir).absolutePath)
         discoveredServices.forEach {
             logger.info("copying ${it.outputDir} source to ${it.sourcesDir}")
             copy {

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -168,11 +168,6 @@ val AwsService.outputDir: String
 
 val sourcesDir: String = rootProject.file("Sources/Services").absolutePath
 
-val AwsService.sourcesDir: String
-    get() {
-        return sourcesDir
-    }
-
 val AwsService.testsDir: String
     get() {
         return rootProject.file("Tests/Services").absolutePath
@@ -188,12 +183,12 @@ task("stageSdks") {
     group = "codegen"
     description = "relocate generated SDK(s) from build directory to Sources and Tests directories"
     doLast {
-        delete(rootProject.file(sourcesDir).absolutePath)
+        delete(sourcesDir)
         discoveredServices.forEach {
-            logger.info("copying ${it.outputDir} source to ${it.sourcesDir}")
+            logger.info("copying ${it.outputDir} source to $sourcesDir")
             copy {
                 from("${it.outputDir}")
-                into("${it.sourcesDir}")
+                into(sourcesDir)
                 exclude("Package.swift")
                 exclude("*Tests")
             }


### PR DESCRIPTION
## Description of changes
Deletes previous generated code before staging new generated code.  Fixes the following problems:
- Ensures that previously generated code doesn't persist to a new generation if it doesn't happen to be explicitly overwritten
- Ensures that source files are deleted when one or more services are excluded from code-generation during development

This was previously done in scattered places around the codebase including CI workflows and test scripts; performing it as part of the `stageSdks` Gradle task DRYs up code by not requiring it to be performed in multiple places.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.