### PR TITLE
chore: Upgrade the Mac CI task

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,10 +21,14 @@ env:
   AWS_SWIFT_SDK_USE_LOCAL_DEPS: 1
 
 jobs:
-  ios-compat:
-    runs-on: macos-13
+  apple-compat:
+    runs-on: macos-latest
     env:
       DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer
+    matrix:
+      destination:
+        - 'platform=iOS Simulator,OS=16.4,name=iPhone 14'
+        - 'platform=OS X'
     steps:
       - name: Checkout aws-sdk-swift
         uses: actions/checkout@v3
@@ -80,40 +84,11 @@ jobs:
           set -o pipefail && \
           NSUnbufferedIO=YES xcodebuild \
             -scheme aws-sdk-swift \
-            -destination 'platform=iOS Simulator,OS=16.4,name=iPhone 14' \
+            -destination '${{ matrix.destination }}' \
             test 2>&1 \
             | xcbeautify
-  macos-compat:
-    runs-on: macos-11
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-      - uses: actions/setup-java@v1
-        with:
-          java-version: '11'
-      - name: Tools Versions
-        run: |
-          which swiftc
-          swiftc --version
-          echo
-          which xcodebuild
-          xcodebuild -version
-      - name: Build and Test ${{ env.PACKAGE_NAME }}
-        run: |
-          python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-          chmod a+x builder.pyz
-          ./builder.pyz build -p ${{ env.PACKAGE_NAME }}
   linux-compat:
+    if: false
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         # This matrix runs tests on iOS sim & Mac, on oldest & newest supported Xcodes
         runner:
-          - macos-12
+          - macos-11
           - macos-13
         xcode:
           # Xcode 13.2.1 is used as oldest because 13.2 is the first version which backports concurrency
@@ -29,7 +29,7 @@ jobs:
           - 'platform=OS X'
         exclude:
           # Don't run old macOS with new Xcode
-          - runner: macos-12
+          - runner: macos-11
             xcode: Xcode_14.3.1
           # Don't run new macOS with old Xcode
           - runner: macos-13
@@ -98,7 +98,6 @@ jobs:
             | xcbeautify
 
   linux:
-    if: false
     runs-on: ubuntu-latest
     container: swift:${{ matrix.version }}-${{ matrix.os }}
     strategy:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   apple-compat:
-    runs-on: macos-latest
+    runs-on: macos-13
     env:
       DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer
     strategy:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,10 +25,12 @@ jobs:
     runs-on: macos-latest
     env:
       DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer
-    matrix:
-      destination:
-        - 'platform=iOS Simulator,OS=16.4,name=iPhone 14'
-        - 'platform=OS X'
+    strategy:
+      fail-fast: false
+      matrix:
+        destination:
+          - 'platform=iOS Simulator,OS=16.4,name=iPhone 14'
+          - 'platform=OS X'
     steps:
       - name: Checkout aws-sdk-swift
         uses: actions/checkout@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,7 +8,73 @@ env:
   AWS_SWIFT_SDK_USE_LOCAL_DEPS: 1
 
 jobs:
