### PR TITLE
fix: Correct serde for errors in event streams

### DIFF
--- a/Sources/Services/AWSKinesis/models/Models.swift
+++ b/Sources/Services/AWSKinesis/models/Models.swift
@@ -2442,7 +2442,7 @@ extension InternalFailureException: Swift.Codable {
     public init(from decoder: Swift.Decoder) throws {
         let containerValues = try decoder.container(keyedBy: CodingKeys.self)
         let messageDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .message)
-        message = messageDecoded
+        properties.message = messageDecoded
     }
 }
 
@@ -2541,7 +2541,7 @@ extension KMSAccessDeniedException: Swift.Codable {
     public init(from decoder: Swift.Decoder) throws {
         let containerValues = try decoder.container(keyedBy: CodingKeys.self)
         let messageDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .message)
-        message = messageDecoded
+        properties.message = messageDecoded
     }
 }
 
@@ -2616,7 +2616,7 @@ extension KMSDisabledException: Swift.Codable {
     public init(from decoder: Swift.Decoder) throws {
         let containerValues = try decoder.container(keyedBy: CodingKeys.self)
         let messageDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .message)
-        message = messageDecoded
+        properties.message = messageDecoded
     }
 }
 
@@ -2691,7 +2691,7 @@ extension KMSInvalidStateException: Swift.Codable {
     public init(from decoder: Swift.Decoder) throws {
         let containerValues = try decoder.container(keyedBy: CodingKeys.self)
         let messageDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .message)
-        message = messageDecoded
+        properties.message = messageDecoded
     }
 }
 
@@ -2766,7 +2766,7 @@ extension KMSNotFoundException: Swift.Codable {
     public init(from decoder: Swift.Decoder) throws {
         let containerValues = try decoder.container(keyedBy: CodingKeys.self)
         let messageDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .message)
-        message = messageDecoded
+        properties.message = messageDecoded
     }
 }
 
@@ -2841,7 +2841,7 @@ extension KMSOptInRequired: Swift.Codable {
     public init(from decoder: Swift.Decoder) throws {
         let containerValues = try decoder.container(keyedBy: CodingKeys.self)
         let messageDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .message)
-        message = messageDecoded
+        properties.message = messageDecoded
     }
 }
 
@@ -2916,7 +2916,7 @@ extension KMSThrottlingException: Swift.Codable {
     public init(from decoder: Swift.Decoder) throws {
         let containerValues = try decoder.container(keyedBy: CodingKeys.self)
         let messageDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .message)
-        message = messageDecoded
+        properties.message = messageDecoded
     }
 }
 
@@ -4760,7 +4760,7 @@ extension ResourceInUseException: Swift.Codable {
     public init(from decoder: Swift.Decoder) throws {
         let containerValues = try decoder.container(keyedBy: CodingKeys.self)
         let messageDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .message)
-        message = messageDecoded
+        properties.message = messageDecoded
     }
 }
 
@@ -4835,7 +4835,7 @@ extension ResourceNotFoundException: Swift.Codable {
     public init(from decoder: Swift.Decoder) throws {
         let containerValues = try decoder.container(keyedBy: CodingKeys.self)
         let messageDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .message)
-        message = messageDecoded
+        properties.message = messageDecoded
     }
 }
 

--- a/Sources/Services/AWSLexRuntimeV2/models/Models.swift
+++ b/Sources/Services/AWSLexRuntimeV2/models/Models.swift
@@ -17,7 +17,7 @@ extension AccessDeniedException: Swift.Codable {
     public init(from decoder: Swift.Decoder) throws {
         let containerValues = try decoder.container(keyedBy: CodingKeys.self)
         let messageDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .message)
-        message = messageDecoded
+        properties.message = messageDecoded
     }
 }
 
@@ -330,7 +330,7 @@ extension BadGatewayException: Swift.Codable {
     public init(from decoder: Swift.Decoder) throws {
         let containerValues = try decoder.container(keyedBy: CodingKeys.self)
         let messageDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .message)
-        message = messageDecoded
+        properties.message = messageDecoded
     }
 }
 
@@ -660,7 +660,7 @@ extension ConflictException: Swift.Codable {
     public init(from decoder: Swift.Decoder) throws {
         let containerValues = try decoder.container(keyedBy: CodingKeys.self)
         let messageDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .message)
-        message = messageDecoded
+        properties.message = messageDecoded
     }
 }
 
@@ -969,7 +969,7 @@ extension DependencyFailedException: Swift.Codable {
     public init(from decoder: Swift.Decoder) throws {
         let containerValues = try decoder.container(keyedBy: CodingKeys.self)
         let messageDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .message)
-        message = messageDecoded
+        properties.message = messageDecoded
     }
 }
 
@@ -1809,7 +1809,7 @@ extension InternalServerException: Swift.Codable {
     public init(from decoder: Swift.Decoder) throws {
         let containerValues = try decoder.container(keyedBy: CodingKeys.self)
         let messageDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .message)
-        message = messageDecoded
+        properties.message = messageDecoded
     }
 }
 
@@ -3048,7 +3048,7 @@ extension ResourceNotFoundException: Swift.Codable {
     public init(from decoder: Swift.Decoder) throws {
         let containerValues = try decoder.container(keyedBy: CodingKeys.self)
         let messageDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .message)
-        message = messageDecoded
+        properties.message = messageDecoded
     }
 }
 
@@ -4102,7 +4102,7 @@ extension ThrottlingException: Swift.Codable {
     public init(from decoder: Swift.Decoder) throws {
         let containerValues = try decoder.container(keyedBy: CodingKeys.self)
         let messageDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .message)
-        message = messageDecoded
+        properties.message = messageDecoded
     }
 }
 
@@ -4222,7 +4222,7 @@ extension ValidationException: Swift.Codable {
     public init(from decoder: Swift.Decoder) throws {
         let containerValues = try decoder.container(keyedBy: CodingKeys.self)
         let messageDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .message)
-        message = messageDecoded
+        properties.message = messageDecoded
     }
 }
 

--- a/Sources/Services/AWSSageMakerRuntime/SageMakerRuntimeClient.swift
+++ b/Sources/Services/AWSSageMakerRuntime/SageMakerRuntimeClient.swift
@@ -161,4 +161,61 @@ extension SageMakerRuntimeClient: SageMakerRuntimeClientProtocol {
         return result
     }
 
