### PR TITLE
fix: Stages packageDependencies.plist when preparing an sdk release

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/PrepareRelease.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/PrepareRelease.swift
@@ -129,6 +129,7 @@ struct PrepareRelease {
             files = [
                 "Package.swift",
                 "Package.version",
+                "packageDependencies.plist",
                 "Sources/Services",
                 "Tests/Services"
             ]

--- a/packageDependencies.plist
+++ b/packageDependencies.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>clientRuntimeVersion</key>
-	<string>0.16.0</string>
+	<string>0.17.0</string>
 	<key>awsCRTSwiftVersion</key>
 	<string>0.9.0</string>
 	<key>clientRuntimeBranch</key>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The packageDependencies.plist file wasn't commited during the last release. 
This PR fixes that issue by adding it to the list of files to stage when preparing a sdk release.
Additionally, this PR updates the versions to the correct value.

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.