### PR TITLE
fix!: Make error factory methods nonpublic

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AWSJsonHttpResponseBindingErrorGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AWSJsonHttpResponseBindingErrorGenerator.kt
@@ -76,13 +76,13 @@ class AWSJsonHttpResponseBindingErrorGenerator : HttpResponseBindingErrorGenerat
                 addImport(SwiftDependency.CLIENT_RUNTIME.target)
 
                 openBlock(
-                    "public enum \$L: \$N {",
+                    "enum \$L: \$N {",
                     "}",
                     operationErrorName,
                     ClientRuntimeTypes.Http.HttpResponseErrorBinding
                 ) {
                     openBlock(
-                        "public static func makeError(httpResponse: \$N, decoder: \$D) async throws -> \$N {", "}",
+                        "static func makeError(httpResponse: \$N, decoder: \$D) async throws -> \$N {", "}",
                         ClientRuntimeTypes.Http.HttpResponse,
                         ClientRuntimeTypes.Serde.ResponseDecoder,
                         SwiftTypes.Error

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/ec2query/httpResponse/AWSEc2QueryHttpResponseBindingErrorGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/ec2query/httpResponse/AWSEc2QueryHttpResponseBindingErrorGenerator.kt
@@ -75,13 +75,13 @@ class AWSEc2QueryHttpResponseBindingErrorGenerator : HttpResponseBindingErrorGen
                 addImport(SwiftDependency.CLIENT_RUNTIME.target)
 
                 openBlock(
-                    "public enum \$L: \$N {",
+                    "enum \$L: \$N {",
                     "}",
                     operationErrorName,
                     ClientRuntimeTypes.Http.HttpResponseErrorBinding
                 ) {
                     openBlock(
-                        "public static func makeError(httpResponse: \$N, decoder: \$D) async throws -> \$N {", "}",
+                        "static func makeError(httpResponse: \$N, decoder: \$D) async throws -> \$N {", "}",
                         ClientRuntimeTypes.Http.HttpResponse,
                         ClientRuntimeTypes.Serde.ResponseDecoder,
                         SwiftTypes.Error

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/restjson/AWSRestJson1HttpResponseBindingErrorGeneratable.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/restjson/AWSRestJson1HttpResponseBindingErrorGeneratable.kt
@@ -77,13 +77,13 @@ class AWSRestJson1HttpResponseBindingErrorGeneratable : HttpResponseBindingError
                 addImport(SwiftDependency.CLIENT_RUNTIME.target)
 
                 openBlock(
-                    "public enum \$L: \$N {",
+                    "enum \$L: \$N {",
                     "}",
                     operationErrorName,
                     ClientRuntimeTypes.Http.HttpResponseErrorBinding
                 ) {
                     openBlock(
-                        "public static func makeError(httpResponse: \$N, decoder: \$D) async throws -> \$N {", "}",
+                        "static func makeError(httpResponse: \$N, decoder: \$D) async throws -> \$N {", "}",
                         ClientRuntimeTypes.Http.HttpResponse,
                         ClientRuntimeTypes.Serde.ResponseDecoder,
                         SwiftTypes.Error

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/restxml/AWSRestXMLHttpResponseBindingErrorGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/restxml/AWSRestXMLHttpResponseBindingErrorGenerator.kt
@@ -80,13 +80,13 @@ class AWSRestXMLHttpResponseBindingErrorGenerator : HttpResponseBindingErrorGene
                 addImport(SwiftDependency.CLIENT_RUNTIME.target)
 
                 openBlock(
-                    "public enum \$L: \$N {",
+                    "enum \$L: \$N {",
                     "}",
                     operationErrorName,
                     ClientRuntimeTypes.Http.HttpResponseErrorBinding
                 ) {
                     openBlock(
-                        "public static func makeError(httpResponse: \$N, decoder: \$D) async throws -> \$N {", "}",
+                        "static func makeError(httpResponse: \$N, decoder: \$D) async throws -> \$N {", "}",
                         ClientRuntimeTypes.Http.HttpResponse,
                         ClientRuntimeTypes.Serde.ResponseDecoder,
                         SwiftTypes.Error

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AWSJsonHttpResponseBindingErrorGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AWSJsonHttpResponseBindingErrorGeneratorTests.kt
@@ -21,8 +21,8 @@ class AWSJsonHttpResponseBindingErrorGeneratorTests {
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            public enum GreetingWithErrorsOutputError: ClientRuntime.HttpResponseErrorBinding {
-                public static func makeError(httpResponse: ClientRuntime.HttpResponse, decoder: ClientRuntime.ResponseDecoder? = nil) async throws -> Swift.Error {
+            enum GreetingWithErrorsOutputError: ClientRuntime.HttpResponseErrorBinding {
+                static func makeError(httpResponse: ClientRuntime.HttpResponse, decoder: ClientRuntime.ResponseDecoder? = nil) async throws -> Swift.Error {
                     let restJSONError = try await AWSClientRuntime.RestJSONError(httpResponse: httpResponse)
                     let requestID = httpResponse.requestId
                     let serviceError = try await Json10ProtocolClientTypes.makeServiceError(httpResponse, decoder, restJSONError, requestID)

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsrestjson/AWSRestJson1HttpResponseBindingErrorGeneratableTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsrestjson/AWSRestJson1HttpResponseBindingErrorGeneratableTests.kt
@@ -19,8 +19,8 @@ class AWSRestJson1HttpResponseBindingErrorGeneratableTests {
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            public enum GreetingWithErrorsOutputError: ClientRuntime.HttpResponseErrorBinding {
-                public static func makeError(httpResponse: ClientRuntime.HttpResponse, decoder: ClientRuntime.ResponseDecoder? = nil) async throws -> Swift.Error {
+            enum GreetingWithErrorsOutputError: ClientRuntime.HttpResponseErrorBinding {
+                static func makeError(httpResponse: ClientRuntime.HttpResponse, decoder: ClientRuntime.ResponseDecoder? = nil) async throws -> Swift.Error {
                     let restJSONError = try await AWSClientRuntime.RestJSONError(httpResponse: httpResponse)
                     let requestID = httpResponse.requestId
                     let serviceError = try await RestJson1ProtocolClientTypes.makeServiceError(httpResponse, decoder, restJSONError, requestID)

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/Route53InvalidBatchErrorIntegrationTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/Route53InvalidBatchErrorIntegrationTests.kt
@@ -70,8 +70,8 @@ class Route53InvalidBatchErrorIntegrationTests {
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            public enum ChangeResourceRecordSetsOutputError: ClientRuntime.HttpResponseErrorBinding {
-                public static func makeError(httpResponse: ClientRuntime.HttpResponse, decoder: ClientRuntime.ResponseDecoder? = nil) async throws -> Swift.Error {
+            enum ChangeResourceRecordSetsOutputError: ClientRuntime.HttpResponseErrorBinding {
+                static func makeError(httpResponse: ClientRuntime.HttpResponse, decoder: ClientRuntime.ResponseDecoder? = nil) async throws -> Swift.Error {
                     if let customBatchError = try await CustomInvalidBatchError.makeFromHttpResponse(httpResponse) {
                         return InvalidChangeBatch(
                             customError: customBatchError,

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/ec2query/Ec2QueryHttpResponseBindingErrorGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/ec2query/Ec2QueryHttpResponseBindingErrorGeneratorTests.kt
@@ -21,8 +21,8 @@ class Ec2QueryHttpResponseBindingErrorGeneratorTests {
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            public enum GreetingWithErrorsOutputError: ClientRuntime.HttpResponseErrorBinding {
-                public static func makeError(httpResponse: ClientRuntime.HttpResponse, decoder: ClientRuntime.ResponseDecoder? = nil) async throws -> Swift.Error {
+            enum GreetingWithErrorsOutputError: ClientRuntime.HttpResponseErrorBinding {
+                static func makeError(httpResponse: ClientRuntime.HttpResponse, decoder: ClientRuntime.ResponseDecoder? = nil) async throws -> Swift.Error {
                     let ec2QueryError = try await Ec2QueryError(httpResponse: httpResponse)
                     let serviceError = try await EC2ProtocolClientTypes.makeServiceError(httpResponse, decoder, ec2QueryError)
                     if let error = serviceError { return error }

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/restxml/AWSRestXMLHttpResponseBindingErrorGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/restxml/AWSRestXMLHttpResponseBindingErrorGeneratorTests.kt
@@ -22,8 +22,8 @@ class AWSRestXMLHttpResponseBindingErrorGeneratorTests {
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
-            public enum GreetingWithErrorsOutputError: ClientRuntime.HttpResponseErrorBinding {
-                public static func makeError(httpResponse: ClientRuntime.HttpResponse, decoder: ClientRuntime.ResponseDecoder? = nil) async throws -> Swift.Error {
+            enum GreetingWithErrorsOutputError: ClientRuntime.HttpResponseErrorBinding {
+                static func makeError(httpResponse: ClientRuntime.HttpResponse, decoder: ClientRuntime.ResponseDecoder? = nil) async throws -> Swift.Error {
                     let restXMLError = try await AWSClientRuntime.RestXMLError(httpResponse: httpResponse)
                     let serviceError = try await RestXmlerrorsClientTypes.makeServiceError(httpResponse, decoder, restXMLError)
                     if let error = serviceError { return error }


### PR DESCRIPTION
## Issue \#
#1155

## Description of changes
Makes the per-operation static factory method `makeError(httpResponse:decoder:)` internal instead of `public` to reduce public API surface area.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.