+    /// Invokes a model at the specified endpoint to return the inference response as a stream. The inference stream provides the response payload incrementally as a series of parts. Before you can get an inference stream, you must have access to a model that's deployed using Amazon SageMaker hosting services, and the container for that model must support inference streaming. For more information that can help you use this API, see the following sections in the Amazon SageMaker Developer Guide:
+    ///
+    /// * For information about how to add streaming support to a model, see [How Containers Serve Requests](https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-inference-code.html#your-algorithms-inference-code-how-containe-serves-requests).
+    ///
+    /// * For information about how to process the streaming response, see [Invoke real-time endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints-test-endpoints.html).
+    ///
+    ///
+    /// Amazon SageMaker strips all POST headers except those supported by the API. Amazon SageMaker might add additional headers. You should not rely on the behavior of headers outside those enumerated in the request syntax. Calls to InvokeEndpointWithResponseStream are authenticated by using Amazon Web Services Signature Version 4. For information, see [Authenticating Requests (Amazon Web Services Signature Version 4)](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html) in the Amazon S3 API Reference.
+    ///
+    /// - Parameter InvokeEndpointWithResponseStreamInput : [no documentation found]
+    ///
+    /// - Returns: `InvokeEndpointWithResponseStreamOutputResponse` : [no documentation found]
+    ///
+    /// - Throws: One of the exceptions listed below __Possible Exceptions__.
+    ///
+    /// __Possible Exceptions:__
+    /// - `InternalFailure` : An internal failure occurred.
+    /// - `InternalStreamFailure` : The stream processing failed because of an unknown error, exception or failure. Try your request again.
+    /// - `ModelError` : Model (owned by the customer in the container) returned 4xx or 5xx error code.
+    /// - `ModelStreamError` : An error occurred while streaming the response body. This error can have the following error codes: ModelInvocationTimeExceeded The model failed to finish sending the response within the timeout period allowed by Amazon SageMaker. StreamBroken The Transmission Control Protocol (TCP) connection between the client and the model was reset or closed.
+    /// - `ServiceUnavailable` : The service is unavailable. Try your call again.
+    /// - `ValidationError` : Inspect your request and try again.
+    public func invokeEndpointWithResponseStream(input: InvokeEndpointWithResponseStreamInput) async throws -> InvokeEndpointWithResponseStreamOutputResponse
+    {
+        let context = ClientRuntime.HttpContextBuilder()
+                      .withEncoder(value: encoder)
+                      .withDecoder(value: decoder)
+                      .withMethod(value: .post)
+                      .withServiceName(value: serviceName)
+                      .withOperation(value: "invokeEndpointWithResponseStream")
+                      .withIdempotencyTokenGenerator(value: config.idempotencyTokenGenerator)
+                      .withLogger(value: config.logger)
+                      .withPartitionID(value: config.partitionID)
+                      .withCredentialsProvider(value: config.credentialsProvider)
+                      .withRegion(value: config.region)
+                      .withSigningName(value: "sagemaker")
+                      .withSigningRegion(value: config.signingRegion)
+                      .build()
+        var operation = ClientRuntime.OperationStack<InvokeEndpointWithResponseStreamInput, InvokeEndpointWithResponseStreamOutputResponse, InvokeEndpointWithResponseStreamOutputError>(id: "invokeEndpointWithResponseStream")
+        operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLPathMiddleware<InvokeEndpointWithResponseStreamInput, InvokeEndpointWithResponseStreamOutputResponse, InvokeEndpointWithResponseStreamOutputError>())
+        operation.initializeStep.intercept(position: .after, middleware: ClientRuntime.URLHostMiddleware<InvokeEndpointWithResponseStreamInput, InvokeEndpointWithResponseStreamOutputResponse>())
+        let endpointParams = EndpointParams(endpoint: config.endpoint, region: config.region, useDualStack: config.useDualStack ?? false, useFIPS: config.useFIPS ?? false)
+        operation.buildStep.intercept(position: .before, middleware: EndpointResolverMiddleware<InvokeEndpointWithResponseStreamOutputResponse, InvokeEndpointWithResponseStreamOutputError>(endpointResolver: config.serviceSpecific.endpointResolver, endpointParams: endpointParams))
+        operation.buildStep.intercept(position: .before, middleware: AWSClientRuntime.UserAgentMiddleware(metadata: AWSClientRuntime.AWSUserAgentMetadata.fromConfig(serviceID: serviceName, version: "1.0", config: config)))
+        operation.serializeStep.intercept(position: .after, middleware: ClientRuntime.HeaderMiddleware<InvokeEndpointWithResponseStreamInput, InvokeEndpointWithResponseStreamOutputResponse>())
+        operation.serializeStep.intercept(position: .after, middleware: ContentTypeMiddleware<InvokeEndpointWithResponseStreamInput, InvokeEndpointWithResponseStreamOutputResponse>(contentType: "application/octet-stream"))
+        operation.serializeStep.intercept(position: .after, middleware: InvokeEndpointWithResponseStreamInputBodyMiddleware())
+        operation.finalizeStep.intercept(position: .before, middleware: ClientRuntime.ContentLengthMiddleware())
+        operation.finalizeStep.intercept(position: .after, middleware: ClientRuntime.RetryMiddleware<ClientRuntime.DefaultRetryStrategy, AWSClientRuntime.AWSRetryErrorInfoProvider, InvokeEndpointWithResponseStreamOutputResponse, InvokeEndpointWithResponseStreamOutputError>(options: config.retryStrategyOptions))
+        let sigv4Config = AWSClientRuntime.SigV4Config(unsignedBody: false, signingAlgorithm: .sigv4)
+        operation.finalizeStep.intercept(position: .before, middleware: AWSClientRuntime.SigV4Middleware<InvokeEndpointWithResponseStreamOutputResponse, InvokeEndpointWithResponseStreamOutputError>(config: sigv4Config))
+        operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.DeserializeMiddleware<InvokeEndpointWithResponseStreamOutputResponse, InvokeEndpointWithResponseStreamOutputError>())
+        operation.deserializeStep.intercept(position: .after, middleware: ClientRuntime.LoggerMiddleware<InvokeEndpointWithResponseStreamOutputResponse, InvokeEndpointWithResponseStreamOutputError>(clientLogMode: config.clientLogMode))
+        let result = try await operation.handleMiddleware(context: context, input: input, next: client.getHandler())
+        return result
+    }
+
 }

--- a/Sources/Services/AWSSageMakerRuntime/SageMakerRuntimeClientProtocol.swift
+++ b/Sources/Services/AWSSageMakerRuntime/SageMakerRuntimeClientProtocol.swift
@@ -33,6 +33,29 @@ public protocol SageMakerRuntimeClientProtocol {
     /// - `ServiceUnavailable` : The service is unavailable. Try your call again.
     /// - `ValidationError` : Inspect your request and try again.
     func invokeEndpointAsync(input: InvokeEndpointAsyncInput) async throws -> InvokeEndpointAsyncOutputResponse
+    /// Invokes a model at the specified endpoint to return the inference response as a stream. The inference stream provides the response payload incrementally as a series of parts. Before you can get an inference stream, you must have access to a model that's deployed using Amazon SageMaker hosting services, and the container for that model must support inference streaming. For more information that can help you use this API, see the following sections in the Amazon SageMaker Developer Guide:
+    ///
+    /// * For information about how to add streaming support to a model, see [How Containers Serve Requests](https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-inference-code.html#your-algorithms-inference-code-how-containe-serves-requests).
+    ///
+    /// * For information about how to process the streaming response, see [Invoke real-time endpoints](https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints-test-endpoints.html).
+    ///
+    ///
+    /// Amazon SageMaker strips all POST headers except those supported by the API. Amazon SageMaker might add additional headers. You should not rely on the behavior of headers outside those enumerated in the request syntax. Calls to InvokeEndpointWithResponseStream are authenticated by using Amazon Web Services Signature Version 4. For information, see [Authenticating Requests (Amazon Web Services Signature Version 4)](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html) in the Amazon S3 API Reference.
+    ///
+    /// - Parameter InvokeEndpointWithResponseStreamInput : [no documentation found]
+    ///
+    /// - Returns: `InvokeEndpointWithResponseStreamOutputResponse` : [no documentation found]
+    ///
+    /// - Throws: One of the exceptions listed below __Possible Exceptions__.
+    ///
+    /// __Possible Exceptions:__
+    /// - `InternalFailure` : An internal failure occurred.
+    /// - `InternalStreamFailure` : The stream processing failed because of an unknown error, exception or failure. Try your request again.
+    /// - `ModelError` : Model (owned by the customer in the container) returned 4xx or 5xx error code.
+    /// - `ModelStreamError` : An error occurred while streaming the response body. This error can have the following error codes: ModelInvocationTimeExceeded The model failed to finish sending the response within the timeout period allowed by Amazon SageMaker. StreamBroken The Transmission Control Protocol (TCP) connection between the client and the model was reset or closed.
+    /// - `ServiceUnavailable` : The service is unavailable. Try your call again.
+    /// - `ValidationError` : Inspect your request and try again.
+    func invokeEndpointWithResponseStream(input: InvokeEndpointWithResponseStreamInput) async throws -> InvokeEndpointWithResponseStreamOutputResponse
 }
 
 public enum SageMakerRuntimeClientTypes {}

