### PR TITLE
chore: Require aws-crt-swift 0.13.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -170,7 +170,7 @@ func addProtocolTests() {
 
 addDependencies(
     clientRuntimeVersion: "0.26.0",
-    crtVersion: "0.12.0"
+    crtVersion: "0.13.0"
 )
 
 let serviceTargets: [String] = [

--- a/packageDependencies.plist
+++ b/packageDependencies.plist
@@ -5,7 +5,7 @@
 	<key>awsCRTSwiftBranch</key>
 	<string>main</string>
 	<key>awsCRTSwiftVersion</key>
-	<string>0.12.0</string>
+	<string>0.13.0</string>
 	<key>clientRuntimeBranch</key>
 	<string>main</string>
 	<key>clientRuntimeVersion</key>


### PR DESCRIPTION
## Description of changes
Requires the latest stable version of `aws-crt-swift`.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.