### PR TITLE
chore: Update Github actions to latest versions, update Java

### DIFF
--- a/.github/workflows/codegen-build-test.yml
+++ b/.github/workflows/codegen-build-test.yml
@@ -4,6 +4,8 @@ name: Codegen, Build, and Test
 
 on:
   workflow_dispatch:
+  issue_comment:
+    types: [created, edited]
 
 env:
   BUILDER_VERSION: v0.8.19
@@ -20,6 +22,7 @@ env:
 
 jobs:
   codegen-build-test:
+    if: (github.event.issue.pull_request && contains(github.event.comment.body, '/codegen-build-test')) || github.event.workflow_dispatch
     runs-on: macos-13
     env:
       DEVELOPER_DIR: /Applications/Xcode_14.3.app/Contents/Developer

--- a/.github/workflows/codegen-build-test.yml
+++ b/.github/workflows/codegen-build-test.yml
@@ -27,6 +27,8 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_14.3.app/Contents/Developer
     steps:
+      - name: Log event
+        run: echo ${{ github.event }}
       - name: Checkout sources
         uses: actions/checkout@v3
       - name: Restore Cache

--- a/.github/workflows/codegen-build-test.yml
+++ b/.github/workflows/codegen-build-test.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   codegen-build-test:
-    if: (github.event.issue.pull_request && contains(github.event.comment.body, '/codegen-build-test')) || github.event.workflow_dispatch
+    if: (github.event.issue.pull_request && contains(github.event.comment.body, '/codegen-build-test')) || github.event_name == 'workflow_dispatch'
     runs-on: macos-13
     env:
       DEVELOPER_DIR: /Applications/Xcode_14.3.app/Contents/Developer

--- a/.github/workflows/codegen-build-test.yml
+++ b/.github/workflows/codegen-build-test.yml
@@ -26,7 +26,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - name: Restore Cache
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -35,10 +36,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Set Up Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
-          java-version: '17'
           distribution: 'corretto'
+          java-version: '17'
       - name: Tools Versions
         run: |
           which swiftc

--- a/.github/workflows/codegen-build-test.yml
+++ b/.github/workflows/codegen-build-test.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '18'
+          distribution: 'corretto'
       - name: Tools Versions
         run: |
           which swiftc

--- a/.github/workflows/codegen-build-test.yml
+++ b/.github/workflows/codegen-build-test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set Up Java
         uses: actions/setup-java@v2
         with:
-          java-version: '18'
+          java-version: '17'
           distribution: 'corretto'
       - name: Tools Versions
         run: |

--- a/.github/workflows/codegen-build-test.yml
+++ b/.github/workflows/codegen-build-test.yml
@@ -4,8 +4,6 @@ name: Codegen, Build, and Test
 
 on:
   workflow_dispatch:
-  issue_comment:
-    types: [created, edited]
 
 env:
   BUILDER_VERSION: v0.8.19
@@ -22,13 +20,10 @@ env:
 
 jobs:
   codegen-build-test:
-    if: (github.event.issue.pull_request && contains(github.event.comment.body, '/codegen-build-test')) || github.event_name == 'workflow_dispatch'
     runs-on: macos-13
     env:
       DEVELOPER_DIR: /Applications/Xcode_14.3.app/Contents/Developer
     steps:
-      - name: Log event
-        run: echo ${{ github.event }}
       - name: Checkout sources
         uses: actions/checkout@v3
       - name: Restore Cache
@@ -37,10 +32,10 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-      - name: Set Up Java
+      - name: Set up Java (Corretto 17)
         uses: actions/setup-java@v3
         with:
           distribution: 'corretto'

--- a/.github/workflows/codegen-build-test.yml
+++ b/.github/workflows/codegen-build-test.yml
@@ -25,8 +25,8 @@ jobs:
       DEVELOPER_DIR: /Applications/Xcode_14.3.app/Contents/Developer
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
-      - uses: actions/cache@v2
+        uses: actions/checkout@v3
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -34,9 +34,10 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-      - uses: actions/setup-java@v1
+      - name: Set Up Java
+        uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '18'
       - name: Tools Versions
         run: |
           which swiftc
@@ -44,6 +45,9 @@ jobs:
           echo
           which xcodebuild
           xcodebuild -version
+          echo
+          which java
+          java --version
       - name: Build and Test ${{ env.PACKAGE_NAME }}
         run: |
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"


### PR DESCRIPTION
## Description of changes

On the `codegen-build-test` workflow:
- Update the `actions/checkout`, `actions/cache`, and `actions/setup-java` Github actions to the latest versions
- Update the cache action config to latest recommendations for Gradle
- Installs Corretto 17 (latest Corretto LTS version) for its JVM, log its version with the other tools

Once we've used these updated actions a few times, I'll make this update on other GH workflows.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.