### PR TITLE
fix: Updates package manifest generator to also add services as products

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
@@ -42,7 +42,8 @@ let package = Package(
         .testTarget(
             name: "AWSClientRuntimeTests",
             dependencies: [.awsClientRuntime, .clientRuntime, .smithyTestUtils],
-            path: "./Tests/Core/AWSClientRuntimeTests"
+            path: "./Tests/Core/AWSClientRuntimeTests",
+            resources: [.process("Resources")]
         )
     ]
 )

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
@@ -86,6 +86,9 @@ func addCRTDependency(_ version: Version) {
 
 func addServiceTarget(_ name: String) {
     let testName = "\(name)Tests"
+    package.products += [
+        .library(name: name, targets: [name]),
+    ]
     package.targets += [
         .target(
             name: name,

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Utils/FileManager+Utils.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Utils/FileManager+Utils.swift
@@ -33,5 +33,6 @@ extension FileManager {
         try FileManager.default
             .contentsOfDirectory(atPath: "Sources/Services")
             .sorted()
+            .filter { !$0.hasPrefix(".") }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR updates the package manifest generator:
- add services as products
- included resources for the AWSClientRuntime tests
- exclude items that start with `.` when retrieving the list of services from the Sources directory as it may include a `.DS_Store` on mac.

## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/939

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.