### PR TITLE
fix: Update smithy-swift and aws-crt-swift for hot fix release

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -364,7 +364,7 @@ let package = Package(
         .library(name: "AWSXRay", targets: ["AWSXRay"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/awslabs/aws-crt-swift", .exact("0.5.7"))
+        .package(url: "https://github.com/awslabs/aws-crt-swift", .exact("0.5.8"))
     ],
     targets: [
         // MARK: - Core Targets

--- a/Package.swift
+++ b/Package.swift
@@ -1070,6 +1070,6 @@ case (false, true):
     ]
 case (false, false):
     package.dependencies += [
-        .package(url: "https://github.com/awslabs/smithy-swift", .exact("0.10.3"))
+        .package(url: "https://github.com/awslabs/smithy-swift", .exact("0.10.4"))
     ]
 }

--- a/packageDependencies.plist
+++ b/packageDependencies.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>clientRuntimeVersion</key>
-	<string>0.10.3</string>
+	<string>0.10.4</string>
 	<key>awsCRTSwiftVersion</key>
 	<string>0.5.8</string>
 	<key>clientRuntimeBranch</key>

--- a/packageDependencies.plist
+++ b/packageDependencies.plist
@@ -5,7 +5,7 @@
 	<key>clientRuntimeVersion</key>
 	<string>0.10.3</string>
 	<key>awsCRTSwiftVersion</key>
-	<string>0.5.7</string>
+	<string>0.5.8</string>
 	<key>clientRuntimeBranch</key>
 	<string>main</string>
 	<key>awsCRTSwiftBranch</key>


### PR DESCRIPTION
## Issue \#
#867 

## Description of changes
Updates aws-crt-swift from 0.5.7 to 0.5.8, and smithy-swift from 0.10.3 to 0.10.4.

This PR is a hot fix on aws-sdk-swift v0.9.1.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.