### PR TITLE
chore: Use containerized swiftlint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
       - name: Lint ${{ env.PACKAGE_NAME }}
-        run: |
-          ./gradlew ktlint
+        run: ./gradlew ktlint
   swiftlint:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/realm/swiftlint:0.50.3
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/Sources/Core/AWSClientRuntime/HttpContextBuilder+Extension.swift
+++ b/Sources/Core/AWSClientRuntime/HttpContextBuilder+Extension.swift
@@ -29,7 +29,7 @@ extension HttpContext {
     func getSigningRegion() -> String? {
         return attributes.get(key: HttpContext.signingRegion)
     }
-    
+
     func getSigningAlgorithm() -> AWSSigningAlgorithm? {
         guard let algorithmRawValue = attributes.get(key: HttpContext.signingAlgorithm) else {
             return nil
@@ -63,7 +63,7 @@ extension HttpContextBuilder {
         self.attributes.set(key: AttributeKey<String>(name: "SigningRegion"), value: value)
         return self
     }
-    
+
     @discardableResult
     public func withSigningAlgorithm(value: AWSSigningAlgorithm?) -> HttpContextBuilder {
         self.attributes.set(key: AttributeKey<String>(name: "SigningAlgorithm"), value: value?.rawValue)


### PR DESCRIPTION
## Issue \#
Fixes #677

## Description of changes
The SwiftLint project now has containerized SwiftLint available for use:
https://github.com/realm/SwiftLint/pkgs/container/swiftlint

Use the latest stable Dockerized SwiftLint version (currently `0.50.3`) to lint this project.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.