### PR TITLE
fix: Updates the list of operations in the disabled auth customization

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/DisabledAuth.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/DisabledAuth.kt
@@ -15,6 +15,7 @@ internal val DISABLED_AUTH_OPERATIONS: Map<String, Set<String>> = mapOf(
         "com.amazonaws.sts#AssumeRoleWithSAML",
         "com.amazonaws.sts#AssumeRoleWithWebIdentity"
     ),
+    // operations with missing optional auth: https://docs.aws.amazon.com/cognito/latest/developerguide/security_iam_service-with-iam.html
     "com.amazonaws.cognitoidentity#AWSCognitoIdentityService" to setOf(
         "com.amazonaws.cognitoidentity#GetId",
         "com.amazonaws.cognitoidentity#GetOpenIdToken",
@@ -48,7 +49,7 @@ internal val DISABLED_AUTH_OPERATIONS: Map<String, Set<String>> = mapOf(
         "com.amazonaws.cognitoidentityprovider#UpdateUserAttributes",
         "com.amazonaws.cognitoidentityprovider#VerifySoftwareToken",
         "com.amazonaws.cognitoidentityprovider#VerifyUserAttribute",
-    ) // operations with missing optional auth: [] per documentation https://docs.aws.amazon.com/cognito/latest/developerguide/security_iam_service-with-iam.html
+    )
 )
 // TODO: If or when the service team adds this trait to their model, we can remove this customization
 class DisabledAuth(private val disabledAuth: Map<String, Set<String>> = DISABLED_AUTH_OPERATIONS) : SwiftIntegration {

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/DisabledAuth.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/DisabledAuth.kt
@@ -15,14 +15,39 @@ internal val DISABLED_AUTH_OPERATIONS: Map<String, Set<String>> = mapOf(
         "com.amazonaws.sts#AssumeRoleWithSAML",
         "com.amazonaws.sts#AssumeRoleWithWebIdentity"
     ),
+    "com.amazonaws.cognitoidentity#AWSCognitoIdentityService" to setOf(
+        "com.amazonaws.cognitoidentity#GetId",
+        "com.amazonaws.cognitoidentity#GetOpenIdToken",
+        "com.amazonaws.cognitoidentity#UnlinkIdentity",
+        "com.amazonaws.cognitoidentity#GetCredentialsForIdentity",
+    ),
     "com.amazonaws.cognitoidentityprovider#AWSCognitoIdentityProviderService" to setOf(
+        "com.amazonaws.cognitoidentityprovider#AssociateSoftwareToken",
+        "com.amazonaws.cognitoidentityprovider#ChangePassword",
         "com.amazonaws.cognitoidentityprovider#ConfirmDevice",
+        "com.amazonaws.cognitoidentityprovider#ConfirmForgotPassword",
+        "com.amazonaws.cognitoidentityprovider#ConfirmSignUp",
+        "com.amazonaws.cognitoidentityprovider#DeleteUser",
+        "com.amazonaws.cognitoidentityprovider#DeleteUserAttributes",
         "com.amazonaws.cognitoidentityprovider#ForgetDevice",
+        "com.amazonaws.cognitoidentityprovider#ForgotPassword",
         "com.amazonaws.cognitoidentityprovider#GetDevice",
+        "com.amazonaws.cognitoidentityprovider#GetUser",
+        "com.amazonaws.cognitoidentityprovider#GetUserAttributeVerificationCode",
         "com.amazonaws.cognitoidentityprovider#GlobalSignOut",
+        "com.amazonaws.cognitoidentityprovider#InitiateAuth",
         "com.amazonaws.cognitoidentityprovider#ListDevices",
+        "com.amazonaws.cognitoidentityprovider#ResendConfirmationCode",
+        "com.amazonaws.cognitoidentityprovider#RespondToAuthChallenge",
         "com.amazonaws.cognitoidentityprovider#RevokeToken",
-        "com.amazonaws.cognitoidentityprovider#UpdateDeviceStatus"
+        "com.amazonaws.cognitoidentityprovider#SetUserMFAPreference",
+        "com.amazonaws.cognitoidentityprovider#SetUserSettings",
+        "com.amazonaws.cognitoidentityprovider#SignUp",
+        "com.amazonaws.cognitoidentityprovider#UpdateAuthEventFeedback",
+        "com.amazonaws.cognitoidentityprovider#UpdateDeviceStatus",
+        "com.amazonaws.cognitoidentityprovider#UpdateUserAttributes",
+        "com.amazonaws.cognitoidentityprovider#VerifySoftwareToken",
+        "com.amazonaws.cognitoidentityprovider#VerifyUserAttribute",
     ) // operations with missing optional auth: [] per documentation https://docs.aws.amazon.com/cognito/latest/developerguide/security_iam_service-with-iam.html
 )
 // TODO: If or when the service team adds this trait to their model, we can remove this customization

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/DisabledAuth.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/DisabledAuth.kt
@@ -15,7 +15,11 @@ internal val DISABLED_AUTH_OPERATIONS: Map<String, Set<String>> = mapOf(
         "com.amazonaws.sts#AssumeRoleWithSAML",
         "com.amazonaws.sts#AssumeRoleWithWebIdentity"
     ),
-    // operations with missing optional auth: https://docs.aws.amazon.com/cognito/latest/developerguide/security_iam_service-with-iam.html
+    // Operations with missing optional auth: https://docs.aws.amazon.com/cognito/latest/developerguide/security_iam_service-with-iam.html
+    //
+    // Some of the following operations do correctly have the `optionalAuth` trait applied and therefore do not need this customization
+    // but maintaining the diff of operations that have the trait and which don't is a nightmare and so
+    // we are applying the trait to all operations listed in the documentation linked above.
     "com.amazonaws.cognitoidentity#AWSCognitoIdentityService" to setOf(
         "com.amazonaws.cognitoidentity#GetId",
         "com.amazonaws.cognitoidentity#GetOpenIdToken",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR updates the list of operations that should have the [@optionalAuth](https://smithy.io/2.0/spec/authentication-traits.html#smithy-api-optionalauth-trait) trait applied as a customization.

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->
#913 

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.