--- a/Sources/Services/AWSTranscribeStreaming/models/Models.swift
+++ b/Sources/Services/AWSTranscribeStreaming/models/Models.swift
@@ -163,7 +163,7 @@ extension BadRequestException: Swift.Codable {
     public init(from decoder: Swift.Decoder) throws {
         let containerValues = try decoder.container(keyedBy: CodingKeys.self)
         let messageDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .message)
-        message = messageDecoded
+        properties.message = messageDecoded
     }
 }
 
@@ -741,7 +741,7 @@ extension ConflictException: Swift.Codable {
     public init(from decoder: Swift.Decoder) throws {
         let containerValues = try decoder.container(keyedBy: CodingKeys.self)
         let messageDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .message)
-        message = messageDecoded
+        properties.message = messageDecoded
     }
 }
 
@@ -990,7 +990,7 @@ extension InternalFailureException: Swift.Codable {
     public init(from decoder: Swift.Decoder) throws {
         let containerValues = try decoder.container(keyedBy: CodingKeys.self)
         let messageDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .message)
-        message = messageDecoded
+        properties.message = messageDecoded
     }
 }
 
@@ -1349,7 +1349,7 @@ extension LimitExceededException: Swift.Codable {
     public init(from decoder: Swift.Decoder) throws {
         let containerValues = try decoder.container(keyedBy: CodingKeys.self)
         let messageDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .message)
-        message = messageDecoded
+        properties.message = messageDecoded
     }
 }
 
@@ -2326,7 +2326,7 @@ extension ServiceUnavailableException: Swift.Codable {
     public init(from decoder: Swift.Decoder) throws {
         let containerValues = try decoder.container(keyedBy: CodingKeys.self)
         let messageDecoded = try containerValues.decodeIfPresent(Swift.String.self, forKey: .message)
-        message = messageDecoded
+        properties.message = messageDecoded
     }
 }
 

--- a/codegen/sdk-codegen/aws-models/sagemaker-runtime.2017-05-13.json
+++ b/codegen/sdk-codegen/aws-models/sagemaker-runtime.2017-05-13.json
@@ -38,6 +38,9 @@
                 },
                 {
                     "target": "com.amazonaws.sagemakerruntime#InvokeEndpointAsync"
+                },
+                {
+                    "target": "com.amazonaws.sagemakerruntime#InvokeEndpointWithResponseStream"
                 }
             ],
             "traits": {
@@ -46,6 +49,7 @@
                     "arnNamespace": "sagemaker",
                     "cloudFormationName": "SageMakerRuntime",
                     "cloudTrailEventSource": "sagemakerruntime.amazonaws.com",
+                    "docId": "runtime.sagemaker-2017-05-13",
                     "endpointPrefix": "runtime.sagemaker"
                 },
                 "aws.auth#sigv4": {
@@ -1113,6 +1117,9 @@
                 "smithy.api#pattern": "^[a-zA-Z0-9](-*[a-zA-Z0-9])*$"
             }
         },
+        "com.amazonaws.sagemakerruntime#ErrorCode": {
+            "type": "string"
+        },
         "com.amazonaws.sagemakerruntime#Header": {
             "type": "string",
             "traits": {
@@ -1169,6 +1176,18 @@
                 "smithy.api#httpError": 500
             }
         },
