### PR TITLE
fix: Package.swift changes need to be codegen + swiftlint

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
@@ -106,11 +106,24 @@ func addServiceTarget(_ name: String) {
 
 func addIntegrationTestTarget(_ name: String) {
     let integrationTestName = "\(name)IntegrationTests"
+    var additionalDependencies: [PackageDescription.Target.Dependency] = []
+    var exclusions: [String] = []
+    switch name {
+    case "AWSECS":
+        additionalDependencies = ["AWSCloudWatchLogs", "AWSEC2",  "AWSIAM"]
+        exclusions = [
+            "README.md",
+            "Resources/ECSIntegTestApp/"
+        ]
+    default:
+        break
+    }
     package.targets += [
         .testTarget(
             name: integrationTestName,
-            dependencies: [.crt, .clientRuntime, .awsClientRuntime, .byName(name: name), .smithyTestUtils],
+            dependencies: [.crt, .clientRuntime, .awsClientRuntime, .byName(name: name), .smithyTestUtils] + additionalDependencies,
             path: "./IntegrationTests/Services/\(integrationTestName)",
+            exclude: exclusions,
             resources: [.process("Resources")]
         )
     ]

--- a/Sources/Core/AWSClientRuntime/Auth/CredentialsProviders/ECSCredentialsProvider.swift
+++ b/Sources/Core/AWSClientRuntime/Auth/CredentialsProviders/ECSCredentialsProvider.swift
@@ -50,7 +50,9 @@ public struct ECSCredentialsProvider: CredentialsSourcedByCRT {
             host = absoluteHost
             pathAndQuery = absolutePathAndQuery
         } else {
-            throw ClientError.pathCreationFailed("Failed to retrieve either relative or absolute URI! URI may be malformed.")
+            throw ClientError.pathCreationFailed(
+                "Failed to retrieve either relative or absolute URI! URI may be malformed."
+            )
         }
 
         self.crtCredentialsProvider = try CRTCredentialsProvider(source: .ecs(
@@ -77,7 +79,7 @@ private func retrieveHostPathAndQuery(from url: URL) throws -> (String, String) 
 }
 
 private func isValidAbsoluteURI(_ uri: String?) -> Bool {
-    guard let validUri = uri, let _ = URL(string: validUri)?.host else {
+    guard let validUri = uri, URL(string: validUri)?.host != nil else {
         return false
     }
     return true


### PR DESCRIPTION
Previously merged CR contained a bug where changes to Package.swift were overwritten. Changes should've been made to the related codegen in AWSSDKSwiftCLI. There were also 2 swiftlint warnings that are also taken care of here.

## Issue \#
N/A
Previous PR: #1091 

## Description of changes
- apply Package.swift changes from aforementioned PR to codegen
- adjust spacing on line to ensure it is less than 125 characters
- switch empty assignment `let _ = x` to preferred `x != nil`

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.