### PR TITLE
feat: Make data streams completely async

### DIFF
--- a/IntegrationTests/Services/AWSS3IntegrationTests/S3StreamTests.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/S3StreamTests.swift
@@ -23,7 +23,7 @@ final class S3StreamTests: S3XCTestCase {
             let actual = String(data: data, encoding: .utf8)
             XCTAssertEqual(actual, expected)
         case .stream(let stream):
-            let actual = String(data: try stream.readToEnd()!, encoding: .utf8)
+            let actual = String(data: try await stream.readToEndAsync()!, encoding: .utf8)
             XCTAssertEqual(actual, expected)
         }
     }

--- a/IntegrationTests/Services/AWSS3IntegrationTests/S3XCTestCase.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/S3XCTestCase.swift
@@ -89,7 +89,7 @@ class S3XCTestCase: XCTestCase {
             let data = try XCTUnwrap(dataOrNil)
             return String(data: data, encoding: .utf8)
         case .stream(let stream):
-            return String(data: try stream.readToEnd()!, encoding: .utf8)
+            return String(data: try await stream.readToEndAsync()!, encoding: .utf8)
         }
     }
 

--- a/IntegrationTests/Services/AWSTranscribeStreamingIntegrationTests/TranscribeStreamingTests.swift
+++ b/IntegrationTests/Services/AWSTranscribeStreamingIntegrationTests/TranscribeStreamingTests.swift
@@ -10,6 +10,7 @@ import Foundation
 import AWSTranscribeStreaming
 
 final class TranscribeStreamingTests: XCTestCase {
+
     func testStartStreamTranscription() async throws {
         let audioURL = Bundle.module.url(forResource: "hello-swift", withExtension: "wav")!
         let audioData = try Data(contentsOf: audioURL)
@@ -17,7 +18,7 @@ final class TranscribeStreamingTests: XCTestCase {
         let chunkSize = 4096
         let audioDataSize = audioData.count
 
-        let client = try await TranscribeStreamingClient(region: "us-west-2")
+        let client = try TranscribeStreamingClient(region: "us-west-2")
 
         let audioStream = AsyncThrowingStream<TranscribeStreamingClientTypes.AudioStream, Error> { continuation in
             Task {

--- a/Sources/Core/AWSClientRuntime/Middlewares/Sha256TreeHashMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Middlewares/Sha256TreeHashMiddleware.swift
@@ -43,10 +43,8 @@ public struct Sha256TreeHashMiddleware<OperationStackOutput: HttpResponseBinding
                       // If the stream is not seekable, we need to cache the stream in memory
                       // so we can compute the hash and still be able to send the stream to the service.
                       // This is not ideal, but it is the best we can do.
-                      let cachingStream = CachingStream(base: stream)
-                      streamBytes = try cachingStream.readToEnd()
-                      try cachingStream.seek(toOffset: currentPosition)
-                      input.withBody(.stream(cachingStream))
+                      streamBytes = try stream.readToEnd()
+                      input.withBody(.data(streamBytes))
                   }
                   guard let streamBytes = streamBytes, !streamBytes.isEmpty else {
                       return try await next.handle(context: context, input: input)

--- a/Sources/Core/AWSClientRuntime/Middlewares/Sha256TreeHashMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Middlewares/Sha256TreeHashMiddleware.swift
@@ -37,13 +37,13 @@ public struct Sha256TreeHashMiddleware<OperationStackOutput: HttpResponseBinding
                   let streamBytes: Data?
                   let currentPosition = stream.position
                   if stream.isSeekable {
-                      streamBytes = try stream.readToEnd()
+                      streamBytes = try await stream.readToEndAsync()
                       try stream.seek(toOffset: currentPosition)
                   } else {
                       // If the stream is not seekable, we need to cache the stream in memory
                       // so we can compute the hash and still be able to send the stream to the service.
                       // This is not ideal, but it is the best we can do.
-                      streamBytes = try stream.readToEnd()
+                      streamBytes = try await stream.readToEndAsync()
                       input.withBody(.data(streamBytes))
                   }
                   guard let streamBytes = streamBytes, !streamBytes.isEmpty else {


### PR DESCRIPTION
## Issue \#
#974 

## Description of changes
This PR is the companion of https://github.com/awslabs/smithy-swift/pull/553

- Use the async `readToEndAsync()` method where possible
- `Sha256TreeHashMiddleware` no longer uses `CachingStream` to duplicate body content.  Instead, the body is passed on as in-memory data.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.