### PR TITLE
feat: Add protocol test option to manifest generator

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/GeneratePackageManifest.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/GeneratePackageManifest.swift
@@ -34,7 +34,10 @@ struct GeneratePackageManifestCommand: ParsableCommand {
 
     @Flag(help: "If the package manifest should include the integration tests.")
     var includesIntegrationTests: Bool = false
-    
+
+    @Flag(help: "If the package manifest should include the protocol tests.")
+    var includeProtocolTests: Bool = false
+
     func run() throws {
         let generatePackageManifest = GeneratePackageManifest.standard(
             repoPath: repoPath,
@@ -42,7 +45,8 @@ struct GeneratePackageManifestCommand: ParsableCommand {
             clientRuntimeVersion: clientRuntimeVersion,
             crtVersion: crtVersion,
             services: services.isEmpty ? nil : services,
-            includesIntegrationTests: includesIntegrationTests
+            includesIntegrationTests: includesIntegrationTests,
+            includeProtocolTests: includeProtocolTests
         )
         try generatePackageManifest.run()
     }
@@ -67,7 +71,9 @@ struct GeneratePackageManifest {
     let services: [String]?
     /// If the package manifest should include the integration tests.
     let includesIntegrationTests: Bool
-    
+    /// If the package manifest should include the protocol tests.
+    let includeProtocolTests: Bool
+
     typealias BuildPackageManifest = (
         _ clientRuntimeVersion: Version,
         _ crtVersion: Version,
@@ -219,7 +225,8 @@ extension GeneratePackageManifest {
         clientRuntimeVersion: Version? = nil,
         crtVersion: Version? = nil,
         services: [String]? = nil,
-        includesIntegrationTests: Bool = false
+        includesIntegrationTests: Bool = false,
+        includeProtocolTests: Bool = false
     ) -> Self {
         GeneratePackageManifest(
             repoPath: repoPath,
@@ -227,12 +234,14 @@ extension GeneratePackageManifest {
             clientRuntimeVersion: clientRuntimeVersion,
             crtVersion: crtVersion,
             services: services,
-            includesIntegrationTests: includesIntegrationTests
+            includesIntegrationTests: includesIntegrationTests,
+            includeProtocolTests: includeProtocolTests
         ) { _clientRuntimeVersion, _crtVersion, _services in
             let builder = PackageManifestBuilder(
                 clientRuntimeVersion: _clientRuntimeVersion,
                 crtVersion: _crtVersion,
-                services: _services
+                services: _services,
+                includeProtocolTests: includeProtocolTests
             )
             return try builder.build()
         }

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Models/PackageManifestBuilder.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Models/PackageManifestBuilder.swift
@@ -18,26 +18,30 @@ struct PackageManifestBuilder {
     let clientRuntimeVersion: Version
     let crtVersion: Version
     let services: [Service]
+    let includeProtocolTests: Bool
     let basePackageContents: () throws -> String
     
     init(
         clientRuntimeVersion: Version,
         crtVersion: Version,
         services: [Service],
+        includeProtocolTests: Bool,
         basePackageContents: @escaping () throws -> String
     ) {
         self.clientRuntimeVersion = clientRuntimeVersion
         self.crtVersion = crtVersion
         self.services = services
+        self.includeProtocolTests = includeProtocolTests
         self.basePackageContents = basePackageContents
     }
     
     init(
         clientRuntimeVersion: Version,
         crtVersion: Version,
-        services: [Service]
+        services: [Service],
+        includeProtocolTests: Bool
     ) {
-        self.init(clientRuntimeVersion: clientRuntimeVersion, crtVersion: crtVersion, services: services) {
+        self.init(clientRuntimeVersion: clientRuntimeVersion, crtVersion: crtVersion, services: services, includeProtocolTests: includeProtocolTests) {
             // Returns the contents of the base package manifest stored in the bundle at `Resources/Package.Base.swift`
             let basePackageName = "Package.Base"
             
@@ -83,7 +87,9 @@ struct PackageManifestBuilder {
             buildServiceTargets(),
             "",
             // Add the generated content that defines the list of services with integration tests to include
-            buildIntegrationTestsTargets()
+            buildIntegrationTestsTargets(),
+            "",
+            buildProtocolTests(),
         ]
         return contents.joined(separator: .newline)
     }
@@ -166,5 +172,14 @@ struct PackageManifestBuilder {
         lines += ["\(propertyName).forEach(addIntegrationTestTarget)"]
 
         return lines.joined(separator: .newline)
+    }
+
+    /// Calls the method to include protocol tests in the manifest.
+    ///
+    ///```
+    ///addProtocolTests()
+    ///```
+    private func buildProtocolTests() -> String {
+        includeProtocolTests ? "addProtocolTests()" : ""
     }
 }

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Models/PackageManifestBuilder.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Models/PackageManifestBuilder.swift
@@ -177,9 +177,14 @@ struct PackageManifestBuilder {
     /// Calls the method to include protocol tests in the manifest.
     ///
     ///```
+    ///// Uncomment this line to enable protocol tests
     ///addProtocolTests()
     ///```
     private func buildProtocolTests() -> String {
-        includeProtocolTests ? "addProtocolTests()" : ""
+        return [
+            "// Uncomment this line to enable protocol tests",
+            (includeProtocolTests ? "" : "// ") + "addProtocolTests()"
+
+        ].joined(separator: .newline)
     }
 }

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
@@ -116,19 +116,20 @@ func addIntegrationTestTarget(_ name: String) {
     ]
 }
 
-struct ProtocolTest {
-    let name: String
-    let sourcePath: String
-    let testPath: String?
-
-    init(name: String, sourcePath: String, testPath: String? = nil) {
-        self.name = name
-        self.sourcePath = sourcePath
-        self.testPath = testPath
-    }
-}
-
 func addProtocolTests() {
+
+    private struct ProtocolTest {
+        let name: String
+        let sourcePath: String
+        let testPath: String?
+
+        init(name: String, sourcePath: String, testPath: String? = nil) {
+            self.name = name
+            self.sourcePath = sourcePath
+            self.testPath = testPath
+        }
+    }
+
     let baseDir = "codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen"
     let baseDirLocal = "codegen/protocol-test-codegen-local/build/smithyprojections/protocol-test-codegen-local"
 

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
@@ -118,7 +118,7 @@ func addIntegrationTestTarget(_ name: String) {
 
 func addProtocolTests() {
 
-    private struct ProtocolTest {
+    struct ProtocolTest {
         let name: String
         let sourcePath: String
         let testPath: String?

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
@@ -115,3 +115,51 @@ func addIntegrationTestTarget(_ name: String) {
         )
     ]
 }
+
+struct ProtocolTest {
+    let name: String
+    let sourcePath: String
+    let testPath: String?
+
+    init(name: String, sourcePath: String, testPath: String? = nil) {
+        self.name = name
+        self.sourcePath = sourcePath
+        self.testPath = testPath
+    }
+}
+
+func addProtocolTests() {
+    let baseDir = "codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen"
+    let baseDirLocal = "codegen/protocol-test-codegen-local/build/smithyprojections/protocol-test-codegen-local"
+
+    let protocolTests: [ProtocolTest] = [
+        .init(name: "AWSRestJsonTestSDK", sourcePath: "\(baseDir)/aws-restjson"),
+        .init(name: "AWSJson1_0TestSDK", sourcePath: "\(baseDir)/aws-json-10"),
+        .init(name: "AWSJson1_1TestSDK", sourcePath: "\(baseDir)/aws-json-11"),
+        .init(name: "RestXmlTestSDK", sourcePath: "\(baseDir)/rest-xml"),
+        .init(name: "RestXmlWithNamespaceTestSDK", sourcePath: "\(baseDir)/rest-xml-xmlns"),
+        .init(name: "Ec2QueryTestSDK", sourcePath: "\(baseDir)/ec2-query"),
+        .init(name: "AWSQueryTestSDK", sourcePath: "\(baseDir)/aws-query"),
+        .init(name: "APIGatewayTestSDK", sourcePath: "\(baseDir)/apigateway"),
+        .init(name: "GlacierTestSDK", sourcePath: "\(baseDir)/glacier"),
+        .init(name: "MachineLearningTestSDK", sourcePath: "\(baseDir)/machinelearning"),
+        .init(name: "S3TestSDK", sourcePath: "\(baseDir)/s3"),
+        .init(name: "aws_restjson", sourcePath: "\(baseDirLocal)/aws-restjson"),
+        .init(name: "rest_json_extras", sourcePath: "\(baseDirLocal)/rest_json_extras"),
+        .init(name: "Waiters", sourcePath: "\(baseDirLocal)/Waiters", testPath: "codegen/protocol-test-codegen-local/Tests"),
+    ]
+    for protocolTest in protocolTests {
+        package.targets += [
+            .target(
+                name: protocolTest.name,
+                dependencies: [.clientRuntime, .awsClientRuntime],
+                path: "\(protocolTest.sourcePath)/swift-codegen/\(protocolTest.name)"
+            ),
+            .testTarget(
+                name: "\(protocolTest.name)Tests",
+                dependencies: [.smithyTestUtils, .byNameItem(name: protocolTest.name, condition: nil)],
+                path: "\(protocolTest.testPath ?? protocolTest.sourcePath)/swift-codegen/\(protocolTest.name)Tests"
+            )
+        ]
+    }
+}

--- a/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Commands/GeneratePackageManifestTests.swift
+++ b/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Commands/GeneratePackageManifestTests.swift
@@ -111,6 +111,7 @@ extension GeneratePackageManifest {
         crtVersion: Version? = nil,
         services: [String]? = nil,
         includesIntegrationTests: Bool = false,
+        includeProtocolTests: Bool = false,
         buildPackageManifest: @escaping BuildPackageManifest = { (_,_,_) throws -> String in "" }
     ) -> GeneratePackageManifest {
         GeneratePackageManifest(
@@ -120,6 +121,7 @@ extension GeneratePackageManifest {
             crtVersion: crtVersion,
             services: services,
             includesIntegrationTests: includesIntegrationTests,
+            includeProtocolTests: includeProtocolTests,
             buildPackageManifest: buildPackageManifest
         )
     }

--- a/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Models/PackageManifestBuilderTests.swift
+++ b/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Models/PackageManifestBuilderTests.swift
@@ -40,6 +40,7 @@ class PackageManifestBuilderTests: XCTestCase {
 
     servicesWithIntegrationTests.forEach(addIntegrationTestTarget)
 
+    // Uncomment this line to enable protocol tests
     addProtocolTests()
     """
     

--- a/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Models/PackageManifestBuilderTests.swift
+++ b/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Models/PackageManifestBuilderTests.swift
@@ -39,16 +39,19 @@ class PackageManifestBuilderTests: XCTestCase {
     ]
 
     servicesWithIntegrationTests.forEach(addIntegrationTestTarget)
+
+    addProtocolTests()
     """
     
     func testBuild() {
-        let subjeect = PackageManifestBuilder(
+        let subject = PackageManifestBuilder(
             clientRuntimeVersion: .init("1.2.3"),
             crtVersion: .init("4.5.6"),
             services: ["A","B","C","D","E"].map { PackageManifestBuilder.Service(name: $0, includeIntegrationTests: true) },
+            includeProtocolTests: true,
             basePackageContents: { "<contents of base package>" }
         )
-        let result = try! subjeect.build()
+        let result = try! subject.build()
         XCTAssertEqual(result, expected)
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -116,6 +116,55 @@ func addIntegrationTestTarget(_ name: String) {
     ]
 }
 
+func addProtocolTests() {
+
+    private struct ProtocolTest {
+        let name: String
+        let sourcePath: String
+        let testPath: String?
+
+        init(name: String, sourcePath: String, testPath: String? = nil) {
+            self.name = name
+            self.sourcePath = sourcePath
+            self.testPath = testPath
+        }
+    }
+
+    let baseDir = "codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen"
+    let baseDirLocal = "codegen/protocol-test-codegen-local/build/smithyprojections/protocol-test-codegen-local"
+
+    let protocolTests: [ProtocolTest] = [
+        .init(name: "AWSRestJsonTestSDK", sourcePath: "\(baseDir)/aws-restjson"),
+        .init(name: "AWSJson1_0TestSDK", sourcePath: "\(baseDir)/aws-json-10"),
+        .init(name: "AWSJson1_1TestSDK", sourcePath: "\(baseDir)/aws-json-11"),
+        .init(name: "RestXmlTestSDK", sourcePath: "\(baseDir)/rest-xml"),
+        .init(name: "RestXmlWithNamespaceTestSDK", sourcePath: "\(baseDir)/rest-xml-xmlns"),
+        .init(name: "Ec2QueryTestSDK", sourcePath: "\(baseDir)/ec2-query"),
+        .init(name: "AWSQueryTestSDK", sourcePath: "\(baseDir)/aws-query"),
+        .init(name: "APIGatewayTestSDK", sourcePath: "\(baseDir)/apigateway"),
+        .init(name: "GlacierTestSDK", sourcePath: "\(baseDir)/glacier"),
+        .init(name: "MachineLearningTestSDK", sourcePath: "\(baseDir)/machinelearning"),
+        .init(name: "S3TestSDK", sourcePath: "\(baseDir)/s3"),
+        .init(name: "aws_restjson", sourcePath: "\(baseDirLocal)/aws-restjson"),
+        .init(name: "rest_json_extras", sourcePath: "\(baseDirLocal)/rest_json_extras"),
+        .init(name: "Waiters", sourcePath: "\(baseDirLocal)/Waiters", testPath: "codegen/protocol-test-codegen-local/Tests"),
+    ]
+    for protocolTest in protocolTests {
+        package.targets += [
+            .target(
+                name: protocolTest.name,
+                dependencies: [.clientRuntime, .awsClientRuntime],
+                path: "\(protocolTest.sourcePath)/swift-codegen/\(protocolTest.name)"
+            ),
+            .testTarget(
+                name: "\(protocolTest.name)Tests",
+                dependencies: [.smithyTestUtils, .byNameItem(name: protocolTest.name, condition: nil)],
+                path: "\(protocolTest.testPath ?? protocolTest.sourcePath)/swift-codegen/\(protocolTest.name)Tests"
+            )
+        ]
+    }
+}
+
 
 // MARK: - Generated
 
@@ -475,3 +524,6 @@ let servicesWithIntegrationTests: [String] = [
 ]
 
 servicesWithIntegrationTests.forEach(addIntegrationTestTarget)
+
+// Uncomment this line to enable protocol tests
+// addProtocolTests()


### PR DESCRIPTION
## Issue \#
<!--- If it fixes an issue, please link to the issue here -->

## Description of changes
Adds the `--include-protocol-tests` flag to the `generate-package-manifest` CLI command.

Protocol tests may then be run from the main app instead of from the separate manifest in `codegen/Package.swift`.  This will speed up build times greatly when both protocol tests and unit / integration tests are to be run as well (this happens often.)

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.