### PR TITLE
fix: Report initial status on comment-generated workflow

### DIFF
--- a/.github/workflows/codegen-build-test-on-comment.yml
+++ b/.github/workflows/codegen-build-test-on-comment.yml
@@ -26,6 +26,14 @@ jobs:
       DEVELOPER_DIR: /Applications/Xcode_14.3.app/Contents/Developer
     if: github.event.issue.pull_request && contains(github.event.comment.body, '/test')
     steps:
+      - name: Set initial commit status as ${{ job.status }}
+        uses: myrotvorets/set-commit-status-action@master
+        if: always()
+        with:
+          sha: ${{ steps.comment-branch.outputs.head_sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
+
       - name: Get PR branch
         uses: xt0rted/pull-request-comment-branch@v2
         id: comment-branch
@@ -72,7 +80,7 @@ jobs:
           swift build --build-tests
           swift test --skip-build
           
-      - name: Set latest commit status as ${{ job.status }}
+      - name: Set final commit status as ${{ job.status }}
         uses: myrotvorets/set-commit-status-action@master
         if: always()
         with:


### PR DESCRIPTION
## Description of changes
Reports status (i.e. pending) immediately after starting a comment-initiated workflow.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.