### PR TITLE
fix: Remove --parallel from swift test cmd to improve performance

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/TestAWSSDK.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/TestAWSSDK.swift
@@ -16,7 +16,7 @@ struct TestAWSSDKCommand: ParsableCommand {
     static var configuration = CommandConfiguration(
         commandName: "test-aws-sdk",
         abstract: "Builds the package and executes its tests",
-        discussion: "swift test --parallel"
+        discussion: "swift test"
     )
     
     @Argument(help: "The path to the aws-sdk-swift repository")
@@ -55,7 +55,7 @@ struct TestAWSSDK {
     func run() throws {
         try FileManager.default.changeWorkingDirectory(repoPath)
         
-        // If batches is 1, then run `swift test --parallel` with the current Package.swift
+        // If batches is 1, then run `swift test` with the current Package.swift
         guard batches > 1 else {
             log("Testing Package.swift...")
             let task = Process.swift.test()
@@ -129,7 +129,7 @@ struct TestAWSSDK {
     
     /// Runs tests using the provided package manifest
     ///
-    /// This renames the provided package to `Package.swift` and then runs `swift test --parallel`
+    /// This renames the provided package to `Package.swift` and then runs `swift test`
     /// When finished, it renames `Package.swift` back to the provided package file name.
     ///
     func testPackage(_ package: String) throws {

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Utils/Process+Swift.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Utils/Process+Swift.swift
@@ -15,9 +15,9 @@ extension Process {
             Process(["swift"] + args)
         }
         
-        /// Returns a process for executing `swift test --parallel`
+        /// Returns a process for executing `swift test`
         func test() -> Process {
-            swiftProcess(["test", "--parallel"])
+            swiftProcess(["test"])
         }
     }
     

--- a/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Commands/GeneratePackageManifestTests.swift
+++ b/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Commands/GeneratePackageManifestTests.swift
@@ -120,7 +120,7 @@ extension GeneratePackageManifest {
             clientRuntimeVersion: clientRuntimeVersion,
             crtVersion: crtVersion,
             services: services,
-            includesIntegrationTests: includesIntegrationTests,
+            includeIntegrationTests: includesIntegrationTests,
             includeProtocolTests: includeProtocolTests,
             buildPackageManifest: buildPackageManifest
         )

--- a/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Commands/TestAWSSDKTests.swift
+++ b/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Commands/TestAWSSDKTests.swift
@@ -69,7 +69,7 @@ class TestAWSSDKTests: CLITestCase {
         try! subject.run()
         
         XCTAssertEqual(commands.count, 4)
-        XCTAssertTrue(commands.allSatisfy { $0.hasSuffix("swift test --parallel") })
+        XCTAssertTrue(commands.allSatisfy { $0.hasSuffix("swift test") })
         XCTAssertEqual(packages, [
             "Package.TestBatch1.swift A-B",
             "Package.TestBatch2.swift C-D",
@@ -90,7 +90,7 @@ class TestAWSSDKTests: CLITestCase {
         try! subject.run()
         
         XCTAssertEqual(commands.count, 1)
-        XCTAssertTrue(commands[0].hasSuffix("swift test --parallel"))
+        XCTAssertTrue(commands[0].hasSuffix("swift test"))
     }
     
     // MARK: createBatches()
@@ -156,7 +156,7 @@ class TestAWSSDKTests: CLITestCase {
             encoding: .utf8
         )
         
-        XCTAssertTrue(command.hasSuffix("swift test --parallel"))
+        XCTAssertTrue(command.hasSuffix("swift test"))
         XCTAssertEqual(testBatchContents, contents)
         XCTAssertNil(packageContents)
     }


### PR DESCRIPTION
## Description of changes
The `test-aws-sdk` CLI command uses the `--parallel` option when running `swift test`.  In practice, this option results in drastically slower tests.

To remedy, the `test-aws-sdk` CLI command now omits the `--parallel` option from `swift test`/

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.