### PR TITLE
fix: Set GITHUB_HEAD_REF when running CRT builder script

### DIFF
--- a/.github/workflows/codegen-build-test-on-comment.yml
+++ b/.github/workflows/codegen-build-test-on-comment.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
-    
+
       - uses: actions/cache@v2
         with:
           path: |
@@ -60,7 +60,7 @@ jobs:
         run: |
           python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
           chmod a+x builder.pyz
-          ./builder.pyz build -p ${{ env.PACKAGE_NAME }}
+          GITHUB_HEAD_REF="${{ steps.comment_branch.outputs.head_ref }}" ./builder.pyz build -p ${{ env.PACKAGE_NAME }}
           ./gradlew -p codegen/sdk-codegen build
           ./gradlew -p codegen/sdk-codegen stageSdks
           ./gradlew --stop


### PR DESCRIPTION
## Description of changes
Set `GITHUB_HEAD_REF` when running the CRT builder script on a comment-initiated build.

This is where CRT builder looks for the branch to be checked out: https://github.com/awslabs/aws-crt-builder/blob/3aceaee71bd5d9ec5fba5c388f61b5c022a5159e/builder/core/env.py#L129

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.