### PR TITLE
fix: Add local protocol tests for awsQuery protocol, test timestamp fix

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
@@ -160,6 +160,7 @@ func addProtocolTests() {
         .init(name: "S3TestSDK", sourcePath: "\(baseDir)/s3"),
         .init(name: "aws_restjson", sourcePath: "\(baseDirLocal)/aws-restjson"),
         .init(name: "rest_json_extras", sourcePath: "\(baseDirLocal)/rest_json_extras"),
+        .init(name: "AwsQueryExtras", sourcePath: "\(baseDirLocal)/AwsQueryExtras"),
         .init(name: "Waiters", sourcePath: "\(baseDirLocal)/Waiters", testPath: "codegen/protocol-test-codegen-local/Tests"),
     ]
     for protocolTest in protocolTests {

--- a/Package.swift
+++ b/Package.swift
@@ -160,6 +160,7 @@ func addProtocolTests() {
         .init(name: "S3TestSDK", sourcePath: "\(baseDir)/s3"),
         .init(name: "aws_restjson", sourcePath: "\(baseDirLocal)/aws-restjson"),
         .init(name: "rest_json_extras", sourcePath: "\(baseDirLocal)/rest_json_extras"),
+        .init(name: "AwsQueryExtras", sourcePath: "\(baseDirLocal)/AwsQueryExtras"),
         .init(name: "Waiters", sourcePath: "\(baseDirLocal)/Waiters", testPath: "codegen/protocol-test-codegen-local/Tests"),
     ]
     for protocolTest in protocolTests {

--- a/codegen/Package.swift
+++ b/codegen/Package.swift
@@ -59,6 +59,8 @@ appendLibTarget(name: "aws_restjson", path: "\(baseDirLocal)/aws-restjson")
 appendTstTarget(name: "aws_restjsonTests", path: "\(baseDirLocal)/aws-restjson", dependency: "aws_restjson")
 appendLibTarget(name: "rest_json_extras", path: "\(baseDirLocal)/rest_json_extras")
 appendTstTarget(name: "rest_json_extrasTests", path: "\(baseDirLocal)/rest_json_extras", dependency: "rest_json_extras")
+appendLibTarget(name: "AwsQueryExtras", path: "\(baseDirLocal)/AwsQueryExtras")
+appendTstTarget(name: "AwsQueryExtrasTests", path: "\(baseDirLocal)/AwsQueryExtras", dependency: "AwsQueryExtras")
 appendLibTarget(name: "Waiters", path: "\(baseDirLocal)/Waiters")
 appendTstTarget(name: "WaitersTests", path: "./protocol-test-codegen-local/Tests", dependency: "Waiters")
 

--- a/codegen/protocol-test-codegen-local/build.gradle.kts
+++ b/codegen/protocol-test-codegen-local/build.gradle.kts
@@ -37,6 +37,10 @@ val codegenTests = listOf(
         "rest_json_extras"
     ),
     CodegenTest(
+        "aws.protocoltests.query#AwsQueryExtras",
+        "AwsQueryExtras"
+    ),
+    CodegenTest(
         "aws.protocoltests.waiters#Waiters",
         "Waiters"
     ),

--- a/codegen/protocol-test-codegen-local/model/aws-query-extras.smithy
+++ b/codegen/protocol-test-codegen-local/model/aws-query-extras.smithy
@@ -1,0 +1,43 @@
+$version: "2.0"
+
+namespace aws.protocoltests.query
+
+use aws.protocols#awsQuery
+use aws.api#service
+use smithy.test#httpRequestTests
+use smithy.test#httpResponseTests
+
+
+@service(sdkId: "Query Protocol")
+@awsQuery
+@xmlNamespace(uri: "https://example.com/")
+service AwsQueryExtras {
+    version: "2019-12-16",
+    operations: [GetTimestamps]
+}
+
+@httpRequestTests([
+    {
+        id: "GetTimestampsRequest",
+        uri: "/",
+        body: "Action=GetTimestamps&Version=2019-12-16&StartTime=2023-09-19T21%3A09%3A28Z&endTime=2023-09-19T21%3A09%3A29Z",
+        params: {
+            StartTime: 1695157768,  // 2023-09-19T21:09:28Z
+            endTime: 1695157769     // 2023-09-19T21:09:29Z
+        }
+        method: "POST",
+        bodyMediaType: "application/x-www-form-urlencoded",
+        protocol: awsQuery
+    }
+])
+@http(uri: "/", method: "POST")
+operation GetTimestamps {
+    input: HasTimestamp,
+    output: HasTimestamp
+}
+
+structure HasTimestamp {
+    StartTime: Timestamp
+    endTime: Timestamp
+}
+

--- a/scripts/protogen.sh
+++ b/scripts/protogen.sh
@@ -39,6 +39,7 @@ rm codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen/s
 # Now do the same for local protocol tests
 rm codegen/protocol-test-codegen-local/build/smithyprojections/protocol-test-codegen-local/aws-restjson/swift-codegen/Package.swift
 rm codegen/protocol-test-codegen-local/build/smithyprojections/protocol-test-codegen-local/rest_json_extras/swift-codegen/Package.swift
+rm codegen/protocol-test-codegen-local/build/smithyprojections/protocol-test-codegen-local/AwsQueryExtras/swift-codegen/Package.swift
 rm codegen/protocol-test-codegen-local/build/smithyprojections/protocol-test-codegen-local/Waiters/swift-codegen/Package.swift
 
 # Regenerate the Package.swift with protocol tests included


### PR DESCRIPTION
## Issue \#
#1121

## Description of changes
Adds a local protocol test suite for the `awsQuery` protocol, to retest the changes in https://github.com/smithy-lang/smithy-swift/pull/590.
Tests that `awsQuery` can successfully serialize a timestamp into a URL-encoded form.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.