### PR TITLE
fix: Custom endpoint config field

### DIFF
--- a/Sources/Core/AWSClientRuntime/AWSClientConfiguration.swift
+++ b/Sources/Core/AWSClientRuntime/AWSClientConfiguration.swift
@@ -108,6 +108,7 @@ public class AWSClientConfiguration<ServiceSpecificConfiguration: AWSServiceSpec
             DefaultSDKRuntimeConfiguration<DefaultRetryStrategy, DefaultRetryErrorInfoProvider>
 
         self.credentialsProvider = credentialsProvider
+        self.endpoint = endpoint
         self.serviceSpecific = try serviceSpecific ?? ServiceSpecificConfiguration(endpointResolver: nil)
         self.frameworkMetadata = frameworkMetadata
         self.region = region

--- a/Tests/Core/AWSClientRuntimeTests/AWSClientConfigurationTests.swift
+++ b/Tests/Core/AWSClientRuntimeTests/AWSClientConfigurationTests.swift
@@ -1,0 +1,40 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import XCTest
+import AWSClientRuntime
+
+class AWSClientConfigurationTests: XCTestCase {
+
+    func test_region_regionPropertyGetsSet() throws {
+        let region = "us-east-1"
+        let subject = try AWSClientConfiguration<TestAWSServiceSpecificConfiguration>(region: region)
+        XCTAssertEqual(subject.region, region)
+    }
+
+    func test_endpoint_endpointPropertyGetsSet() throws {
+        let endpoint = "https://my-xctest-endpoint.test.com/"
+        let subject = try AWSClientConfiguration<TestAWSServiceSpecificConfiguration>(region: "us-east-1", endpoint: endpoint)
+        XCTAssertEqual(subject.endpoint, endpoint)
+    }
+}
+
+struct TestAWSServiceSpecificConfiguration: AWSServiceSpecificConfiguration {
+    struct EndpointResolver {}
+
+    typealias AWSServiceEndpointResolver = EndpointResolver
+
+    var endpointResolver: EndpointResolver
+
+    init(endpointResolver: EndpointResolver?) throws {
+        self.endpointResolver = endpointResolver ?? EndpointResolver()
+    }
+
+    var serviceName: String { "TestAWSService" }
+    var clientName: String { "TestAWSServiceClient" }
+}


### PR DESCRIPTION
## Description of changes
#1036 inadvertently broke the `endpoint` field on client configuration.  This PR restores it, and verifies it with a couple tests.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.