### PR TITLE
chore: bump smithy-swift to 0.11.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1070,6 +1070,6 @@ case (false, true):
     ]
 case (false, false):
     package.dependencies += [
-        .package(url: "https://github.com/awslabs/smithy-swift", .exact("0.10.2"))
+        .package(url: "https://github.com/awslabs/smithy-swift", .exact("0.11.0"))
     ]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->

Since, aws-crt-swift upgrade main got unstable when not using local dependencies.

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

This change updates the main to use latest smithy-swift version.

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.