### PR TITLE
fix: Require aws-crt-swift 0.6.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -364,7 +364,7 @@ let package = Package(
         .library(name: "AWSXRay", targets: ["AWSXRay"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/awslabs/aws-crt-swift", .exact("0.6.0"))
+        .package(url: "https://github.com/awslabs/aws-crt-swift", .exact("0.6.1"))
     ],
     targets: [
         // MARK: - Core Targets
@@ -1070,6 +1070,6 @@ case (false, true):
     ]
 case (false, false):
     package.dependencies += [
-        .package(url: "https://github.com/awslabs/smithy-swift", .exact("0.11.0"))
+        .package(url: "https://github.com/awslabs/smithy-swift", .exact("0.10.2"))
     ]
 }

--- a/packageDependencies.plist
+++ b/packageDependencies.plist
@@ -5,7 +5,7 @@
 	<key>clientRuntimeVersion</key>
 	<string>0.10.2</string>
 	<key>awsCRTSwiftVersion</key>
-	<string>0.6.0</string>
+	<string>0.6.1</string>
 	<key>clientRuntimeBranch</key>
 	<string>main</string>
 	<key>awsCRTSwiftBranch</key>


### PR DESCRIPTION
## Issue \#
Pulls in fix for https://github.com/awslabs/aws-sdk-swift/issues/867

## Description of changes
Fixes an issue that prevents the SDK from building to an iOS device when building on a M series Mac.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.