### PR TITLE
feat: add ability to configure timeout in AWSClientConfiguration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -68,11 +68,11 @@ func addClientRuntimeDependency(_ version: Version) {
         ]
     case (false, true):
         package.dependencies += [
-            .package(url: smithySwiftURL, .branch("day/expose-timeout"))
+            .package(url: smithySwiftURL, .branch("main"))
         ]
     case (false, false):
         package.dependencies += [
-            .package(url: smithySwiftURL, .exact(version))
+            .package(url: smithySwiftURL, .branch("day/expose-timeout"))
         ]
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -72,7 +72,7 @@ func addClientRuntimeDependency(_ version: Version) {
         ]
     case (false, false):
         package.dependencies += [
-            .package(url: smithySwiftURL, .branch("day/expose-timeout"))
+            .package(url: smithySwiftURL, .exact(version))
         ]
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -68,7 +68,7 @@ func addClientRuntimeDependency(_ version: Version) {
         ]
     case (false, true):
         package.dependencies += [
-            .package(url: smithySwiftURL, .branch("main"))
+            .package(url: smithySwiftURL, .branch("day/expose-timeout"))
         ]
     case (false, false):
         package.dependencies += [

--- a/Sources/Core/AWSClientRuntime/AWSClientConfiguration.swift
+++ b/Sources/Core/AWSClientRuntime/AWSClientConfiguration.swift
@@ -102,6 +102,11 @@ public class AWSClientConfiguration<ServiceSpecificConfiguration: AWSServiceSpec
     /// This structure is custom code-generated for each AWS service.
     public var serviceSpecific: ServiceSpecificConfiguration
 
+    /// The timeout for a request in milliseconds
+    ///
+    /// If none is provided the client with use default values based on the operation system.
+    public var connectTimeoutMs: UInt32?
+
     /// Internal designated init
     /// All convenience inits should call this.
     private init(
@@ -115,7 +120,8 @@ public class AWSClientConfiguration<ServiceSpecificConfiguration: AWSServiceSpec
         _ useFIPS: Swift.Bool?,
         _ retryStrategyOptions: RetryStrategyOptions?,
         _ appID: String?,
-        _ awsRetryMode: AWSRetryMode
+        _ awsRetryMode: AWSRetryMode,
+        _ connectTimeoutMs: UInt32? = nil
     ) throws {
         typealias RuntimeConfigType =
             DefaultSDKRuntimeConfiguration<DefaultRetryStrategy, DefaultRetryErrorInfoProvider>
@@ -128,8 +134,13 @@ public class AWSClientConfiguration<ServiceSpecificConfiguration: AWSServiceSpec
         self.useDualStack = useDualStack
         self.useFIPS = useFIPS
         self.clientLogMode = RuntimeConfigType.defaultClientLogMode
+        self.connectTimeoutMs = connectTimeoutMs
         self.httpClientConfiguration = RuntimeConfigType.defaultHttpClientConfiguration
-        self.httpClientEngine = RuntimeConfigType.defaultHttpClientEngine
+        if let connectTimeoutMs = self.connectTimeoutMs {
+            self.httpClientEngine = RuntimeConfigType.httpClientEngineWithTimeout(timeoutMs: connectTimeoutMs)
+        } else {
+            self.httpClientEngine = RuntimeConfigType.defaultHttpClientEngine
+        }
         self.idempotencyTokenGenerator = RuntimeConfigType.defaultIdempotencyTokenGenerator
         self.logger = RuntimeConfigType.defaultLogger(clientName: self.serviceSpecific.clientName)
         self.retryStrategyOptions = retryStrategyOptions ?? RuntimeConfigType.defaultRetryStrategyOptions
@@ -162,7 +173,8 @@ extension AWSClientConfiguration {
         useFIPS: Swift.Bool? = nil,
         retryMode: AWSRetryMode? = nil,
         maxAttempts: Int? = nil,
-        appID: String? = nil
+        appID: String? = nil,
+        connectTimeoutMs: UInt32? = nil
     ) async throws {
         let fileBasedConfig = try await CRTFileBasedConfiguration.makeAsync()
         let resolvedRegionResolver = try regionResolver ?? DefaultRegionResolver { _, _ in fileBasedConfig }
@@ -200,7 +212,8 @@ extension AWSClientConfiguration {
             useFIPS,
             retryStrategyOptions,
             resolvedAppID,
-            resolvedAWSRetryMode
+            resolvedAWSRetryMode,
+            connectTimeoutMs
         )
     }
 
@@ -214,7 +227,8 @@ extension AWSClientConfiguration {
         useFIPS: Swift.Bool? = nil,
         retryMode: AWSRetryMode? = nil,
         maxAttempts: Int? = nil,
-        appID: String? = nil
+        appID: String? = nil,
+        connectTimeoutMs: UInt32? = nil
     ) throws {
         let fileBasedConfig = try CRTFileBasedConfiguration.make()
         let resolvedCredentialsProvider: CredentialsProviding
@@ -245,7 +259,8 @@ extension AWSClientConfiguration {
             useFIPS,
             retryStrategyOptions,
             resolvedAppID,
-            resolvedAWSRetryMode
+            resolvedAWSRetryMode,
+            connectTimeoutMs
         )
     }
 

--- a/Tests/Core/AWSClientRuntimeTests/AWSClientConfigurationTests.swift
+++ b/Tests/Core/AWSClientRuntimeTests/AWSClientConfigurationTests.swift
@@ -63,6 +63,14 @@ class AWSClientConfigurationTests: XCTestCase {
         let subject = try await Subject(region: region, appID: appID)
         XCTAssertEqual(subject.appID, appID)
     }
+
+    // MARK: - Timeout
+
+    func test_async_configureTimeoutOptionsFromParams() throws {
+        let customTimeout = 10_000
+        let subject = try Subject(region: region, connectTimeoutMs: customTimeout)
+        XCTAssertEqual(subject.connectTimeoutMs, customTimeout)
+    }
 }
 
 struct TestAWSServiceSpecificConfiguration: AWSServiceSpecificConfiguration {
@@ -78,4 +86,5 @@ struct TestAWSServiceSpecificConfiguration: AWSServiceSpecificConfiguration {
 
     var serviceName: String { "TestAWSService" }
     var clientName: String { "TestAWSServiceClient" }
+    var connectTimeoutMs: UInt32 { 10_000 }
 }


### PR DESCRIPTION
Add ability to configure connectTimeoutMs in AWSClientConfiguration.

## Issue \#
#1065 
Companion PR: [#592](https://github.com/smithy-lang/smithy-swift/pull/592)

## Description of changes
- expose connectTimeoutMs in AWSClientConfiguration which is used to create a CRTClientEngine() with the related configuration.

Ex. Usage (S3)
```
let client = try await S3Client(
    config: S3Client.S3ClientConfiguration(connectTimeoutMs: 15_000)
)
```

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.