### PR TITLE
fix: Updates `prepareRelease` command of CLI

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/PrepareRelease.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/PrepareRelease.swift
@@ -76,6 +76,7 @@ struct PrepareRelease {
             previousVersion: previousVersion,
             sourceCodeArtifactId: sourceCodeArtifactId
         )
+        try gitStatus()
     }
     
     // MARK: - Helpers
@@ -142,7 +143,7 @@ struct PrepareRelease {
     ///
     /// - Parameter newVersion: The version to use in the commit message
     func commitChanges(_ newVersion: Version) throws {
-        try _run(Process.git.commit("Updates version to \(newVersion)"))
+        try _run(Process.git.commit("chore: Updates version to \(newVersion)"))
     }
     
     /// Tags the repository with the provided version
@@ -150,6 +151,11 @@ struct PrepareRelease {
     /// - Parameter newVersion: The version to use for the tag
     func tagVersion(_ newVersion: Version) throws {
         try _run(Process.git.tag(newVersion, "Release \(newVersion)"))
+    }
+    
+    /// Run git status
+    func gitStatus() throws {
+        try _run(Process.git.status())
     }
     
     /// Generates the release manifest and saves it to `release_manifest.json`
@@ -164,7 +170,7 @@ struct PrepareRelease {
         previousVersion: Version,
         sourceCodeArtifactId: String
     ) throws {
-        let commits = try Process.git.listOfCommitsBetween("\(newVersion)", "\(previousVersion)")
+        let commits = try Process.git.listOfCommitsBetween("HEAD", "\(previousVersion)")
         
         let releaseNotes = ReleaseNotesBuilder(
             previousVersion: previousVersion,

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/TestAWSSDK.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/TestAWSSDK.swift
@@ -60,7 +60,6 @@ struct TestAWSSDK {
             log("Testing Package.swift...")
             let task = Process.swift.test()
             try _run(task)
-            task.waitUntilExit()
             return
         }
 
@@ -142,7 +141,6 @@ struct TestAWSSDK {
         )
         let task = Process.swift.test()
         try _run(task)
-        task.waitUntilExit()
     
         // Move the file back when we are finished
         try FileManager.default.moveItem(

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Utils/Process+Git.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Utils/Process+Git.swift
@@ -16,6 +16,11 @@ extension Process {
             Process(["git"] + args)
         }
         
+        /// Returns a process for executing `git status`
+        func status() -> Process {
+            gitProcess(["status"])
+        }
+        
         /// Returns a process for executing `git diff <a>..<b> --quiet`
         /// This is used for determining if `<a>` is different from `<b>` and therefore
         func diff(_ a: String, _ b: String) -> Process {
@@ -68,7 +73,6 @@ extension Process.Git {
     func diffHasChanges(_ a: String, _ b: String) throws -> Bool {
         let task = diff(a, b)
         try _run(task)
-        task.waitUntilExit()
         return task.terminationStatus != 0
     }
     
@@ -76,11 +80,9 @@ extension Process.Git {
     func hasLocalChanges() throws -> Bool {
         let updateIndexTask = updateIndex()
         try _run(updateIndexTask)
-        updateIndexTask.waitUntilExit()
         
         let diffIndexTask = diffIndex()
         try _run(diffIndexTask)
-        diffIndexTask.waitUntilExit()
         return diffIndexTask.terminationStatus != 0
     }
     

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Utils/Process+Utils.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Utils/Process+Utils.swift
@@ -72,6 +72,7 @@ struct ProcessRunner {
     static let standard = ProcessRunner { process in
         log("Running process: \(process.commandString)")
         try process.run()
+        process.waitUntilExit()
     }
     
     #if DEBUG

--- a/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Commands/PrepareReleaseTests.swift
+++ b/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Commands/PrepareReleaseTests.swift
@@ -45,11 +45,12 @@ class PrepareReleaseTests: CLITestCase {
         XCTAssertEqual(releaseManifest.name, "\(newVersion)")
         XCTAssertEqual(releaseManifest.tagName, "\(newVersion)")
         
-        XCTAssertEqual(commands.count, 4)
+        XCTAssertEqual(commands.count, 5)
         XCTAssertTrue(commands[0].contains("git add"))
         XCTAssertTrue(commands[1].contains("git commit"))
         XCTAssertTrue(commands[2].contains("git tag"))
         XCTAssertTrue(commands[3].contains("git log"))
+        XCTAssertTrue(commands[4].contains("git status"))
     }
     
     func testRunBailsEarlyIfThereAreNoChanges() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR updates the `prepareRelease` command of CLI
- Wait for every task to finish executing. 
- Updates git commit message
- Uses HEAD instead of new tag when generating commits for release notes
- Adds a gitStatus call for logs

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.