### PR TITLE
fix: Make AWS SDK CLI test runner fail when tests fail

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Utils/Process+Utils.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Utils/Process+Utils.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import ArgumentParser
 
 extension Process {
     /// Creates a process using `/usr/bin/env` as the executable
@@ -73,6 +74,11 @@ struct ProcessRunner {
         log("Running process: \(process.commandString)")
         try process.run()
         process.waitUntilExit()
+        print("term reason: \(process.terminationReason)")
+        let exitCode = ExitCode(process.terminationStatus)
+        if !exitCode.isSuccess {
+            throw exitCode
+        }
     }
     
     #if DEBUG

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Utils/Process+Utils.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Utils/Process+Utils.swift
@@ -74,7 +74,6 @@ struct ProcessRunner {
         log("Running process: \(process.commandString)")
         try process.run()
         process.waitUntilExit()
-        print("term reason: \(process.terminationReason)")
         let exitCode = ExitCode(process.terminationStatus)
         if !exitCode.isSuccess {
             throw exitCode

--- a/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Utils/ProcessUtilsTests.swift
+++ b/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Utils/ProcessUtilsTests.swift
@@ -1,0 +1,26 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import AWSSDKSwiftCLI
+import PackageDescription
+import ArgumentParser
+import XCTest
+
+class ProcessUtilsTests: XCTestCase {
+
+    func test_exit_itThrowsErrorWithErrorCode() {
+        let process = Process("false")  // this refers to /usr/bin/false which always returns unsuccessfully
+        do {
+            try ProcessRunner.standard.run(process)
+            XCTFail("Process runner should have thrown")
+        } catch let exitCodeError as ExitCode {
+            XCTAssertTrue(exitCodeError.rawValue != 0)
+        } catch {
+            XCTFail("Process runner threw an unexpected type of error")
+        }
+    }
+}

--- a/sdk.properties
+++ b/sdk.properties
@@ -1,1 +1,1 @@
-excludeModels=verifiedpermissions.2021-12-01
+# onlyIncludeModels=verifiedpermissions.2021-12-01

--- a/sdk.properties
+++ b/sdk.properties
@@ -1,1 +1,1 @@
-# onlyIncludeModels=verifiedpermissions.2021-12-01
+excludeModels=verifiedpermissions.2021-12-01


### PR DESCRIPTION
## Issue \#
#1046

## Description of changes
Currently, when the AWS SDK CLI test runner fails (i.e. `swift test` exits with a nonzero status code), the AWS SDK CLI command exits but with a status code zero for success.

With this change, when the AWS SDK CLI runs a `Process` and the process exits with a nonzero exit code, an `ExitCode` error (defined in the Swift Argument Parser package) is thrown with the abnormal exit code.

A test is added to verify the change works as expected.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.