-  apple:
+  xcode-oldest:
+    runs-on: macos-12
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_13.1.app/Contents/Developer
+    strategy:
+      fail-fast: false
+      matrix:
+        destination:
+          - 'platform=iOS Simulator,OS=15.0,name=iPhone 13'
+          - 'platform=OS X'
+    steps:
+      - name: Checkout aws-sdk-swift
+        uses: actions/checkout@v3
+      - name: Select smithy-swift branch
+        run: |
+          ORIGINAL_REPO_HEAD_REF="$GITHUB_HEAD_REF" \
+          DEPENDENCY_REPO_URL="https://github.com/awslabs/smithy-swift.git" \
+          ./scripts/ci_steps/select_dependency_branch.sh
+      - name: Checkout smithy-swift
+        uses: actions/checkout@v3
+        with:
+          repository: awslabs/smithy-swift
+          ref: ${{ env.DEPENDENCY_REPO_SHA }}
+          path: smithy-swift
+      - name: Move smithy-swift into place
+        run: mv smithy-swift ..
+      - name: Cache Gradle
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: 1-${{ runner.os }}-gradle-${{ hashFiles('settings.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            1-${{ runner.os }}-gradle-${{ hashFiles('settings.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
+            1-${{ runner.os }}-gradle-
+      - name: Cache Swift
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            ~/.cache/org.swift.swiftpm
+          key: 1-${{ runner.os }}-swift5.8.1-spm-${{ hashFiles('Package.swift', 'AWSSDKSwiftCLI/Package.swift') }}
+          restore-keys: |
+            1-${{ runner.os }}-swift5.8.1-spm-${{ hashFiles('Package.swift', 'AWSSDKSwiftCLI/Package.swift') }}
+            1-${{ runner.os }}-swift5.8.1-spm-
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 17
+      - name: Setup xcbeautify
+        run: HOMEBREW_NO_AUTO_UPDATE=1 brew install xcbeautify
+      - name: Tools Versions
+        run: ./scripts/ci_steps/log_tool_versions.sh
+      - name: Prepare Protocol & Unit Tests
+        run: |
+          ./scripts/ci_steps/prepare_protocol_and_unit_tests.sh
+      - name: Build and Run Protocol & Unit Tests on iOS Simulator
+        run: |
+          set -o pipefail && \
+          NSUnbufferedIO=YES xcodebuild \
+            -scheme aws-sdk-swift \
+            -destination '${{ matrix.destination }}' \
+            test 2>&1 \
+            | xcbeautify
+  xcode-latest:
     runs-on: macos-13
     env:
       DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,13 +11,13 @@ jobs:
   xcode-oldest:
     runs-on: macos-12
     env:
-      # Xcode 13.2 is used as oldest because it is the first version which backports concurrency
-      DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
+      # Xcode 13.2.1 is used as oldest because 13.2 is the first version which backports concurrency
+      DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
     strategy:
       fail-fast: false
       matrix:
         destination:
-          - 'platform=iOS Simulator,OS=15.0,name=iPhone 13'
+          - 'platform=iOS Simulator,OS=15.2,name=iPhone 13'
           - 'platform=OS X'
     steps:
       - name: Checkout aws-sdk-swift
@@ -75,7 +75,7 @@ jobs:
             -destination '${{ matrix.destination }}' \
             test 2>&1 \
             | xcbeautify
-  xcode-latest:
+  xcode-newest:
     runs-on: macos-13
     env:
       DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,23 +5,10 @@ on:
   workflow_dispatch:
 
 env:
-  BUILDER_VERSION: v0.9.18
-  BUILDER_SOURCE: releases
-  # host owned by CRT team to host aws-crt-builder releases. Contact their on-call with any issues
-  BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
-  PACKAGE_NAME: aws-sdk-swift
-  LINUX_BASE_IMAGE: ubuntu-16-x64
-  RUN: ${{ github.run_id }}-${{ github.run_number }}
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  AWS_REGION: us-east-1
-  AWS_SDK_SWIFT_CI_DIR: /Users/runner/work/aws-sdk-swift/aws-sdk-swift
-  AWS_CRT_SWIFT_CI_DIR: /Users/runner/work/aws-sdk-swift/aws-sdk-swift/target/build/deps/aws-crt-swift
-  SMITHY_SWIFT_CI_DIR: /Users/runner/work/aws-sdk-swift/aws-sdk-swift/target/build/deps/smithy-swift
   AWS_SWIFT_SDK_USE_LOCAL_DEPS: 1
 
 jobs:
-  apple-compat:
+  apple:
     runs-on: macos-13
     env:
       DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer
@@ -81,8 +68,6 @@ jobs:
           ./scripts/ci_steps/prepare_protocol_and_unit_tests.sh
       - name: Build and Run Protocol & Unit Tests on iOS Simulator
         run: |
-          unset SMITHY_SWIFT_CI_DIR
-          unset AWS_SDK_SWIFT_CI_DIR
           set -o pipefail && \
           NSUnbufferedIO=YES xcodebuild \
             -scheme aws-sdk-swift \
@@ -151,7 +136,4 @@ jobs:
         run: |
           ./scripts/ci_steps/prepare_protocol_and_unit_tests.sh
       - name: Build and Run Protocol & Unit Tests on Linux
-        run: |
-          unset SMITHY_SWIFT_CI_DIR
-          unset AWS_SDK_SWIFT_CI_DIR
-          swift test
+        run: swift test

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,30 +11,35 @@ jobs:
   apple:
     runs-on: ${{ matrix.runner }}
     env:
-      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/${{ matrix.xcode }}.app/Contents/Developer
     strategy:
       fail-fast: false
       matrix:
+        # This matrix runs tests on iOS sim & Mac, on oldest & newest supported Xcodes
         runner:
           - macos-12
           - macos-13
         xcode:
           # Xcode 13.2.1 is used as oldest because 13.2 is the first version which backports concurrency
-          - 13.2.1
-          - 14.3.1
+          - Xcode_13.2.1
+          - Xcode_14.3.1
         destination:
           - 'platform=iOS Simulator,OS=15.2,name=iPhone 13'
           - 'platform=iOS Simulator,OS=16.4,name=iPhone 14'
           - 'platform=OS X'
         exclude:
+          # Don't run old macOS with new Xcode
           - runner: macos-12
-            xcode: 14.3.1
+            xcode: Xcode_14.3.1
+          # Don't run new macOS with old Xcode
           - runner: macos-13
-            xcode: 13.2.1
+            xcode: Xcode_13.2.1
+          # Don't run old iOS simulator with new Xcode
           - destination: 'platform=iOS Simulator,OS=15.2,name=iPhone 13'
-            xcode: 14.3.1
+            xcode: Xcode_14.3.1
+          # Don't run new iOS simulator with old Xcode
           - destination: 'platform=iOS Simulator,OS=16.4,name=iPhone 14'
-            xcode: 13.2.1
+            xcode: Xcode_13.2.1
     steps:
       - name: Checkout aws-sdk-swift
         uses: actions/checkout@v3
@@ -91,6 +96,7 @@ jobs:
             -destination '${{ matrix.destination }}' \
             test 2>&1 \
             | xcbeautify
+
   linux:
     if: false
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -72,10 +72,10 @@ jobs:
           path: |
             ~/Library/Caches/org.swift.swiftpm
             ~/.cache/org.swift.swiftpm
-          key: 1-${{ runner.os }}-swift5.8.1-spm-${{ hashFiles('Package.swift', 'AWSSDKSwiftCLI/Package.swift') }}
+          key: 1-${{ runner.os }}-${{ matrix.xcode }}-${{ hashFiles('Package.swift', 'AWSSDKSwiftCLI/Package.swift') }}
           restore-keys: |
-            1-${{ runner.os }}-swift5.8.1-spm-${{ hashFiles('Package.swift', 'AWSSDKSwiftCLI/Package.swift') }}
-            1-${{ runner.os }}-swift5.8.1-spm-
+            1-${{ runner.os }}-${{ matrix.xcode }}-${{ hashFiles('Package.swift', 'AWSSDKSwiftCLI/Package.swift') }}
+            1-${{ runner.os }}-${{ matrix.xcode }}-
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
@@ -88,7 +88,7 @@ jobs:
       - name: Prepare Protocol & Unit Tests
         run: |
           ./scripts/ci_steps/prepare_protocol_and_unit_tests.sh
-      - name: Build and Run Protocol & Unit Tests on iOS Simulator
+      - name: Build and Run Protocol & Unit Tests
         run: |
           set -o pipefail && \
           NSUnbufferedIO=YES xcodebuild \

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,83 +8,33 @@ env:
   AWS_SWIFT_SDK_USE_LOCAL_DEPS: 1
 
 jobs:
-  xcode-oldest:
-    runs-on: macos-12
+  apple:
+    runs-on: ${{ matrix.runner }}
     env:
-      # Xcode 13.2.1 is used as oldest because 13.2 is the first version which backports concurrency
-      DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
     strategy:
       fail-fast: false
       matrix:
+        runner:
+          - macos-12
+          - macos-13
+        xcode:
+          # Xcode 13.2.1 is used as oldest because 13.2 is the first version which backports concurrency
+          - 13.2.1
+          - 14.3.1
         destination:
           - 'platform=iOS Simulator,OS=15.2,name=iPhone 13'
-          - 'platform=OS X'
-    steps:
-      - name: Checkout aws-sdk-swift
-        uses: actions/checkout@v3
-      - name: Select smithy-swift branch
-        run: |
-          ORIGINAL_REPO_HEAD_REF="$GITHUB_HEAD_REF" \
-          DEPENDENCY_REPO_URL="https://github.com/awslabs/smithy-swift.git" \
-          ./scripts/ci_steps/select_dependency_branch.sh
-      - name: Checkout smithy-swift
-        uses: actions/checkout@v3
-        with:
-          repository: awslabs/smithy-swift
-          ref: ${{ env.DEPENDENCY_REPO_SHA }}
-          path: smithy-swift
-      - name: Move smithy-swift into place
-        run: mv smithy-swift ..
-      - name: Cache Gradle
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: 1-${{ runner.os }}-gradle-${{ hashFiles('settings.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            1-${{ runner.os }}-gradle-${{ hashFiles('settings.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
-            1-${{ runner.os }}-gradle-
-      - name: Cache Swift
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/Library/Caches/org.swift.swiftpm
-            ~/.cache/org.swift.swiftpm
-          key: 1-${{ runner.os }}-swift5.8.1-spm-${{ hashFiles('Package.swift', 'AWSSDKSwiftCLI/Package.swift') }}
-          restore-keys: |
-            1-${{ runner.os }}-swift5.8.1-spm-${{ hashFiles('Package.swift', 'AWSSDKSwiftCLI/Package.swift') }}
-            1-${{ runner.os }}-swift5.8.1-spm-
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: corretto
-          java-version: 17
-      - name: Setup xcbeautify
-        run: HOMEBREW_NO_AUTO_UPDATE=1 brew install xcbeautify
-      - name: Tools Versions
-        run: ./scripts/ci_steps/log_tool_versions.sh
-      - name: Prepare Protocol & Unit Tests
-        run: |
-          ./scripts/ci_steps/prepare_protocol_and_unit_tests.sh
-      - name: Build and Run Protocol & Unit Tests on iOS Simulator
-        run: |
-          set -o pipefail && \
-          NSUnbufferedIO=YES xcodebuild \
-            -scheme aws-sdk-swift \
-            -destination '${{ matrix.destination }}' \
-            test 2>&1 \
-            | xcbeautify
-  xcode-newest:
-    runs-on: macos-13
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer
-    strategy:
-      fail-fast: false
-      matrix:
-        destination:
           - 'platform=iOS Simulator,OS=16.4,name=iPhone 14'
           - 'platform=OS X'
+        exclude:
+          - runner: macos-12
+            xcode: 14.3.1
+          - runner: macos-13
+            xcode: 13.2.1
+          - destination: 'platform=iOS Simulator,OS=15.2,name=iPhone 13'
+            xcode: 14.3.1
+          - destination: 'platform=iOS Simulator,OS=16.4,name=iPhone 14'
+            xcode: 13.2.1
     steps:
       - name: Checkout aws-sdk-swift
         uses: actions/checkout@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,7 +11,8 @@ jobs:
   xcode-oldest:
     runs-on: macos-12
     env:
-      DEVELOPER_DIR: /Applications/Xcode_13.1.app/Contents/Developer
+      # Xcode 13.2 is used as oldest because it is the first version which backports concurrency
+      DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description of changes
Builds & tests Mac & iOS platforms on oldest & newest Xcode, using a single job matrixed to run 4 combinations of OS, Xcode, and platform.
- Eliminates dependence on CRT builder script, and all of the config for that script is removed.
- No need for Github or AWS credentials on this workflow anymore.  AWS credentials may be removed from this repo after merge.
- Allows for easy add of new Apple platforms (TV, watch, etc.) in the future.

Note: Update the required CI checks to reflect the new names after this PR merges.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.