### PR TITLE
feat: Forces http2 for bidirectional event streams

### DIFF
--- a/IntegrationTests/Services/AWSTranscribeStreamingIntegrationTests/TranscribeStreamingTests.swift
+++ b/IntegrationTests/Services/AWSTranscribeStreamingIntegrationTests/TranscribeStreamingTests.swift
@@ -17,7 +17,7 @@ final class TranscribeStreamingTests: XCTestCase {
         let chunkSize = 4096
         let audioDataSize = audioData.count
 
-        let client = try TranscribeStreamingClient(region: "us-west-2")
+        let client = try await TranscribeStreamingClient(region: "us-west-2")
 
         let audioStream = AsyncThrowingStream<TranscribeStreamingClientTypes.AudioStream, Error> { continuation in
             Task {

--- a/Sources/Core/AWSClientRuntime/Auth/Credentials+CRT.swift
+++ b/Sources/Core/AWSClientRuntime/Auth/Credentials+CRT.swift
@@ -18,7 +18,7 @@ public extension Credentials {
         guard let accessKey = crtCredentials.getAccessKey() else {
             throw ClientError.authError("Failed to get access key.")
         }
-        
+
         guard let secret = crtCredentials.getSecret() else {
             throw ClientError.authError("Failed to get secret.")
         }

--- a/Sources/Core/AWSClientRuntime/Auth/Credentials.swift
+++ b/Sources/Core/AWSClientRuntime/Auth/Credentials.swift
@@ -17,7 +17,7 @@ public struct Credentials {
     let secret: String
     let expirationTimeout: Date?
     let sessionToken: String?
-    
+
     /// Creates credentials with the specified keys and optionally an expiration and session token.
     ///
     /// - Parameters:

--- a/Sources/Core/AWSClientRuntime/Auth/CredentialsProvider/CredentialsProvider+CRT.swift
+++ b/Sources/Core/AWSClientRuntime/Auth/CredentialsProvider/CredentialsProvider+CRT.swift
@@ -13,11 +13,11 @@ typealias CRTCredentialsProvider = AwsCommonRuntimeKit.CredentialsProvider
 /// A credentials provider that adapts a CRT credentials provider to `CredentialsProviding`
 struct CRTCredentialsProviderAdapter: CredentialsProviding {
     let crtCredentialsProvider: CRTCredentialsProviding
-    
+
     init(_ crtCredentialsProvider: CRTCredentialsProviding) {
         self.crtCredentialsProvider = crtCredentialsProvider
     }
-    
+
     func getCredentials() async throws -> Credentials {
         let crtCredentials = try await crtCredentialsProvider.getCredentials()
         return try .init(crtCredentials: crtCredentials)

--- a/Sources/Core/AWSClientRuntime/Auth/CredentialsProvider/CredentialsProvider+Factory.swift
+++ b/Sources/Core/AWSClientRuntime/Auth/CredentialsProvider/CredentialsProvider+Factory.swift
@@ -77,7 +77,7 @@ public extension CredentialsProvider {
         public let configFilePath: String?
         /// The path to the shared credentials file to use. If not provided it will be resolved internally via the `AWS_SHARED_CREDENTIALS_FILE` environment variable or defaulted `~/.aws/credentials` if not configured.
         public let credentialsFilePath: String?
-        
+
         /// Creates options to configure the profile credentials provider
         ///
         /// - Parameters:
@@ -94,7 +94,7 @@ public extension CredentialsProvider {
             self.credentialsFilePath = credentialsFilePath
         }
     }
-    
+
     /// A credentials provider that gets credentials from a profile in `~/.aws/config` or the shared credentials file `~/.aws/credentials`.
     /// The locations of these files are configurable via environment variables or via `ProfileOptions`.
     ///
@@ -135,7 +135,7 @@ public extension CredentialsProvider {
                 configFilePath: options.configFilePath,
                 credentialsFilePath: options.credentialsFilePath
             )
-            
+
             return try CRTCredentialsProvider(source: .profile(
                 bootstrap: bootstrap,
                 fileBasedConfiguration: fileBasedConfiguration,
@@ -152,18 +152,18 @@ public extension CredentialsProvider {
     struct STSOptions {
         /// The underlying credentials provider to be used to sign the requests made to STS
         public let credentialsProvider: CredentialsProvider
-        
+
         /// The ARN of the target role to assume, e.g. `arn:aws:iam:123456789:role/example`
         public let roleArn: String
-        
+
         /// The name to associate with the session. This is used to uniquely identify a session when the same role is assumed by different principals
         /// or for different reasons. In cross-account scenarios, the session name is visible to, and can be logged by the account that owns the role.
         /// The role session name is also in the ARN of the assumed role principal.
         public let sessionName: String
-        
+
         /// The expiry duration of the STS credentials. Defaults to 15 minutes if not set.
         public let durationSeconds: TimeInterval
-        
+
         /// Creates options to connfigure a STS assume role credential provider
         ///
         /// - Parameters:
@@ -183,7 +183,7 @@ public extension CredentialsProvider {
             self.durationSeconds = durationSeconds
         }
     }
-    
+
     /// Creates a credential provider that uses another provider to assume a role from the AWS Security Token Service (STS).
     ///
     /// When asked to provide credentials, this provider will first invoke the inner credentials provider to get AWS credentials for STS.
@@ -198,9 +198,9 @@ public extension CredentialsProvider {
         .makeWithCRTCredentialsProvider(identifier: "STS Assume Role") { configuration in
             var provider = options.credentialsProvider
             try await provider.configure(configuration)
-            
+
             let adapter = CredentialsProviderCRTAdapter(credentialsProvider: provider)
-                        
+
             return try CRTCredentialsProvider(source: .sts(
                 bootstrap: bootstrap,
                 tlsContext: tlsContext,
@@ -222,7 +222,7 @@ public extension CredentialsProvider {
         public let configFilePath: String?
         /// The path to the shared credentials file to use. If not provided it will be resolved internally via the `AWS_SHARED_CREDENTIALS_FILE` environment variable or defaulted `~/.aws/credentials` if not configured.
         public let credentialsFilePath: String?
-        
+
         /// Creates options to configure a STS Web Identity credential provider
         ///
         /// - Parameters:
@@ -236,7 +236,7 @@ public extension CredentialsProvider {
             self.credentialsFilePath = credentialsFilePath
         }
     }
-    
+
     /// Creates a credential provider that exchanges a Web Identity Token for credentials from the AWS Security Token Service (STS).
     ///
     /// It depends on the following values sourced from either environment variables or the configuration file"
@@ -256,7 +256,7 @@ public extension CredentialsProvider {
                 configFilePath: options.configFilePath,
                 credentialsFilePath: options.credentialsFilePath
             )
-            
+
             return try CRTCredentialsProvider(source: .stsWebIdentity(
                 bootstrap: bootstrap,
                 tlsContext: tlsContext,
@@ -270,7 +270,7 @@ public extension CredentialsProvider {
 // MARK: - Container
 
 // TODO uncomment when CRT fixes https://github.com/awslabs/aws-crt-swift/issues/174
-//public extension CredentialsProvider {
+// public extension CredentialsProvider {
 //
 //    struct ContainerOptions {
 //        public let pathAndQuery: String
@@ -320,7 +320,7 @@ public extension CredentialsProvider {
 //            ))
 //        }
 //    }
-//}
+// }
 
 // MARK: - Cached
 
@@ -329,11 +329,11 @@ public extension CredentialsProvider {
     struct CachedOptions {
         /// The source credentials provider to get the credentials.
         public let source: CredentialsProvider
-        
+
         /// The number of seconds that must pass before new credentials will be fetched again.
         /// If the credentials are queried during this time period, then the cached credentials are returned.
         public let refreshTime: TimeInterval
-        
+
         /// Creates options to configure  a cached credentials provider
         ///
         /// - Parameters:
@@ -359,9 +359,9 @@ public extension CredentialsProvider {
         .makeWithCRTCredentialsProvider(identifier: "Cached") { configuration in
             var provider = options.source
             try await provider.configure(configuration)
-            
+
             let adapter = CredentialsProviderCRTAdapter(credentialsProvider: provider)
-            
+
             return try CRTCredentialsProvider(source: .cached(
                 source: .init(provider: adapter),
                 refreshTime: options.refreshTime
@@ -389,7 +389,7 @@ public extension CredentialsProvider {
     static func fromDefaultChain() throws -> CredentialsProvider {
         .makeWithCRTCredentialsProvider(identifier: "Default Chain") { dependencies in
             let fileBasedConfiguration = try await dependencies.fileBasedConfigurationStore._fileBasedConfiguration()
-            
+
             return try CRTCredentialsProvider(source: .defaultChain(
                 bootstrap: bootstrap,
                 fileBasedConfiguration: fileBasedConfiguration

--- a/Sources/Core/AWSClientRuntime/Auth/CredentialsProvider/CredentialsProvider.swift
+++ b/Sources/Core/AWSClientRuntime/Auth/CredentialsProvider/CredentialsProvider.swift
@@ -14,21 +14,21 @@ public typealias AWSCredentialsProvider = CredentialsProvider
 /// Create instances using its static functions.
 public struct CredentialsProvider {
     @_spi(Internal)
-    public struct Configuration  {
+    public struct Configuration {
         public let fileBasedConfigurationStore: CRTFiledBasedConfigurationStore
-        
+
         public init(fileBasedConfigurationStore: CRTFiledBasedConfigurationStore) {
             self.fileBasedConfigurationStore = fileBasedConfigurationStore
         }
     }
-    
+
     private var configuredProvider: CredentialsProviding?
     private var configureProvider: ((Configuration) async throws -> CredentialsProviding)?
-    
+
     /// A string that identifies the credential provider
     /// This is useful for debugging and tests to verify type of credentials provider
     let identifier: String
-        
+
     init(
         identifier: String,
         _ configureProvider: @escaping (Configuration) async throws -> CredentialsProviding
@@ -36,7 +36,7 @@ public struct CredentialsProvider {
         self.identifier = identifier
         self.configureProvider = configureProvider
     }
-    
+
     @_spi(Internal)
     mutating public func configure(_ configuration: Configuration) async throws {
         guard let configureProvider = self.configureProvider else {
@@ -58,7 +58,7 @@ extension CredentialsProvider: CredentialsProviding {
             `client.config.credentialsProvider`
             """)
         }
-        
+
         return try await configuredProvider.getCredentials()
     }
 }

--- a/Sources/Core/AWSClientRuntime/FileBasedConfiguration/FileBasedConfiguration.swift
+++ b/Sources/Core/AWSClientRuntime/FileBasedConfiguration/FileBasedConfiguration.swift
@@ -65,7 +65,7 @@ public extension FileBasedConfigurationPropertyProviding {
             return nil
         }
     }
-    
+
     func subproperties(for name: FileBasedConfigurationKey) -> FileBasedConfigurationSubsection? {
         guard let value = property(for: name) else { return nil }
         switch value {

--- a/Sources/Core/AWSClientRuntime/FileBasedConfiguration/FileBasedConfigurationKeys.swift
+++ b/Sources/Core/AWSClientRuntime/FileBasedConfiguration/FileBasedConfigurationKeys.swift
@@ -10,11 +10,11 @@ public struct FileBasedConfigurationKey: RawRepresentable, ExpressibleByStringLi
     public typealias RawValue = String
     public typealias StringLiteralType = String
     public var rawValue: String
-    
+
     public init(rawValue: String) {
         self.rawValue = rawValue
     }
-    
+
     public init(stringLiteral value: String) {
         self.rawValue = value
     }

--- a/Sources/Core/AWSClientRuntime/FileBasedConfiguration/Store/FileBasedConfiguratioStore+CRT.swift
+++ b/Sources/Core/AWSClientRuntime/FileBasedConfiguration/Store/FileBasedConfiguratioStore+CRT.swift
@@ -20,10 +20,10 @@ public extension CRTFiledBasedConfigurationStore {
                     credentialsFilePath: sources.credentialPath
                 )
             }
-            
+
             return try await task.value
         }
-        
+
         self.init(
             cache: cache,
             defaultConfigFilePath: try CRTFileBasedConfiguration.resolveConfigPath(sourceType: .config),

--- a/Sources/Core/AWSClientRuntime/FileBasedConfiguration/Store/FileBasedConfigurationStore.swift
+++ b/Sources/Core/AWSClientRuntime/FileBasedConfiguration/Store/FileBasedConfigurationStore.swift
@@ -11,11 +11,11 @@ import Foundation
 public struct FileBasedConfigurationStore<T: FileBasedConfiguration> {
     typealias Cache = FunctionCache<FileBasedConfigurationSources, T>
     private let cache: Cache
-    
+
     public let defaultConfigFilePath: String
-    
+
     public let defaultCredentialsFilePath: String
-    
+
     init(
         cache: Cache,
         defaultConfigFilePath: String,
@@ -25,7 +25,7 @@ public struct FileBasedConfigurationStore<T: FileBasedConfiguration> {
         self.defaultConfigFilePath = defaultConfigFilePath
         self.defaultCredentialsFilePath = defaultCredentialsFilePath
     }
-    
+
     public func _fileBasedConfiguration(
         configFilePath: String? = nil,
         credentialsFilePath: String? = nil

--- a/Sources/Core/AWSClientRuntime/Regions/ProfileRegionProvider.swift
+++ b/Sources/Core/AWSClientRuntime/Regions/ProfileRegionProvider.swift
@@ -34,12 +34,12 @@ struct ProfileRegionProvider: RegionProvider {
             logger.debug("Failed to resolve region from configuration file. No configuration file found.")
             return nil
         }
-        
+
         guard let profile = configuration.section(for: profileName) else {
             logger.debug("Failed to resolve region from configuration file. No profile with name: \(profileName)")
             return nil
         }
-        
+
         return profile.string(for: .region)
     }
 }

--- a/Sources/Core/AWSClientRuntime/Utils/Cache/FunctionCache.swift
+++ b/Sources/Core/AWSClientRuntime/Utils/Cache/FunctionCache.swift
@@ -13,7 +13,7 @@ import Foundation
 actor FunctionCache<Input: Hashable, Output> {
     typealias Function = (Input) async throws -> Output
     private let f: Function
-    
+
     // Future Improvement:
     // Allow for the cache type and instance to be injected in,
     // this would allow composers to specify the type of backing cache that they need.
@@ -21,7 +21,7 @@ actor FunctionCache<Input: Hashable, Output> {
     // resources when the system is low on memory.
     private var cache = [Input: Output]()
     private var activeTasks = [Input: Task<Output, Error>]()
-    
+
     /// Creates a function cache that will store the outputs of the provided function.
     init(_ f: @escaping Function) {
         self.f = f
@@ -43,13 +43,13 @@ extension FunctionCache {
             // We have an existing task scheduled for the input, so await its value
             return try await existingTask.value
         }
-        
+
         // Check if we have an output cached for the input
         if let existingOutput = cache[input] {
             // We have an output cached for the input, so return that
             return existingOutput
         }
-        
+
         // Create a task that handles performing the work
         // It will execute the function and store the output in the cache.
         let task = Task<Output, Error> {
@@ -68,12 +68,12 @@ extension FunctionCache {
                 throw error
             }
         }
-        
+
         // Keep track of the task
         // This allows us to use this same task if another call is made with the same input
         // before the function finishes executing.
         activeTasks[input] = task
-        
+
         // Await the task and return it's value
         return try await task.value
     }

--- a/Tests/Core/AWSClientRuntimeTests/EventStream/AWSMessageEncoderStreamTests.swift
+++ b/Tests/Core/AWSClientRuntimeTests/EventStream/AWSMessageEncoderStreamTests.swift
@@ -23,60 +23,65 @@ final class AWSMessageEncoderStreamTests: XCTestCase {
     let serviceName = "test"
     let credentials = AWSCredentials(accessKey: "fake access key", secret: "fake secret key")
     let messageEncoder = AWSEventStream.AWSMessageEncoder()
-
+    
     func testIterator_EndMessageSent() async throws {
-        let context = HttpContextBuilder().withSigningRegion(value: region)
+        let context = HttpContextBuilder()
+            .withSigningRegion(value: region)
             .withSigningName(value: serviceName)
             .withRequestSignature(value: requestSignature)
             .withCredentialsProvider(value: MyCustomCredentialsProvider(credentials: credentials))
             .build()
-
+        
         let messageSigner = AWSEventStream.AWSMessageSigner(encoder: messageEncoder) {
-            try await context.makeEventStreamSigningConfig()
+            return try await context.makeEventStreamSigningConfig()
         } requestSignature: {
             return context.getRequestSignature()
         }
-
-        let sut = EventStream.DefaultMessageEncoderStream(stream: baseStream,
-                                                         messageEncoder: messageEncoder,
-                                                         requestEncoder: JSONEncoder(),
-                                                         messageSinger: messageSigner)
-
+        
+        let sut = EventStream.DefaultMessageEncoderStream(
+            stream: baseStream,
+            messageEncoder: messageEncoder,
+            requestEncoder: JSONEncoder(),
+            messageSinger: messageSigner
+        )
+        
         var actual: [Data] = []
         for try await data in sut {
             actual.append(data)
         }
-
+        
         XCTAssertEqual(4, actual.count)
     }
-
+    
     func testReadAsync() async throws {
         let context = HttpContextBuilder().withSigningRegion(value: region)
             .withSigningName(value: serviceName)
             .withRequestSignature(value: requestSignature)
             .withCredentialsProvider(value: MyCustomCredentialsProvider(credentials: credentials))
             .build()
-
+        
         let messageSigner = AWSEventStream.AWSMessageSigner(encoder: messageEncoder) {
-            try await context.makeEventStreamSigningConfig()
+            return try await context.makeEventStreamSigningConfig()
         } requestSignature: {
             return context.getRequestSignature()
         }
-
-        let sut = EventStream.DefaultMessageEncoderStream(stream: baseStream,
-                                                          messageEncoder: messageEncoder,
-                                                          requestEncoder: JSONEncoder(),
-                                                          messageSinger: messageSigner)
-
+        
+        let sut = EventStream.DefaultMessageEncoderStream(
+            stream: baseStream,
+            messageEncoder: messageEncoder,
+            requestEncoder: JSONEncoder(),
+            messageSinger: messageSigner
+        )
+        
         let read1 = try await sut.readAsync(upToCount: 100)
         XCTAssertEqual(100, read1!.count)
-
+        
         let read2 = try await sut.readAsync(upToCount: 200)
         XCTAssertEqual(200, read2!.count)
-
+        
         let read3 = try await sut.readAsync(upToCount: 500)
         XCTAssertEqual(249, read3!.count)
-
+        
         let read4 = try await sut.readAsync(upToCount: 500)
         XCTAssertNil(read4)
     }

--- a/Tests/Core/AWSClientRuntimeTests/EventStream/AWSMessageEncoderStreamTests.swift
+++ b/Tests/Core/AWSClientRuntimeTests/EventStream/AWSMessageEncoderStreamTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+import AwsCommonRuntimeKit
 import ClientRuntime
 @testable import AWSClientRuntime
 
@@ -23,6 +24,12 @@ final class AWSMessageEncoderStreamTests: XCTestCase {
     let serviceName = "test"
     let credentials = AWSCredentials(accessKey: "fake access key", secret: "fake secret key")
     let messageEncoder = AWSEventStream.AWSMessageEncoder()
+    
+    override class func setUp() {
+        AwsCommonRuntimeKit.CommonRuntimeKit.initialize()
+    }
+    
+    // MARK: - Tests
     
     func testIterator_EndMessageSent() async throws {
         let context = HttpContextBuilder()

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/EventStreamTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/EventStreamTests.kt
@@ -228,8 +228,8 @@ extension EventStreamTestClient: EventStreamTestClientProtocol {
         operation.finalizeStep.intercept(position: .after, middleware: ClientRuntime.RetryerMiddleware<TestStreamOpOutputResponse, TestStreamOpOutputError>(retryer: config.retryer))
         let sigv4Config = AWSClientRuntime.SigV4Config(unsignedBody: false, signingAlgorithm: .sigv4)
         operation.finalizeStep.intercept(position: .before, middleware: AWSClientRuntime.SigV4Middleware<TestStreamOpOutputResponse, TestStreamOpOutputError>(config: sigv4Config))
-        operation.deserializeStep.intercept(position: .before, middleware: ClientRuntime.LoggerMiddleware<TestStreamOpOutputResponse, TestStreamOpOutputError>(clientLogMode: config.clientLogMode))
         operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.DeserializeMiddleware<TestStreamOpOutputResponse, TestStreamOpOutputError>())
+        operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.LoggerMiddleware<TestStreamOpOutputResponse, TestStreamOpOutputError>(clientLogMode: config.clientLogMode))
         let result = try await operation.handleMiddleware(context: context, input: input, next: client.getHandler())
         return result
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR is the corresponding aws-sdk-swift PR for https://github.com/awslabs/smithy-swift/pull/545 which forces http2 for bidirectional event streams. 

## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/870

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.