### PR TITLE
fix: Switch CI log processor from xcbeautify to xcpretty

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -83,14 +83,14 @@ jobs:
           java-version: 17
       - name: Setup xcbeautify
         run: |
-        # use $USER variable to mimick userName/repoName structure
-        # this does not actually create any git repositories
-        # 1. create a new tap
-        brew tap-new $USER/local-xcbeautify
-        # 2. extract into local tap
-        brew extract --version=0.20.0 xcbeautify $USER/local-xcbeautify
-        # 3. run brew install@version as usual
-        HOMEBREW_NO_AUTO_UPDATE=1 brew install xcbeautify@0.20.0
+          # use $USER variable to mimick userName/repoName structure
+          # this does not actually create any git repositories
+          # 1. create a new tap
+          brew tap-new $USER/local-xcbeautify
+          # 2. extract into local tap
+          brew extract --version=0.20.0 xcbeautify $USER/local-xcbeautify
+          # 3. run brew install@version as usual
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install xcbeautify@0.20.0
       - name: Tools Versions
         run: ./scripts/ci_steps/log_tool_versions.sh
       - name: Prepare Protocol & Unit Tests

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -81,16 +81,6 @@ jobs:
         with:
           distribution: corretto
           java-version: 17
-      - name: Setup xcbeautify
-        run: |
-          # use $USER variable to mimick userName/repoName structure
-          # this does not actually create any git repositories
-          # 1. create a new tap
-          brew tap-new $USER/local-xcbeautify
-          # 2. extract into local tap
-          brew extract --version=0.20.0 xcbeautify $USER/local-xcbeautify
-          # 3. run brew install@version as usual
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install xcbeautify@0.20.0
       - name: Tools Versions
         run: ./scripts/ci_steps/log_tool_versions.sh
       - name: Prepare Protocol & Unit Tests
@@ -103,7 +93,7 @@ jobs:
             -scheme aws-sdk-swift \
             -destination '${{ matrix.destination }}' \
             test 2>&1 \
-            | xcbeautify
+            | xcpretty
 
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -82,7 +82,7 @@ jobs:
           distribution: corretto
           java-version: 17
       - name: Setup xcbeautify
-        run: HOMEBREW_NO_AUTO_UPDATE=1 brew install xcbeautify
+        run: HOMEBREW_NO_AUTO_UPDATE=1 brew install xcbeautify@0.20.0
       - name: Tools Versions
         run: ./scripts/ci_steps/log_tool_versions.sh
       - name: Prepare Protocol & Unit Tests

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -82,7 +82,15 @@ jobs:
           distribution: corretto
           java-version: 17
       - name: Setup xcbeautify
-        run: HOMEBREW_NO_AUTO_UPDATE=1 brew install xcbeautify@0.20.0
+        run: |
+        # use $USER variable to mimick userName/repoName structure
+        # this does not actually create any git repositories
+        # 1. create a new tap
+        brew tap-new $USER/local-xcbeautify
+        # 2. extract into local tap
+        brew extract --version=0.20.0 xcbeautify $USER/local-xcbeautify
+        # 3. run brew install@version as usual
+        HOMEBREW_NO_AUTO_UPDATE=1 brew install xcbeautify@0.20.0
       - name: Tools Versions
         run: ./scripts/ci_steps/log_tool_versions.sh
       - name: Prepare Protocol & Unit Tests

--- a/Package.swift
+++ b/Package.swift
@@ -531,6 +531,10 @@ let serviceTargets: [String] = [
 serviceTargets.forEach(addServiceTarget)
 
 let servicesWithIntegrationTests: [String] = [
+    "AWSKinesis",
+    "AWSMediaConvert",
+    "AWSS3",
+    "AWSTranscribeStreaming",
 ]
 
 servicesWithIntegrationTests.forEach(addIntegrationTestTarget)

--- a/Package.swift
+++ b/Package.swift
@@ -531,10 +531,6 @@ let serviceTargets: [String] = [
 serviceTargets.forEach(addServiceTarget)
 
 let servicesWithIntegrationTests: [String] = [
-    "AWSKinesis",
-    "AWSMediaConvert",
-    "AWSS3",
-    "AWSTranscribeStreaming",
 ]
 
 servicesWithIntegrationTests.forEach(addIntegrationTestTarget)


### PR DESCRIPTION
## Description of changes
Recently CI builds started failing on macOS 11 CI jobs because `xcbeautify` (installed via Homebrew) was updated to not support macOS 11 & Xcode 13.  `xcbeautify` is not published to Homebrew with versioning, so it is difficult to specify an exact `xcbeautify` version to be installed.

The solution is to use `xcpretty` instead of `xcbeautify` to format logs.  `xcpretty` is slower and less recently updated, but comes pre-installed on every Github mac runner.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.