### PR TITLE
feat: Adds command to CLI to generate package.swift with integration tests

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
@@ -103,3 +103,15 @@ func addServiceTarget(_ name: String) {
         )
     ]
 }
+
+func addIntegrationTestTarget(_ name: String) {
+    let integrationTestName = "\(name)IntegrationTests"
+    package.targets += [
+        .testTarget(
+            name: integrationTestName,
+            dependencies: [.crt, .clientRuntime, .awsClientRuntime, .byName(name: name), .smithyTestUtils],
+            path: "./IntegrationTests/Services/\(integrationTestName)",
+            resources: [.process("Resources")]
+        )
+    ]
+}

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Utils/FileManager+Utils.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Utils/FileManager+Utils.swift
@@ -35,4 +35,14 @@ extension FileManager {
             .sorted()
             .filter { !$0.hasPrefix(".") }
     }
+
+    /// Returns the list of integration tests.
+    ///
+    /// - Returns: The list of integration tests.
+    func integrationTests() throws -> [String] {
+        try FileManager.default
+            .contentsOfDirectory(atPath: "IntegrationTests/Services")
+            .sorted()
+            .filter { !$0.hasPrefix(".") }
+    }
 }

--- a/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Commands/GeneratePackageManifestTests.swift
+++ b/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Commands/GeneratePackageManifestTests.swift
@@ -48,7 +48,7 @@ class GeneratePackageManifestTests: CLITestCase {
         createServiceFolders(services)
         
         let subject = GeneratePackageManifest.mock(buildPackageManifest: { _clientRuntimeVersion, _crtVersion, services in
-            "\(_clientRuntimeVersion)-\(_crtVersion)-\(services.joined(separator: "-"))"
+            "\(_clientRuntimeVersion)-\(_crtVersion)-\(services.map(\.name).joined(separator: "-"))"
         })
         try! subject.run()
         let result = try! String(contentsOfFile: "Package.swift", encoding: .utf8)
@@ -110,6 +110,7 @@ extension GeneratePackageManifest {
         clientRuntimeVersion: Version? = nil,
         crtVersion: Version? = nil,
         services: [String]? = nil,
+        includesIntegrationTests: Bool = false,
         buildPackageManifest: @escaping BuildPackageManifest = { (_,_,_) throws -> String in "" }
     ) -> GeneratePackageManifest {
         GeneratePackageManifest(
@@ -118,6 +119,7 @@ extension GeneratePackageManifest {
             clientRuntimeVersion: clientRuntimeVersion,
             crtVersion: crtVersion,
             services: services,
+            includesIntegrationTests: includesIntegrationTests,
             buildPackageManifest: buildPackageManifest
         )
     }

--- a/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Commands/PrepareReleaseTests.swift
+++ b/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Commands/PrepareReleaseTests.swift
@@ -104,7 +104,7 @@ class PrepareReleaseTests: CLITestCase {
         ProcessRunner.testRunner = runner
         let subject = PrepareRelease.mock(repoType: .awsSdkSwift)
         try! subject.stageFiles()
-        XCTAssertTrue(command.hasSuffix("git add Package.swift Package.version Sources/Services Tests/Services"))
+        XCTAssertTrue(command.hasSuffix("git add Package.swift Package.version packageDependencies.plist Sources/Services Tests/Services"))
     }
     
     func testStageFilesForSmithySwift() {

--- a/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Models/PackageManifestBuilderTests.swift
+++ b/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Models/PackageManifestBuilderTests.swift
@@ -29,13 +29,23 @@ class PackageManifestBuilderTests: XCTestCase {
     ]
     
     serviceTargets.forEach(addServiceTarget)
+
+    let servicesWithIntegrationTests: [String] = [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E",
+    ]
+
+    servicesWithIntegrationTests.forEach(addIntegrationTestTarget)
     """
     
     func testBuild() {
         let subjeect = PackageManifestBuilder(
             clientRuntimeVersion: .init("1.2.3"),
             crtVersion: .init("4.5.6"),
-            services: ["A","B","C","D","E"],
+            services: ["A","B","C","D","E"].map { PackageManifestBuilder.Service(name: $0, includeIntegrationTests: true) },
             basePackageContents: { "<contents of base package>" }
         )
         let result = try! subjeect.build()

--- a/Package.swift
+++ b/Package.swift
@@ -104,6 +104,18 @@ func addServiceTarget(_ name: String) {
     ]
 }
 
+func addIntegrationTestTarget(_ name: String) {
+    let integrationTestName = "\(name)IntegrationTests"
+    package.targets += [
+        .testTarget(
+            name: integrationTestName,
+            dependencies: [.crt, .clientRuntime, .awsClientRuntime, .byName(name: name), .smithyTestUtils],
+            path: "./IntegrationTests/Services/\(integrationTestName)",
+            resources: [.process("Resources")]
+        )
+    ]
+}
+
 
 // MARK: - Generated
 
@@ -458,3 +470,8 @@ let serviceTargets: [String] = [
 ]
 
 serviceTargets.forEach(addServiceTarget)
+
+let servicesWithIntegrationTests: [String] = [
+]
+
+servicesWithIntegrationTests.forEach(addIntegrationTestTarget)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Example usage:
`swift run AWSSDKSwiftCLI generate-package-manifest ../ --services AWSS3 --includes-integration-tests`

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.