### PR TITLE
fix: Release note exit codes cause script failure, other release note issues

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/PrepareRelease.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/PrepareRelease.swift
@@ -176,6 +176,7 @@ struct PrepareRelease {
         let releaseNotes = ReleaseNotesBuilder(
             previousVersion: previousVersion,
             newVersion: newVersion,
+            repoType: repoType,
             commits: commits
         ).build()
         

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Models/ReleaseNotesBuilder.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Models/ReleaseNotesBuilder.swift
@@ -12,6 +12,7 @@ import PackageDescription
 struct ReleaseNotesBuilder {
     let previousVersion: Version
     let newVersion: Version
+    let repoType: PrepareRelease.Repo
     let commits: [String]
     
     // MARK: - Build
@@ -21,7 +22,7 @@ struct ReleaseNotesBuilder {
             "## What's Changed",
             buildCommits(),
             .newline,
-            "**Full Changelog**: https://github.com/awslabs/aws-sdk-swift/compare/\(previousVersion)...\(newVersion)"
+            "**Full Changelog**: https://github.com/awslabs/\(repoType.rawValue)/compare/\(previousVersion)...\(newVersion)"
         ]
         return contents.joined(separator: .newline)
     }


### PR DESCRIPTION
## Issue \#
#1031

## Description of changes
The change in #1049 broke the release notes script by throwing an uncaught error.  This was detected on a Catapult dry run, where the script failed because of a routine issue (a git diff was not clean, which was expected.)

To remedy, the script is modified to catch the expected exit code & handle it appropriately.

(also: issues with unwanted quotation marks and a broken Github diff link were fixed.)

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.