### PR TITLE
fix: Remove expectations from tree hash test

### DIFF
--- a/Tests/Core/AWSClientRuntimeTests/Middlewares/Sha256TreeHashMiddlewareTests.swift
+++ b/Tests/Core/AWSClientRuntimeTests/Middlewares/Sha256TreeHashMiddlewareTests.swift
@@ -14,8 +14,8 @@ import SmithyTestUtil
 class Sha256TreeHashMiddlewareTests: XCTestCase {
 
     func testTreeHashAllZeroes() async throws {
+        var completed = false
         let context = HttpContextBuilder().build()
-        let expectation = XCTestExpectation(description: "closure was run")
         let bytesIn5_5MB: Int = Int(1024 * 1024 * 5.5)
         let byteArray: [UInt8] = Array(repeating: 0, count: bytesIn5_5MB)
         let byteStream = ByteStream.stream(BufferedStream(data: .init(byteArray), isClosed: true))
@@ -31,14 +31,9 @@ class Sha256TreeHashMiddlewareTests: XCTestCase {
             XCTAssertEqual(linear, "733cf513448ce6b20ad1bc5e50eb27c06aefae0c320713a5dd99f4e51bc1ca60")
             let treeHash = input.headers.value(for: "X-Amz-Sha256-Tree-Hash")
             XCTAssertEqual(treeHash, "a3a82dbe3644dd6046be472f2e3ec1f8ef47f8f3adb86d0de4de7a254f255455")
-            expectation.fulfill()
+            completed = true
             return output
         }))
-
-#if swift(>=5.8)
-        await fulfillment(of: [expectation], timeout: 3.0)
-#else
-        wait(for: [expectation], timeout: 3.0)
-#endif
+        XCTAssertTrue(completed)
     }
 }


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1005

## Description of changes
Removes expectations from this test, since they cannot be reliably used on asynchronous tests on Linux.  This particular test does not seem to be causing any problems, but I am nevertheless fixing it because it can potentially cause deadlock.

This code executes in deterministic order, so the callback is guaranteed to have been run before the test ends, but I have also used a `completed` flag to verify that the test assertions were actually run.

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.