### PR TITLE
fix: Adds explicit type for `LazyValue` in CLI

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/GeneratePackageManifest.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/GeneratePackageManifest.swift
@@ -113,7 +113,7 @@ struct GeneratePackageManifest {
     /// - Returns: The versions for ClientRuntime and CRT.
     func resolveVersions() throws -> (clientRuntime: Version, crt: Version) {
         log("Resolving versions of dependencies...")
-        let packageDependencies = LazyValue {
+        let packageDependencies = LazyValue<PackageDependencies> {
             do {
                 return try PackageDependencies.load()
             } catch let error as Error {

--- a/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Models/LazyValueTests.swift
+++ b/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Models/LazyValueTests.swift
@@ -12,7 +12,7 @@ class LazyValueTests: XCTestCase {
     
     func testLazyValue() {
         var count: Int = 0
-        let subject = LazyValue {
+        let subject = LazyValue<Int> {
             count += 1
             return 1
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The CLI is failing to compile on Swift 5.5 due to a complex closure type. This fixes the issue by defining an explicit type for the generic.

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.