### PR TITLE
fix: Fix streaming for AWS Kinesis

### DIFF
--- a/.github/workflows/codegen-build-test.yml
+++ b/.github/workflows/codegen-build-test.yml
@@ -16,6 +16,7 @@ env:
   AWS_SDK_SWIFT_CI_DIR: /Users/runner/work/aws-sdk-swift/aws-sdk-swift
   AWS_CRT_SWIFT_CI_DIR: /Users/runner/work/aws-sdk-swift/aws-sdk-swift/target/build/deps/aws-crt-swift
   SMITHY_SWIFT_CI_DIR: /Users/runner/work/aws-sdk-swift/aws-sdk-swift/target/build/deps/smithy-swift
+  AWS_SWIFT_SDK_USE_LOCAL_DEPS: 1
 
 jobs:
   codegen-build-test:
@@ -41,9 +42,11 @@ jobs:
           AWS_CRT_SWIFT_CI_DIR="${{ env.AWS_CRT_SWIFT_CI_DIR }}" AWS_SDK_SWIFT_CI_DIR="${{ env.AWS_SDK_SWIFT_CI_DIR }}" SMITHY_SWIFT_CI_DIR="${{ env.SMITHY_SWIFT_CI_DIR }}" ./builder.pyz build -p ${{ env.PACKAGE_NAME }}
           ./gradlew -p codegen/sdk-codegen build
           ./gradlew -p codegen/sdk-codegen stageSdks
-          ./scripts/mergeModels.sh release
-          ./scripts/generatePackageSwift.swift > Package.swift
-          cat Package.swift
           ./gradlew --stop
+          ./scripts/mergeModels.sh release
+          cd AWSSDKSwiftCLI
+          swift run AWSSDKSwiftCLI generate-package-manifest ../
+          cd ..
+          cat Package.swift
           swift build --build-tests
           swift test --skip-build --parallel

--- a/.github/workflows/codegen-build-test.yml
+++ b/.github/workflows/codegen-build-test.yml
@@ -43,7 +43,7 @@ jobs:
           ./gradlew -p codegen/sdk-codegen build
           ./gradlew -p codegen/sdk-codegen stageSdks
           ./gradlew --stop
-          ./scripts/mergeModels.sh release
+          ./scripts/mergeModels.sh Sources/Services
           cd AWSSDKSwiftCLI
           swift run AWSSDKSwiftCLI generate-package-manifest ../
           cd ..

--- a/.github/workflows/codegen-build-test.yml
+++ b/.github/workflows/codegen-build-test.yml
@@ -40,6 +40,7 @@ jobs:
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
           chmod a+x builder.pyz
           AWS_CRT_SWIFT_CI_DIR="${{ env.AWS_CRT_SWIFT_CI_DIR }}" AWS_SDK_SWIFT_CI_DIR="${{ env.AWS_SDK_SWIFT_CI_DIR }}" SMITHY_SWIFT_CI_DIR="${{ env.SMITHY_SWIFT_CI_DIR }}" ./builder.pyz build -p ${{ env.PACKAGE_NAME }}
+          ln -s $SMITHY_SWIFT_CI_DIR ../smithy-swift
           ./gradlew -p codegen/sdk-codegen build
           ./gradlew -p codegen/sdk-codegen stageSdks
           ./gradlew --stop

