### PR TITLE
feat: Release Automation - Generate release manifest

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Models/ReleaseManifest.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Models/ReleaseManifest.swift
@@ -1,0 +1,30 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import PackageDescription
+
+struct ReleaseManifest: Codable {
+    let name: String
+    let tagName: String
+    let body: String
+    let assets: [Asset]
+}
+
+extension ReleaseManifest {
+    struct Asset: Codable {
+        let artifactId: String
+        let name: String
+    }
+}
+
+extension ReleaseManifest {
+    static func fromFile(_ filePath: String) throws -> Self {
+        let fileContents = try FileManager.default.loadContents(atPath: filePath)
+        return try JSONDecoder().decode(Self.self, from: fileContents)
+    }
+}

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Models/ReleaseNotesBuilder.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Models/ReleaseNotesBuilder.swift
@@ -1,0 +1,36 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import PackageDescription
+
+// Builds the release notes
+struct ReleaseNotesBuilder {
+    let previousVersion: Version
+    let newVersion: Version
+    let commits: [String]
+    
+    // MARK: - Build
+    
+    func build() -> String {
+        let contents = [
+            "## What's Changed",
+            buildCommits(),
+            .newline,
+            "**Full Changelog**: https://github.com/awslabs/aws-sdk-swift/compare/\(previousVersion)...\(newVersion)"
+        ]
+        return contents.joined(separator: .newline)
+    }
+    
+    // Adds a preceding `*` to each commit string
+    // This renders the list of commits as a list in markdown
+    func buildCommits() -> String {
+        commits
+            .map { "* \($0)"}
+            .joined(separator: .newline)
+    }
+}

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Utils/Process+Git.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Utils/Process+Git.swift
@@ -52,6 +52,12 @@ extension Process {
         func diffIndex() -> Process {
             gitProcess(["diff-index", "--quiet", "HEAD", "--"])
         }
+        
+        /// Returns a process for executing `git log <a>..<b> --pretty=format:<format>`
+        /// This is used returning the list of commits between two tags.
+        func log(_ a: String, _ b: String, format: String) -> Process {
+            gitProcess(["log", "\(a)...\(b)", "--pretty=format:\(format.wrappedInQuotes())"])
+        }
     }
     
     static var git: Git { Git() }
@@ -76,5 +82,11 @@ extension Process.Git {
         try _run(diffIndexTask)
         diffIndexTask.waitUntilExit()
         return diffIndexTask.terminationStatus != 0
+    }
+    
+    func listOfCommitsBetween(_ a: String, _ b: String) throws -> [String] {
+        let log = log(a, b, format: "%s")
+        let result = try _runReturningStdOut(log)
+        return result?.components(separatedBy: .newlines) ?? []
     }
 }

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Utils/Process+Utils.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Utils/Process+Utils.swift
@@ -47,6 +47,21 @@ func _run(_ process: Process) throws {
     try ProcessRunner.standard.run(process)
 }
 
+func _runReturningStdOut(_ process: Process) throws -> String? {
+    let stdOut = Pipe()
+    process.standardOutput = stdOut
+    
+    var data = Data()
+    stdOut.fileHandleForReading.readabilityHandler = { handle in
+        data += handle.availableData
+    }
+    
+    try _run(process)
+    process.waitUntilExit()
+    
+    return String(data: data, encoding: .utf8)
+}
+
 /// A simple struct that runs a process
 struct ProcessRunner {
     let run: (Process) throws -> Void

--- a/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Commands/PrepareReleaseTests.swift
+++ b/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Commands/PrepareReleaseTests.swift
@@ -41,10 +41,15 @@ class PrepareReleaseTests: CLITestCase {
         let versionFromFile = try! Version.fromFile("Package.version")
         XCTAssertEqual(versionFromFile, newVersion)
         
-        XCTAssertEqual(commands.count, 3)
+        let releaseManifest = try! ReleaseManifest.fromFile("release_manifest.json")
+        XCTAssertEqual(releaseManifest.name, "\(newVersion)")
+        XCTAssertEqual(releaseManifest.tagName, "\(newVersion)")
+        
+        XCTAssertEqual(commands.count, 4)
         XCTAssertTrue(commands[0].contains("git add"))
         XCTAssertTrue(commands[1].contains("git commit"))
         XCTAssertTrue(commands[2].contains("git tag"))
+        XCTAssertTrue(commands[3].contains("git log"))
     }
     
     func testRunBailsEarlyIfThereAreNoChanges() {
@@ -119,11 +124,13 @@ extension PrepareRelease {
     static func mock(
         repoType: PrepareRelease.Repo = .awsSdkSwift,
         repoPath: String = ".",
+        sourceCodeArtifactId: String = "source-code-artifact-id",
         diffChecker: @escaping DiffChecker = { _,_ in true }
     ) -> Self {
         PrepareRelease(
             repoType: repoType,
             repoPath: repoPath,
+            sourceCodeArtifactId: sourceCodeArtifactId,
             diffChecker: diffChecker
         )
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR updates the `prepare-release` command in the cli to generate a release manifest file. 
The release manifest is used to config a release created on github. It includes fields for the name, tag, release notes, and artifacts.

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-swift/issues/855

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.