+        "com.amazonaws.sagemakerruntime#InternalStreamFailure": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.sagemakerruntime#Message"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The stream processing failed because of an unknown error, exception or failure. Try your request again.</p>",
+                "smithy.api#error": "server"
+            }
+        },
         "com.amazonaws.sagemakerruntime#InvocationTimeoutSecondsHeader": {
             "type": "integer",
             "traits": {
@@ -1207,7 +1226,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>After you deploy a model into production using Amazon SageMaker hosting services, your\n            client applications use this API to get inferences from the model hosted at the\n            specified endpoint. </p>\n         <p>For an overview of Amazon SageMaker, see <a href=\"https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works.html\">How It Works</a>. </p>\n         <p>Amazon SageMaker strips all POST headers except those supported by the API. Amazon SageMaker might add\n            additional headers. You should not rely on the behavior of headers outside those\n            enumerated in the request syntax. </p>\n         <p>Calls to <code>InvokeEndpoint</code> are authenticated by using Amazon Web Services\n            Signature Version 4. For information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html\">Authenticating\n                Requests (Amazon Web Services Signature Version 4)</a> in the <i>Amazon S3 API\n                Reference</i>.</p>\n         <p>A customer's model containers must respond to requests within 60 seconds. The model\n            itself can have a maximum processing time of 60 seconds before responding to\n            invocations. If your model is going to take 50-60 seconds of processing time, the SDK\n            socket timeout should be set to be 70 seconds.</p>\n         <note>\n            <p>Endpoints are scoped to an individual account, and are not public. The URL does\n                not contain the account ID, but Amazon SageMaker determines the account ID from the\n                authentication token that is supplied by the caller.</p>\n         </note>",
+                "smithy.api#documentation": "<p>After you deploy a model into production using Amazon SageMaker hosting services,\n            your client applications use this API to get inferences from the model hosted at the\n            specified endpoint. </p>\n         <p>For an overview of Amazon SageMaker, see <a href=\"https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works.html\">How It Works</a>. </p>\n         <p>Amazon SageMaker strips all POST headers except those supported by the API. Amazon SageMaker might add\n    additional headers. You should not rely on the behavior of headers outside those\n    enumerated in the request syntax. </p>\n         <p>Calls to <code>InvokeEndpoint</code> are authenticated by using Amazon Web Services\n            Signature Version 4. For information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html\">Authenticating\n                Requests (Amazon Web Services Signature Version 4)</a> in the <i>Amazon S3 API Reference</i>.</p>\n         <p>A customer's model containers must respond to requests within 60 seconds. The model\n            itself can have a maximum processing time of 60 seconds before responding to\n            invocations. If your model is going to take 50-60 seconds of processing time, the SDK\n            socket timeout should be set to be 70 seconds.</p>\n         <note>\n            <p>Endpoints are scoped to an individual account, and are not public. The URL does\n                not contain the account ID, but Amazon SageMaker determines the account ID from\n                the authentication token that is supplied by the caller.</p>\n         </note>",
                 "smithy.api#http": {
                     "method": "POST",
                     "uri": "/endpoints/{EndpointName}/invocations",
@@ -1235,7 +1254,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>After you deploy a model into production using Amazon SageMaker hosting services, your client\n            applications use this API to get inferences from the model hosted at the specified\n            endpoint in an asynchronous manner.</p>\n         <p>Inference requests sent to this API are enqueued for asynchronous processing. The\n            processing of the inference request may or may not complete before you receive a\n            response from this API. The response from this API will not contain the result of the\n            inference request but contain information about where you can locate it.</p>\n         <p>Amazon SageMaker strips all <code>POST</code> headers except those supported by the API. Amazon SageMaker\n            might add additional headers. You should not rely on the behavior of headers outside\n            those enumerated in the request syntax.</p>\n         <p>Calls to <code>InvokeEndpointAsync</code> are authenticated by using Amazon Web Services Signature Version 4. For information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html\">Authenticating Requests (Amazon Web Services Signature Version 4)</a> in the\n                <i>Amazon S3 API Reference</i>.</p>",
+                "smithy.api#documentation": "<p>After you deploy a model into production using Amazon SageMaker hosting services,\n            your client applications use this API to get inferences from the model hosted at the\n            specified endpoint in an asynchronous manner.</p>\n         <p>Inference requests sent to this API are enqueued for asynchronous processing. The\n            processing of the inference request may or may not complete before you receive a\n            response from this API. The response from this API will not contain the result of the\n            inference request but contain information about where you can locate it.</p>\n         <p>Amazon SageMaker strips all POST headers except those supported by the API. Amazon SageMaker might add\n    additional headers. You should not rely on the behavior of headers outside those\n    enumerated in the request syntax. </p>\n         <p>Calls to <code>InvokeEndpointAsync</code> are authenticated by using Amazon Web Services Signature Version 4. For information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html\">Authenticating\n                Requests (Amazon Web Services Signature Version 4)</a> in the <i>Amazon S3 API Reference</i>.</p>",
                 "smithy.api#http": {
                     "method": "POST",
                     "uri": "/endpoints/{EndpointName}/async-invocations",
@@ -1249,7 +1268,7 @@
                 "EndpointName": {
                     "target": "com.amazonaws.sagemakerruntime#EndpointName",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the endpoint that you specified when you created the endpoint using the\n                <a href=\"https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateEndpoint.html\">\n               <code>CreateEndpoint</code>\n            </a> API.</p>",
+                        "smithy.api#documentation": "<p>The name of the endpoint that you specified when you created the endpoint using the\n    <a href=\"https://docs.aws.amazon.com/sagemaker/latest/dg/API_CreateEndpoint.html\">CreateEndpoint</a> API.</p>",
                         "smithy.api#httpLabel": {},
                         "smithy.api#required": {}
                     }
@@ -1264,21 +1283,21 @@
                 "Accept": {
                     "target": "com.amazonaws.sagemakerruntime#Header",
                     "traits": {
-                        "smithy.api#documentation": "<p>The desired MIME type of the inference in the response.</p>",
+                        "smithy.api#documentation": "<p>The desired MIME type of the inference response from the model container.</p>",
                         "smithy.api#httpHeader": "X-Amzn-SageMaker-Accept"
                     }
                 },
                 "CustomAttributes": {
                     "target": "com.amazonaws.sagemakerruntime#CustomAttributesHeader",
                     "traits": {
-                        "smithy.api#documentation": "<p>Provides additional information about a request for an inference submitted to a model\n            hosted at an Amazon SageMaker endpoint. The information is an opaque value that is forwarded\n            verbatim. You could use this value, for example, to provide an ID that you can use to\n            track a request or to provide other metadata that a service endpoint was programmed to\n            process. The value must consist of no more than 1024 visible US-ASCII characters as\n            specified in <a href=\"https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6\">Section 3.3.6. Field Value Components</a> of the Hypertext Transfer Protocol\n            (HTTP/1.1). </p>\n         <p>The code in your model is responsible for setting or updating any custom attributes in\n            the response. If your code does not set this value in the response, an empty value is\n            returned. For example, if a custom attribute represents the trace ID, your model can\n            prepend the custom attribute with <code>Trace ID</code>: in your post-processing\n            function. </p>\n         <p>This feature is currently supported in the Amazon Web Services SDKs but not in the Amazon SageMaker\n            Python SDK. </p>",
+                        "smithy.api#documentation": "<p>Provides additional information about a request for an inference submitted to a model\n        hosted at an Amazon SageMaker endpoint. The information is an opaque value that is forwarded\n        verbatim. You could use this value, for example, to provide an ID that you can use to\n        track a request or to provide other metadata that a service endpoint was programmed to\n        process. The value must consist of no more than 1024 visible US-ASCII characters as\n        specified in <a href=\"https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6\">Section 3.3.6. Field Value Components</a> of the Hypertext Transfer Protocol\n        (HTTP/1.1). </p>\n         <p>The code in your model is responsible for setting or updating any custom attributes in\n        the response. If your code does not set this value in the response, an empty value is\n        returned. For example, if a custom attribute represents the trace ID, your model can\n        prepend the custom attribute with <code>Trace ID:</code> in your post-processing\n        function. </p>\n         <p>This feature is currently supported in the Amazon Web Services SDKs but not in the Amazon SageMaker\n        Python SDK. </p>",
                         "smithy.api#httpHeader": "X-Amzn-SageMaker-Custom-Attributes"
                     }
                 },
                 "InferenceId": {
                     "target": "com.amazonaws.sagemakerruntime#InferenceId",
                     "traits": {
-                        "smithy.api#documentation": "<p>The identifier for the inference request. Amazon SageMaker will generate an identifier for you if\n            none is specified. </p>",
+                        "smithy.api#documentation": "<p>The identifier for the inference request. Amazon SageMaker will generate an\n            identifier for you if none is specified. </p>",
                         "smithy.api#httpHeader": "X-Amzn-SageMaker-Inference-Id"
                     }
                 },
@@ -1293,14 +1312,14 @@
                 "RequestTTLSeconds": {
                     "target": "com.amazonaws.sagemakerruntime#RequestTTLSecondsHeader",
                     "traits": {
-                        "smithy.api#documentation": "<p>Maximum age in seconds a request can be in the queue before it is marked as\n            expired. The default is 6 hours, or 21,600 seconds.</p>",
+                        "smithy.api#documentation": "<p>Maximum age in seconds a request can be in the queue before it is marked as expired.\n            The default is 6 hours, or 21,600 seconds.</p>",
                         "smithy.api#httpHeader": "X-Amzn-SageMaker-RequestTTLSeconds"
                     }
                 },
                 "InvocationTimeoutSeconds": {
                     "target": "com.amazonaws.sagemakerruntime#InvocationTimeoutSecondsHeader",
                     "traits": {
-                        "smithy.api#documentation": "<p>Maximum amount of time in seconds a request can be processed before it is marked as expired. The default is 15 minutes, or 900 seconds.</p>",
+                        "smithy.api#documentation": "<p>Maximum amount of time in seconds a request can be processed before it is marked as\n            expired. The default is 15 minutes, or 900 seconds.</p>",
                         "smithy.api#httpHeader": "X-Amzn-SageMaker-InvocationTimeoutSeconds"
                     }
                 }
@@ -1315,7 +1334,7 @@
                 "InferenceId": {
                     "target": "com.amazonaws.sagemakerruntime#Header",
                     "traits": {
-                        "smithy.api#documentation": "<p>Identifier for an inference request. This will be the same as the\n                <code>InferenceId</code> specified in the input. Amazon SageMaker will generate an identifier\n            for you if you do not specify one.</p>"
+                        "smithy.api#documentation": "<p>Identifier for an inference request. This will be the same as the\n                <code>InferenceId</code> specified in the input. Amazon SageMaker will generate\n            an identifier for you if you do not specify one.</p>"
                     }
                 },
                 "OutputLocation": {
@@ -1328,7 +1347,7 @@
                 "FailureLocation": {
                     "target": "com.amazonaws.sagemakerruntime#Header",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon S3 URI where the inference failure response payload is stored.</p>",
+                        "smithy.api#documentation": "<p>The Amazon S3 URI where the inference failure response payload is\n            stored.</p>",
                         "smithy.api#httpHeader": "X-Amzn-SageMaker-FailureLocation"
                     }
                 }
@@ -1343,7 +1362,7 @@
                 "EndpointName": {
                     "target": "com.amazonaws.sagemakerruntime#EndpointName",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the endpoint that you specified when you created the endpoint using the\n                <a href=\"https://docs.aws.amazon.com/sagemaker/latest/dg/API_CreateEndpoint.html\">CreateEndpoint</a> API. </p>",
+                        "smithy.api#documentation": "<p>The name of the endpoint that you specified when you created the endpoint using the\n    <a href=\"https://docs.aws.amazon.com/sagemaker/latest/dg/API_CreateEndpoint.html\">CreateEndpoint</a> API.</p>",
                         "smithy.api#httpLabel": {},
                         "smithy.api#required": {}
                     }
@@ -1351,7 +1370,7 @@
                 "Body": {
                     "target": "com.amazonaws.sagemakerruntime#BodyBlob",
                     "traits": {
-                        "smithy.api#documentation": "<p>Provides input data, in the format specified in the <code>ContentType</code>\n            request header. Amazon SageMaker passes all of the data in the body to the model. </p>\n         <p>For information about the format of the request body, see <a href=\"https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-inference.html\">Common Data\n                Formats-Inference</a>.</p>",
+                        "smithy.api#documentation": "<p>Provides input data, in the format specified in the <code>ContentType</code>\n    request header. Amazon SageMaker passes all of the data in the body to the model. </p>\n         <p>For information about the format of the request body, see <a href=\"https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-inference.html\">Common Data\n        Formats-Inference</a>.</p>",
                         "smithy.api#httpPayload": {},
                         "smithy.api#required": {}
                     }
@@ -1366,14 +1385,14 @@
                 "Accept": {
                     "target": "com.amazonaws.sagemakerruntime#Header",
                     "traits": {
-                        "smithy.api#documentation": "<p>The desired MIME type of the inference in the response.</p>",
+                        "smithy.api#documentation": "<p>The desired MIME type of the inference response from the model container.</p>",
                         "smithy.api#httpHeader": "Accept"
                     }
                 },
                 "CustomAttributes": {
                     "target": "com.amazonaws.sagemakerruntime#CustomAttributesHeader",
                     "traits": {
-                        "smithy.api#documentation": "<p>Provides additional information about a request for an inference submitted to a model\n            hosted at an Amazon SageMaker endpoint. The information is an opaque value that is\n            forwarded verbatim. You could use this value, for example, to provide an ID that you can\n            use to track a request or to provide other metadata that a service endpoint was\n            programmed to process. The value must consist of no more than 1024 visible US-ASCII\n            characters as specified in <a href=\"https://tools.ietf.org/html/rfc7230#section-3.2.6\">Section 3.3.6. Field Value\n                Components</a> of the Hypertext Transfer Protocol (HTTP/1.1). </p>\n         <p>The code in your model is responsible for setting or updating any custom attributes in\n            the response. If your code does not set this value in the response, an empty value is\n            returned. For example, if a custom attribute represents the trace ID, your model can\n            prepend the custom attribute with <code>Trace ID:</code> in your post-processing\n            function.</p>\n         <p>This feature is currently supported in the Amazon Web Services SDKs but not in the Amazon SageMaker\n            Python SDK.</p>",
+                        "smithy.api#documentation": "<p>Provides additional information about a request for an inference submitted to a model\n        hosted at an Amazon SageMaker endpoint. The information is an opaque value that is forwarded\n        verbatim. You could use this value, for example, to provide an ID that you can use to\n        track a request or to provide other metadata that a service endpoint was programmed to\n        process. The value must consist of no more than 1024 visible US-ASCII characters as\n        specified in <a href=\"https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6\">Section 3.3.6. Field Value Components</a> of the Hypertext Transfer Protocol\n        (HTTP/1.1). </p>\n         <p>The code in your model is responsible for setting or updating any custom attributes in\n        the response. If your code does not set this value in the response, an empty value is\n        returned. For example, if a custom attribute represents the trace ID, your model can\n        prepend the custom attribute with <code>Trace ID:</code> in your post-processing\n        function. </p>\n         <p>This feature is currently supported in the Amazon Web Services SDKs but not in the Amazon SageMaker\n        Python SDK. </p>",
                         "smithy.api#httpHeader": "X-Amzn-SageMaker-Custom-Attributes"
                     }
                 },
@@ -1387,14 +1406,14 @@
                 "TargetVariant": {
                     "target": "com.amazonaws.sagemakerruntime#TargetVariantHeader",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specify the production variant to send the inference request to when invoking an\n            endpoint that is running two or more variants. Note that this parameter overrides the\n            default behavior for the endpoint, which is to distribute the invocation traffic based\n            on the variant weights.</p>\n         <p>For information about how to use variant targeting to perform a/b testing, see <a href=\"https://docs.aws.amazon.com/sagemaker/latest/dg/model-ab-testing.html\">Test models in\n                production</a>\n         </p>",
+                        "smithy.api#documentation": "<p>Specify the production variant to send the inference request to when invoking an\n        endpoint that is running two or more variants. Note that this parameter overrides the\n        default behavior for the endpoint, which is to distribute the invocation traffic based\n        on the variant weights.</p>\n         <p>For information about how to use variant targeting to perform a/b testing, see <a href=\"https://docs.aws.amazon.com/sagemaker/latest/dg/model-ab-testing.html\">Test models in\n            production</a>\n         </p>",
                         "smithy.api#httpHeader": "X-Amzn-SageMaker-Target-Variant"
                     }
                 },
                 "TargetContainerHostname": {
                     "target": "com.amazonaws.sagemakerruntime#TargetContainerHostnameHeader",
                     "traits": {
-                        "smithy.api#documentation": "<p>If the endpoint hosts multiple containers and is configured to use direct invocation,\n            this parameter specifies the host name of the container to invoke.</p>",
+                        "smithy.api#documentation": "<p>If the endpoint hosts multiple containers and is configured to use direct invocation,\n        this parameter specifies the host name of the container to invoke.</p>",
                         "smithy.api#httpHeader": "X-Amzn-SageMaker-Target-Container-Hostname"
                     }
                 },
@@ -1423,7 +1442,7 @@
                 "Body": {
                     "target": "com.amazonaws.sagemakerruntime#BodyBlob",
                     "traits": {
-                        "smithy.api#documentation": "<p>Includes the inference provided by the model. </p>\n         <p>For information about the format of the response body, see <a href=\"https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-inference.html\">Common Data\n                Formats-Inference</a>.</p>\n         <p>If the explainer is activated, the\n            body includes the explanations provided by the model. For more information, see the\n            <b>Response section</b> under <a href=\"https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-online-explainability-invoke-endpoint.html#clarify-online-explainability-response\">Invoke the Endpoint</a> in the Developer Guide.</p>",
+                        "smithy.api#documentation": "<p>Includes the inference provided by the model. </p>\n         <p>For information about the format of the response body, see <a href=\"https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-inference.html\">Common Data\n            Formats-Inference</a>.</p>\n         <p>If the explainer is activated, the body includes the explanations provided by the\n            model. For more information, see the <b>Response section</b>\n            under <a href=\"https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-online-explainability-invoke-endpoint.html#clarify-online-explainability-response\">Invoke the Endpoint</a> in the Developer Guide.</p>",
                         "smithy.api#httpPayload": {},
                         "smithy.api#required": {}
                     }
@@ -1431,7 +1450,7 @@
                 "ContentType": {
                     "target": "com.amazonaws.sagemakerruntime#Header",
                     "traits": {
-                        "smithy.api#documentation": "<p>The MIME type of the inference returned in the response body.</p>",
+                        "smithy.api#documentation": "<p>The MIME type of the inference returned from the model container.</p>",
                         "smithy.api#httpHeader": "Content-Type"
                     }
                 },
@@ -1445,7 +1464,146 @@
                 "CustomAttributes": {
                     "target": "com.amazonaws.sagemakerruntime#CustomAttributesHeader",
                     "traits": {
-                        "smithy.api#documentation": "<p>Provides additional information in the response about the inference returned by a\n            model hosted at an Amazon SageMaker endpoint. The information is an opaque value that is\n            forwarded verbatim. You could use this value, for example, to return an ID received in\n            the <code>CustomAttributes</code> header of a request or other metadata that a service\n            endpoint was programmed to produce. The value must consist of no more than 1024 visible\n            US-ASCII characters as specified in <a href=\"https://tools.ietf.org/html/rfc7230#section-3.2.6\">Section 3.3.6. Field Value\n                Components</a> of the Hypertext Transfer Protocol (HTTP/1.1). If the customer\n            wants the custom attribute returned, the model must set the custom attribute to be\n            included on the way back. </p>\n         <p>The code in your model is responsible for setting or updating any custom attributes in\n            the response. If your code does not set this value in the response, an empty value is\n            returned. For example, if a custom attribute represents the trace ID, your model can\n            prepend the custom attribute with <code>Trace ID:</code> in your post-processing\n            function.</p>\n         <p>This feature is currently supported in the Amazon Web Services SDKs but not in the Amazon SageMaker\n            Python SDK.</p>",
+                        "smithy.api#documentation": "<p>Provides additional information in the response about the inference returned by a\n        model hosted at an Amazon SageMaker endpoint. The information is an opaque value that is\n        forwarded verbatim. You could use this value, for example, to return an ID received in\n        the <code>CustomAttributes</code> header of a request or other metadata that a service\n        endpoint was programmed to produce. The value must consist of no more than 1024 visible\n        US-ASCII characters as specified in <a href=\"https://tools.ietf.org/html/rfc7230#section-3.2.6\">Section 3.3.6. Field Value\n            Components</a> of the Hypertext Transfer Protocol (HTTP/1.1). If the customer\n        wants the custom attribute returned, the model must set the custom attribute to be\n        included on the way back. </p>\n         <p>The code in your model is responsible for setting or updating any custom attributes in\n        the response. If your code does not set this value in the response, an empty value is\n        returned. For example, if a custom attribute represents the trace ID, your model can\n        prepend the custom attribute with <code>Trace ID:</code> in your post-processing\n        function.</p>\n         <p>This feature is currently supported in the Amazon Web Services SDKs but not in the Amazon SageMaker\n        Python SDK.</p>",
+                        "smithy.api#httpHeader": "X-Amzn-SageMaker-Custom-Attributes"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.sagemakerruntime#InvokeEndpointWithResponseStream": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.sagemakerruntime#InvokeEndpointWithResponseStreamInput"
+            },
+            "output": {
+                "target": "com.amazonaws.sagemakerruntime#InvokeEndpointWithResponseStreamOutput"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.sagemakerruntime#InternalFailure"
+                },
+                {
+                    "target": "com.amazonaws.sagemakerruntime#InternalStreamFailure"
+                },
+                {
+                    "target": "com.amazonaws.sagemakerruntime#ModelError"
+                },
+                {
+                    "target": "com.amazonaws.sagemakerruntime#ModelStreamError"
+                },
+                {
+                    "target": "com.amazonaws.sagemakerruntime#ServiceUnavailable"
+                },
+                {
+                    "target": "com.amazonaws.sagemakerruntime#ValidationError"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Invokes a model at the specified endpoint to return the inference response as a\n            stream. The inference stream provides the response payload incrementally as a series of\n            parts. Before you can get an inference stream, you must have access to a model that's\n            deployed using Amazon SageMaker hosting services, and the container for that model\n            must support inference streaming.</p>\n         <p>For more information that can help you use this API, see the following sections in the\n                    <i>Amazon SageMaker Developer Guide</i>:</p>\n         <ul>\n            <li>\n               <p>For information about how to add streaming support to a model, see <a href=\"https://docs.aws.amazon.com/sagemaker/latest/dg/your-algorithms-inference-code.html#your-algorithms-inference-code-how-containe-serves-requests\">How Containers Serve Requests</a>.</p>\n            </li>\n            <li>\n               <p>For information about how to process the streaming response, see <a href=\"https://docs.aws.amazon.com/sagemaker/latest/dg/realtime-endpoints-test-endpoints.html\">Invoke real-time endpoints</a>.</p>\n            </li>\n         </ul>\n         <p>Amazon SageMaker strips all POST headers except those supported by the API. Amazon SageMaker might add\n    additional headers. You should not rely on the behavior of headers outside those\n    enumerated in the request syntax. </p>\n         <p>Calls to <code>InvokeEndpointWithResponseStream</code> are authenticated by using\n                Amazon Web Services Signature Version 4. For information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html\">Authenticating Requests (Amazon Web Services Signature Version 4)</a> in the\n                    <i>Amazon S3 API Reference</i>.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/endpoints/{EndpointName}/invocations-response-stream",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.sagemakerruntime#InvokeEndpointWithResponseStreamInput": {
+            "type": "structure",
+            "members": {
+                "EndpointName": {
+                    "target": "com.amazonaws.sagemakerruntime#EndpointName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the endpoint that you specified when you created the endpoint using the\n    <a href=\"https://docs.aws.amazon.com/sagemaker/latest/dg/API_CreateEndpoint.html\">CreateEndpoint</a> API.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "Body": {
+                    "target": "com.amazonaws.sagemakerruntime#BodyBlob",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Provides input data, in the format specified in the <code>ContentType</code>\n    request header. Amazon SageMaker passes all of the data in the body to the model. </p>\n         <p>For information about the format of the request body, see <a href=\"https://docs.aws.amazon.com/sagemaker/latest/dg/cdf-inference.html\">Common Data\n        Formats-Inference</a>.</p>",
+                        "smithy.api#httpPayload": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "ContentType": {
+                    "target": "com.amazonaws.sagemakerruntime#Header",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The MIME type of the input data in the request body.</p>",
+                        "smithy.api#httpHeader": "Content-Type"
+                    }
+                },
+                "Accept": {
+                    "target": "com.amazonaws.sagemakerruntime#Header",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The desired MIME type of the inference response from the model container.</p>",
+                        "smithy.api#httpHeader": "X-Amzn-SageMaker-Accept"
+                    }
+                },
+                "CustomAttributes": {
+                    "target": "com.amazonaws.sagemakerruntime#CustomAttributesHeader",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Provides additional information about a request for an inference submitted to a model\n        hosted at an Amazon SageMaker endpoint. The information is an opaque value that is forwarded\n        verbatim. You could use this value, for example, to provide an ID that you can use to\n        track a request or to provide other metadata that a service endpoint was programmed to\n        process. The value must consist of no more than 1024 visible US-ASCII characters as\n        specified in <a href=\"https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6\">Section 3.3.6. Field Value Components</a> of the Hypertext Transfer Protocol\n        (HTTP/1.1). </p>\n         <p>The code in your model is responsible for setting or updating any custom attributes in\n        the response. If your code does not set this value in the response, an empty value is\n        returned. For example, if a custom attribute represents the trace ID, your model can\n        prepend the custom attribute with <code>Trace ID:</code> in your post-processing\n        function. </p>\n         <p>This feature is currently supported in the Amazon Web Services SDKs but not in the Amazon SageMaker\n        Python SDK. </p>",
+                        "smithy.api#httpHeader": "X-Amzn-SageMaker-Custom-Attributes"
+                    }
+                },
+                "TargetVariant": {
+                    "target": "com.amazonaws.sagemakerruntime#TargetVariantHeader",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specify the production variant to send the inference request to when invoking an\n        endpoint that is running two or more variants. Note that this parameter overrides the\n        default behavior for the endpoint, which is to distribute the invocation traffic based\n        on the variant weights.</p>\n         <p>For information about how to use variant targeting to perform a/b testing, see <a href=\"https://docs.aws.amazon.com/sagemaker/latest/dg/model-ab-testing.html\">Test models in\n            production</a>\n         </p>",
+                        "smithy.api#httpHeader": "X-Amzn-SageMaker-Target-Variant"
+                    }
+                },
+                "TargetContainerHostname": {
+                    "target": "com.amazonaws.sagemakerruntime#TargetContainerHostnameHeader",
+                    "traits": {
+                        "smithy.api#documentation": "<p>If the endpoint hosts multiple containers and is configured to use direct invocation,\n        this parameter specifies the host name of the container to invoke.</p>",
+                        "smithy.api#httpHeader": "X-Amzn-SageMaker-Target-Container-Hostname"
+                    }
+                },
+                "InferenceId": {
+                    "target": "com.amazonaws.sagemakerruntime#InferenceId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An identifier that you assign to your request.</p>",
+                        "smithy.api#httpHeader": "X-Amzn-SageMaker-Inference-Id"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.sagemakerruntime#InvokeEndpointWithResponseStreamOutput": {
+            "type": "structure",
+            "members": {
+                "Body": {
+                    "target": "com.amazonaws.sagemakerruntime#ResponseStream",
+                    "traits": {
+                        "smithy.api#httpPayload": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "ContentType": {
+                    "target": "com.amazonaws.sagemakerruntime#Header",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The MIME type of the inference returned from the model container.</p>",
+                        "smithy.api#httpHeader": "X-Amzn-SageMaker-Content-Type"
+                    }
+                },
+                "InvokedProductionVariant": {
+                    "target": "com.amazonaws.sagemakerruntime#Header",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Identifies the production variant that was invoked.</p>",
+                        "smithy.api#httpHeader": "x-Amzn-Invoked-Production-Variant"
+                    }
+                },
+                "CustomAttributes": {
+                    "target": "com.amazonaws.sagemakerruntime#CustomAttributesHeader",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Provides additional information in the response about the inference returned by a\n        model hosted at an Amazon SageMaker endpoint. The information is an opaque value that is\n        forwarded verbatim. You could use this value, for example, to return an ID received in\n        the <code>CustomAttributes</code> header of a request or other metadata that a service\n        endpoint was programmed to produce. The value must consist of no more than 1024 visible\n        US-ASCII characters as specified in <a href=\"https://tools.ietf.org/html/rfc7230#section-3.2.6\">Section 3.3.6. Field Value\n            Components</a> of the Hypertext Transfer Protocol (HTTP/1.1). If the customer\n        wants the custom attribute returned, the model must set the custom attribute to be\n        included on the way back. </p>\n         <p>The code in your model is responsible for setting or updating any custom attributes in\n        the response. If your code does not set this value in the response, an empty value is\n        returned. For example, if a custom attribute represents the trace ID, your model can\n        prepend the custom attribute with <code>Trace ID:</code> in your post-processing\n        function.</p>\n         <p>This feature is currently supported in the Amazon Web Services SDKs but not in the Amazon SageMaker\n        Python SDK.</p>",
                         "smithy.api#httpHeader": "X-Amzn-SageMaker-Custom-Attributes"
                     }
                 }
@@ -1514,6 +1672,45 @@
                 "smithy.api#httpError": 429
             }
         },
+        "com.amazonaws.sagemakerruntime#ModelStreamError": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.sagemakerruntime#Message"
+                },
+                "ErrorCode": {
+                    "target": "com.amazonaws.sagemakerruntime#ErrorCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>This error can have the following error codes:</p>\n         <dl>\n            <dt>ModelInvocationTimeExceeded</dt>\n            <dd>\n               <p>The model failed to finish sending the response within the timeout period\n                        allowed by Amazon SageMaker.</p>\n            </dd>\n            <dt>StreamBroken</dt>\n            <dd>\n               <p>The Transmission Control Protocol (TCP) connection between the client and\n                        the model was reset or closed.</p>\n            </dd>\n         </dl>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> An error occurred while streaming the response body. This error can have the\n    following error codes:</p>\n         <dl>\n            <dt>ModelInvocationTimeExceeded</dt>\n            <dd>\n               <p>The model failed to finish sending the response within the timeout period allowed by Amazon SageMaker.</p>\n            </dd>\n            <dt>StreamBroken</dt>\n            <dd>\n               <p>The Transmission Control Protocol (TCP) connection between the client and\n                    the model was reset or closed.</p>\n            </dd>\n         </dl>",
+                "smithy.api#error": "client"
+            }
+        },
+        "com.amazonaws.sagemakerruntime#PartBlob": {
+            "type": "blob",
+            "traits": {
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.sagemakerruntime#PayloadPart": {
+            "type": "structure",
+            "members": {
+                "Bytes": {
+                    "target": "com.amazonaws.sagemakerruntime#PartBlob",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A blob that contains part of the response for your streaming inference request.</p>",
+                        "smithy.api#eventPayload": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A wrapper for pieces of the payload that's returned in response to a streaming\n        inference request. A streaming inference response consists of one or more payload parts.\n    </p>"
+            }
+        },
         "com.amazonaws.sagemakerruntime#RequestTTLSecondsHeader": {
             "type": "integer",
             "traits": {
@@ -1521,6 +1718,33 @@
                     "min": 60,
                     "max": 21600
                 }
+            }
+        },
+        "com.amazonaws.sagemakerruntime#ResponseStream": {
+            "type": "union",
+            "members": {
+                "PayloadPart": {
+                    "target": "com.amazonaws.sagemakerruntime#PayloadPart",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A wrapper for pieces of the payload that's returned in response to a streaming\n        inference request. A streaming inference response consists of one or more payload parts.\n    </p>"
+                    }
+                },
+                "ModelStreamError": {
+                    "target": "com.amazonaws.sagemakerruntime#ModelStreamError",
+                    "traits": {
+                        "smithy.api#documentation": "<p> An error occurred while streaming the response body. This error can have the\n    following error codes:</p>\n         <dl>\n            <dt>ModelInvocationTimeExceeded</dt>\n            <dd>\n               <p>The model failed to finish sending the response within the timeout period allowed by Amazon SageMaker.</p>\n            </dd>\n            <dt>StreamBroken</dt>\n            <dd>\n               <p>The Transmission Control Protocol (TCP) connection between the client and\n                    the model was reset or closed.</p>\n            </dd>\n         </dl>"
+                    }
+                },
+                "InternalStreamFailure": {
+                    "target": "com.amazonaws.sagemakerruntime#InternalStreamFailure",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The stream processing failed because of an unknown error, exception or failure. Try your request again.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A stream of payload parts. Each part contains a portion of the response for a\n            streaming inference request.</p>",
+                "smithy.api#streaming": {}
             }
         },
         "com.amazonaws.sagemakerruntime#ServiceUnavailable": {

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHttpBindingProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHttpBindingProtocolGenerator.kt
@@ -96,6 +96,7 @@ abstract class AWSHttpBindingProtocolGenerator : HttpBindingProtocolGenerator() 
         members: List<MemberShape>,
         writer: SwiftWriter,
         defaultTimestampFormat: TimestampFormatTrait.Format,
+        path: String
     ) {
         val encodeGenerator = StructEncodeGenerator(ctx, members, writer, defaultTimestampFormat)
         encodeGenerator.render()
@@ -106,9 +107,10 @@ abstract class AWSHttpBindingProtocolGenerator : HttpBindingProtocolGenerator() 
         shapeMetaData: Map<ShapeMetadata, Any>,
         members: List<MemberShape>,
         writer: SwiftWriter,
-        defaultTimestampFormat: TimestampFormatTrait.Format
+        defaultTimestampFormat: TimestampFormatTrait.Format,
+        path: String
     ) {
-        val decoder = StructDecodeGenerator(ctx, members, writer, defaultTimestampFormat)
+        val decoder = StructDecodeGenerator(ctx, members, writer, defaultTimestampFormat, path)
         decoder.render()
     }
 

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/AwsQueryProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/AwsQueryProtocolGenerator.kt
@@ -61,6 +61,7 @@ open class AwsQueryProtocolGenerator : AWSHttpBindingProtocolGenerator() {
         members: List<MemberShape>,
         writer: SwiftWriter,
         defaultTimestampFormat: TimestampFormatTrait.Format,
+        path: String
     ) {
         val customizations = AwsQueryFormURLEncodeCustomizations()
         val encoder = StructEncodeFormURLGenerator(ctx, customizations, shapeContainingMembers, shapeMetadata, members, writer, defaultTimestampFormat)
@@ -72,7 +73,8 @@ open class AwsQueryProtocolGenerator : AWSHttpBindingProtocolGenerator() {
         shapeMetadata: Map<ShapeMetadata, Any>,
         members: List<MemberShape>,
         writer: SwiftWriter,
-        defaultTimestampFormat: TimestampFormatTrait.Format
+        defaultTimestampFormat: TimestampFormatTrait.Format,
+        path: String
     ) {
         val decoder = AwsQueryStructDecodeXMLGenerator(ctx, members, shapeMetadata, writer, defaultTimestampFormat)
         decoder.render()

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/ec2query/Ec2QueryProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/ec2query/Ec2QueryProtocolGenerator.kt
@@ -57,6 +57,7 @@ class Ec2QueryProtocolGenerator : AWSHttpBindingProtocolGenerator() {
         members: List<MemberShape>,
         writer: SwiftWriter,
         defaultTimestampFormat: TimestampFormatTrait.Format,
+        path: String
     ) {
         val customizations = Ec2QueryFormURLEncodeCustomizations()
         val encoder = StructEncodeFormURLGenerator(ctx, customizations, shapeContainingMembers, shapeMetadata, members, writer, defaultTimestampFormat)
@@ -68,7 +69,8 @@ class Ec2QueryProtocolGenerator : AWSHttpBindingProtocolGenerator() {
         shapeMetadata: Map<ShapeMetadata, Any>,
         members: List<MemberShape>,
         writer: SwiftWriter,
-        defaultTimestampFormat: TimestampFormatTrait.Format
+        defaultTimestampFormat: TimestampFormatTrait.Format,
+        path: String
     ) {
         val decoder = StructDecodeXMLGenerator(ctx, members, mapOf(), writer, defaultTimestampFormat)
         decoder.render()

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/ec2query/httpResponse/AWSEc2QueryHttpResponseTraitWithoutPayload.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/ec2query/httpResponse/AWSEc2QueryHttpResponseTraitWithoutPayload.kt
@@ -58,7 +58,7 @@ class AWSEc2QueryHttpResponseTraitWithoutPayload(
                         else -> "nil"
                     }
                 }
-                writer.write("self.$path$memberName = $value")
+                writer.write("$path$memberName = $value")
             }
             writer.dedent()
             writer.write("}")

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/ec2query/httpResponse/AWSEc2QueryHttpResponseTraitWithoutPayload.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/ec2query/httpResponse/AWSEc2QueryHttpResponseTraitWithoutPayload.kt
@@ -58,7 +58,7 @@ class AWSEc2QueryHttpResponseTraitWithoutPayload(
                         else -> "nil"
                     }
                 }
-                writer.write("$path$memberName = $value")
+                writer.write("self.$path$memberName = $value")
             }
             writer.dedent()
             writer.write("}")

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/restxml/RestXmlProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/restxml/RestXmlProtocolGenerator.kt
@@ -43,6 +43,7 @@ class RestXmlProtocolGenerator : AWSHttpBindingProtocolGenerator() {
         members: List<MemberShape>,
         writer: SwiftWriter,
         defaultTimestampFormat: TimestampFormatTrait.Format,
+        path: String
     ) {
         val encoder = StructEncodeXMLGenerator(ctx, shapeContainingMembers, members, writer, defaultTimestampFormat)
         encoder.render()
@@ -57,7 +58,8 @@ class RestXmlProtocolGenerator : AWSHttpBindingProtocolGenerator() {
         shapeMetadata: Map<ShapeMetadata, Any>,
         members: List<MemberShape>,
         writer: SwiftWriter,
-        defaultTimestampFormat: TimestampFormatTrait.Format
+        defaultTimestampFormat: TimestampFormatTrait.Format,
+        path: String
     ) {
         val decoder = RestXmlStructDecodeXMLGenerator(ctx, members, shapeMetadata, writer, defaultTimestampFormat)
         decoder.render()


### PR DESCRIPTION
## Issue \#
#1100

## Description of changes
Fixes serializers / deserializers for errors that are embedded in event streams, by accounting for the custom error properties being namespaced under `properties`.

To show the effect of this change clearly, the model for `SageMaker` with the breaking change is included, and code has been regenerated for all AWS services.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.