--- a/IntegrationTests/Services/AWSKinesisIntegrationTests/KinesisTests.swift
+++ b/IntegrationTests/Services/AWSKinesisIntegrationTests/KinesisTests.swift
@@ -1,0 +1,104 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import AWSKinesis
+import ClientRuntime
+
+class KinesisTests: XCTestCase {
+
+    func test_kinesisIntegrationTest() async throws {
+        // Performs a test against "live" AWS Kinesis to ensure that the `subscribeToShard` event streaming operation
+        // operates as expected.  Test should take ~20-30 seconds to complete.
+        //
+        // Streaming is over HTTP/1.1.  Streaming is unidirectional (in the response.)
+        // AWS Kinesis uses awsJson1_1 protocol.
+        //
+        // Client must have AWS credentials set that allow access to the Kinesis service.
+        // Resources will be cleaned up before the test concludes, pass or fail, unless the test crashes.
+
+        let streamName = UUID().uuidString
+        let client = try KinesisClient(region: "us-west-2")
+
+        do {
+            // Create stream named `streamName`, wait until it is fully created, and get its description
+            let createStreamInput = CreateStreamInput(shardCount: 1, streamModeDetails: KinesisClientTypes.StreamModeDetails(streamMode: .provisioned), streamName: streamName)
+            let _ = try await client.createStream(input: createStreamInput)
+            let describeStreamInput = DescribeStreamInput(streamName: streamName)
+            let describeStreamOutput = try await client.waitUntilStreamExists(options: WaiterOptions(maxWaitTime: 30.0), input: describeStreamInput)
+            guard case .success(let stream) = describeStreamOutput.result else { throw KinesisTestError("could not describe stream") }
+            let streamARN = stream.streamDescription?.streamARN
+
+            // Make a set of 10 records, add them to the stream
+            var recordStrings = (1...10).map { _ in UUID().uuidString }
+            for record in recordStrings {
+                let putRecordInput = PutRecordInput(data: record.data(using: .utf8), explicitHashKey: nil, partitionKey: "Test", sequenceNumberForOrdering: nil, streamName: streamName)
+                let _ = try await client.putRecord(input: putRecordInput)
+            }
+
+            // Get the first (only) shard in the data stream
+            let listShardsInput = ListShardsInput(streamName: streamName)
+            let shardList = try await client.listShards(input: listShardsInput)
+            let shard = shardList.shards?.first!
+
+            // Create a consumer for the shard
+            let consumerName = UUID().uuidString
+            let consumerInput = RegisterStreamConsumerInput(consumerName: consumerName, streamARN: stream.streamDescription?.streamARN)
+            let consumer = try await client.registerStreamConsumer(input: consumerInput)
+            let consumerARN = consumer.consumer?.consumerARN
+
+            // Wait until the consumer becomes active
+            let describeConsumerInput = DescribeStreamConsumerInput(consumerARN: consumerARN, streamARN: streamARN)
+            var counter = 30
+            repeat {
+                try await Task<Never, Never>.sleep(nanoseconds: 1_000_000_000)
+                let out = try await client.describeStreamConsumer(input: describeConsumerInput)
+                if out.consumerDescription?.consumerStatus == .active { break }
+                counter -= 1
+                if counter < 0 { throw KinesisTestError("consumer timed out while waiting for active") }
+            } while true
+
+            // Create the subscription stream
+            let input = SubscribeToShardInput(consumerARN: consumerARN, shardId: shard?.shardId, startingPosition: KinesisClientTypes.StartingPosition(sequenceNumber: shard?.sequenceNumberRange?.startingSequenceNumber, type: .atSequenceNumber))
+            let output = try await client.subscribeToShard(input: input)
+
+            // Monitor the shard event stream
+            for try await event in output.eventStream! {
+                switch event {
+                case .subscribetoshardevent(let event):
+                    event.records?.forEach { record in
+                        let recordString = String(data: record.data ?? Data(), encoding: .utf8)
+                        recordStrings.removeAll { recordString == $0 }
+                    }
+                case .sdkUnknown(let message):
+                    print("Unknown event: \(message)")
+                }
+
+                // Once all the events have been received, stop streaming
+                if recordStrings.isEmpty { break }
+            }
+
+            // Clean up before ending test
+            await cleanUpKinesis(client: client, streamName: streamName)
+        } catch {
+            // If an error is thrown, clean up then rethrow error
+            // Test will fail when XCTest catches the error
+            await cleanUpKinesis(client: client, streamName: streamName)
+            throw error
+        }
+    }
+
+    private func cleanUpKinesis(client: KinesisClient, streamName: String) async {
+        let deleteStreamInput = DeleteStreamInput(enforceConsumerDeletion: true, streamName: streamName)
+        _ = try? await client.deleteStream(input: deleteStreamInput)
+    }
+
+    private struct KinesisTestError: Error {
+        let localizedDescription: String
+        init(_ localizedDescription: String) { self.localizedDescription = localizedDescription }
+    }
+}

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_0_ProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AwsJson1_0_ProtocolGenerator.kt
@@ -7,6 +7,8 @@ package software.amazon.smithy.aws.swift.codegen.awsjson
 
 import software.amazon.smithy.aws.swift.codegen.AWSHttpBindingProtocolGenerator
 import software.amazon.smithy.aws.swift.codegen.AWSHttpProtocolClientCustomizableFactory
+import software.amazon.smithy.aws.swift.codegen.MessageMarshallableGenerator
+import software.amazon.smithy.aws.swift.codegen.MessageUnmarshallableGenerator
 import software.amazon.smithy.aws.swift.codegen.middleware.AWSXAmzTargetMiddleware
 import software.amazon.smithy.aws.traits.protocols.AwsJson1_0Trait
 import software.amazon.smithy.model.shapes.OperationShape
@@ -50,5 +52,21 @@ open class AwsJson1_0_ProtocolGenerator : AWSHttpBindingProtocolGenerator() {
         val resolver = getProtocolHttpBindingResolver(ctx, defaultContentType)
         operationMiddleware.removeMiddleware(operation, MiddlewareStep.SERIALIZESTEP, "ContentTypeMiddleware")
         operationMiddleware.appendMiddleware(operation, ContentTypeMiddleware(ctx.model, ctx.symbolProvider, resolver.determineRequestContentType(operation), true))
+    }
+
+    override fun generateMessageMarshallable(ctx: ProtocolGenerator.GenerationContext) {
+        var streamingShapes = outputStreamingShapes(ctx)
+        val messageUnmarshallableGenerator = MessageUnmarshallableGenerator(ctx)
+        streamingShapes.forEach { streamingMember ->
+            messageUnmarshallableGenerator.render(streamingMember)
+        }
+    }
+
+    override fun generateMessageUnmarshallable(ctx: ProtocolGenerator.GenerationContext) {
+        val streamingShapes = inputStreamingShapes(ctx)
+        val messageMarshallableGenerator = MessageMarshallableGenerator(ctx, defaultContentType)
+        for (streamingShape in streamingShapes) {
+            messageMarshallableGenerator.render(streamingShape)
+        }
     }
 }

--- a/scripts/codegen.sh
+++ b/scripts/codegen.sh
@@ -25,7 +25,9 @@ fi
 ./scripts/mergeModels.sh Sources/Services
 
 # Regenerate the package manifest
-./scripts/generatePackageSwift.swift > Package.swift
+cd AWSSDKSwiftCLI
+swift run AWSSDKSwiftCLI generate-package-manifest ../
+cd ..
 
 # If on Mac, open Xcode to the newly refreshed SDK
 if [ -x "$(command -v osascript)" ]; then


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/973

## Description of changes
- `awsJson1_0` and `awsJson1_1` now generate marshallers/unmarshallers that don't "fast-fail" with `fatalError()`
- Added `AWSKinesisIntegrationTests` to ensure that Kinesis (and `awsJson`-based streaming more generally) work as intended

Also: Fixes to `Package.swift` generation & usage in the "Codegen, Build & Test" workflow

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.