### PR TITLE
chore: creates pull-request comment triggers for CI jobs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
   workflow_dispatch:
+  issue_comment:
+    types: [created]
 
 env:
   BUILDER_VERSION: v0.9.18
@@ -21,6 +23,8 @@ env:
 
 jobs:
   ios-compat:
+    # if the job is triggered by a comment, then it must start with /ci
+    if: github.event_name != 'issue_comment' || (github.event.issue.pull_request && startsWith(github.event.comment.body, '/ci'))
     runs-on: macos-12
     env:
       DEVELOPER_DIR: /Applications/Xcode_14.0.app
@@ -44,6 +48,8 @@ jobs:
           chmod a+x builder.pyz
           AWS_CRT_SWIFT_CI_DIR="${{ env.AWS_CRT_SWIFT_CI_DIR }}" AWS_SDK_SWIFT_CI_DIR="${{ env.AWS_SDK_SWIFT_CI_DIR }}" SMITHY_SWIFT_CI_DIR="${{ env.SMITHY_SWIFT_CI_DIR }}" AWS_SWIFT_SDK_USE_LOCAL_DEPS=1 ./builder.pyz build -p ${{ env.PACKAGE_NAME }} --target=ios-armv8
   macos-compat:
+    # if the job is triggered by a comment, then it must start with /ci
+    if: github.event_name != 'issue_comment' || (github.event.issue.pull_request && startsWith(github.event.comment.body, '/ci'))
     runs-on: macos-11
     env:
       DEVELOPER_DIR: /Applications/Xcode_13.2.1.app
@@ -67,6 +73,8 @@ jobs:
           chmod a+x builder.pyz
           AWS_CRT_SWIFT_CI_DIR="${{ env.AWS_CRT_SWIFT_CI_DIR }}" AWS_SDK_SWIFT_CI_DIR="${{ env.AWS_SDK_SWIFT_CI_DIR }}" SMITHY_SWIFT_CI_DIR="${{ env.SMITHY_SWIFT_CI_DIR }}" AWS_SWIFT_SDK_USE_LOCAL_DEPS=1 ./builder.pyz build -p ${{ env.PACKAGE_NAME }}
   linux-compat:
+    # if the job is triggered by a comment, then it must start with /ci
+    if: github.event_name != 'issue_comment' || (github.event.issue.pull_request && startsWith(github.event.comment.body, '/ci'))
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,12 +5,16 @@ on:
     branches: [ main ]
   pull_request:
   workflow_dispatch:
+  issue_comment:
+    types: [created]
 
 env:
   PACKAGE_NAME: aws-sdk-swift
 
 jobs:
   ktlint:
+    # if the job is triggered by a comment, then it must start with /ci
+    if: github.event_name != 'issue_comment' || (github.event.issue.pull_request && startsWith(github.event.comment.body, '/ci'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -18,6 +22,8 @@ jobs:
       - name: Lint ${{ env.PACKAGE_NAME }}
         run: ./gradlew ktlint
   swiftlint:
+    # if the job is triggered by a comment, then it must start with /ci
+    if: github.event_name != 'issue_comment' || (github.event.issue.pull_request && startsWith(github.event.comment.body, '/ci'))
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/realm/swiftlint:0.50.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release
 
 on:
-  pull_request:
   workflow_dispatch:
+  issue_comment:
+    types: [created]
 
 env:
   BUILDER_VERSION: v0.8.19
@@ -22,7 +23,8 @@ env:
 
 jobs:
   macos-release:
-    if:  startsWith(github.head_ref, 'release/')
+    # if the workflow was manually dispatched, or if someone commented on the PR with /release 
+    if: github.event_name == 'workflow_dispatch' || (startsWith(github.ref_name, 'release/') && github.event.issue.pull_request && startsWith(github.event.comment.body, '/release'))
     runs-on: macos-11
     steps:
       - name: Checkout sources


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR configures the following github workflows to be triggered by commenting on a PR. 

Release Workflow
- can now also be triggered by commenting `/release` on the PR and the branch name starts with `release/`

CI Workflow
- can now also be triggered by commenting `/ci` on the PR

Lint Workflow
- can now also be triggered by commenting `/ci` on the PR


Unfortunately, this cannot be tested until these changes are present in the default branch. After merging, i will verify behavior.

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.