### PR TITLE
feat: Move over signing flow from SigV4Middleware into AWSSigV4Signer

### DIFF
--- a/Sources/Core/AWSClientRuntime/HttpContextBuilder+Extension.swift
+++ b/Sources/Core/AWSClientRuntime/HttpContextBuilder+Extension.swift
@@ -20,7 +20,7 @@ extension HttpContext {
     func getRequestSignature() -> String {
         return attributes.get(key: AttributeKeys.requestSignature)!
     }
-    
+
     func getSigningAlgorithm() -> AWSSigningAlgorithm? {
         return attributes.get(key: AttributeKeys.signingAlgorithm)
     }

--- a/Sources/Core/AWSClientRuntime/HttpContextBuilder+Extension.swift
+++ b/Sources/Core/AWSClientRuntime/HttpContextBuilder+Extension.swift
@@ -6,7 +6,8 @@
 //
 
 import ClientRuntime
-import Foundation
+import struct Foundation.Date
+import struct Foundation.TimeInterval
 
 extension HttpContext {
     func getCredentialsProvider() -> (any CredentialsProviding)? {

--- a/Sources/Core/AWSClientRuntime/HttpContextBuilder+Extension.swift
+++ b/Sources/Core/AWSClientRuntime/HttpContextBuilder+Extension.swift
@@ -6,43 +6,31 @@
 //
 
 import ClientRuntime
-import struct Foundation.Date
+import Foundation
 
 extension HttpContext {
-    static let credentialsProvider = AttributeKey<(any CredentialsProviding)>(name: "CredentialsProvider")
-    static let region = AttributeKey<String>(name: "Region")
-    public static let signingName = AttributeKey<String>(name: "SigningName")
-    public static let signingRegion = AttributeKey<String>(name: "SigningRegion")
-    public static let signingAlgorithm = AttributeKey<String>(name: "SigningAlgorithm")
-    public static let requestSignature = AttributeKey<String>(name: "AWS_HTTP_SIGNATURE")
-
     func getCredentialsProvider() -> (any CredentialsProviding)? {
-        return attributes.get(key: HttpContext.credentialsProvider)
+        return attributes.get(key: AttributeKeys.credentialsProvider)
     }
 
     func getRegion() -> String? {
-        return attributes.get(key: Self.region)
+        return attributes.get(key: AttributeKeys.region)
+    }
+
+    func getRequestSignature() -> String {
+        return attributes.get(key: AttributeKeys.requestSignature)!
+    }
+    
+    func getSigningAlgorithm() -> AWSSigningAlgorithm? {
+        return attributes.get(key: AttributeKeys.signingAlgorithm)
     }
 
     func getSigningName() -> String? {
-        return attributes.get(key: Self.signingName)
+        return attributes.get(key: AttributeKeys.signingName)
     }
 
     func getSigningRegion() -> String? {
-        return attributes.get(key: Self.signingRegion)
-    }
-
-    func getSigningAlgorithm() -> AWSSigningAlgorithm? {
-        guard let algorithmRawValue = attributes.get(key: Self.signingAlgorithm) else {
-            return nil
-        }
-        return AWSSigningAlgorithm(rawValue: algorithmRawValue)
-    }
-
-    /// Returns the request signature for the event stream operation
-    /// - Returns: `String` request signature
-    public func getRequestSignature() -> String {
-        return attributes.get(key: Self.requestSignature)!
+        return attributes.get(key: AttributeKeys.signingRegion)
     }
 
     /// Returns the signing config for the event stream message
@@ -83,43 +71,24 @@ extension HttpContext {
         } requestSignature: {
             self.getRequestSignature()
         }
-        attributes.set(key: HttpContext.messageEncoder, value: messageEncoder)
-        attributes.set(key: HttpContext.messageSigner, value: messageSigner)
+        attributes.set(key: AttributeKeys.messageEncoder, value: messageEncoder)
+        attributes.set(key: AttributeKeys.messageSigner, value: messageSigner)
 
         // enable the flag
-        attributes.set(key: HttpContext.bidirectionalStreaming, value: true)
+        attributes.set(key: AttributeKeys.bidirectionalStreaming, value: true)
     }
 }
 
 extension HttpContextBuilder {
+    @discardableResult
+    public func withCredentialsProvider(value: any CredentialsProviding) -> HttpContextBuilder {
+        self.attributes.set(key: AttributeKeys.credentialsProvider, value: value)
+        return self
+    }
 
     @discardableResult
     public func withRegion(value: String?) -> HttpContextBuilder {
-        self.attributes.set(key: HttpContext.region, value: value)
-        return self
-    }
-
-    @discardableResult
-    public func withCredentialsProvider(value: any CredentialsProviding) -> HttpContextBuilder {
-        self.attributes.set(key: HttpContext.credentialsProvider, value: value)
-        return self
-    }
-
-    @discardableResult
-    public func withSigningName(value: String) -> HttpContextBuilder {
-        self.attributes.set(key: HttpContext.signingName, value: value)
-        return self
-    }
-
-    @discardableResult
-    public func withSigningRegion(value: String?) -> HttpContextBuilder {
-        self.attributes.set(key: HttpContext.signingRegion, value: value)
-        return self
-    }
-
-    @discardableResult
-    public func withSigningAlgorithm(value: AWSSigningAlgorithm?) -> HttpContextBuilder {
-        self.attributes.set(key: HttpContext.signingAlgorithm, value: value?.rawValue)
+        self.attributes.set(key: AttributeKeys.region, value: value)
         return self
     }
 
@@ -127,7 +96,43 @@ extension HttpContextBuilder {
     /// - Parameter value: `String` request signature
     @discardableResult
     public func withRequestSignature(value: String) -> HttpContextBuilder {
-        self.attributes.set(key: HttpContext.requestSignature, value: value)
+        self.attributes.set(key: AttributeKeys.requestSignature, value: value)
         return self
     }
+
+    @discardableResult
+    public func withSigningAlgorithm(value: AWSSigningAlgorithm) -> HttpContextBuilder {
+        self.attributes.set(key: AttributeKeys.signingAlgorithm, value: value)
+        return self
+    }
+
+    @discardableResult
+    public func withSigningName(value: String) -> HttpContextBuilder {
+        self.attributes.set(key: AttributeKeys.signingName, value: value)
+        return self
+    }
+
+    @discardableResult
+    public func withSigningRegion(value: String?) -> HttpContextBuilder {
+        self.attributes.set(key: AttributeKeys.signingRegion, value: value)
+        return self
+    }
+}
+
+extension AttributeKeys {
+    public static let credentialsProvider = AttributeKey<(any CredentialsProviding)>(name: "CredentialsProvider")
+    public static let region = AttributeKey<String>(name: "Region")
+    public static let signingName = AttributeKey<String>(name: "SigningName")
+    public static let signingRegion = AttributeKey<String>(name: "SigningRegion")
+    public static let signingAlgorithm = AttributeKey<AWSSigningAlgorithm>(name: "SigningAlgorithm")
+    public static let requestSignature = AttributeKey<String>(name: "AWS_HTTP_SIGNATURE")
+
+    // Keys used to store/retrieve AWSSigningConfig fields in/from signingProperties passed to AWSSigV4Signer
+    public static let unsignedBody = AttributeKey<Bool>(name: "UnsignedBody")
+    public static let expiration = AttributeKey<TimeInterval>(name: "Expiration")
+    public static let signedBodyHeader = AttributeKey<AWSSignedBodyHeader>(name: "SignedBodyHeader")
+    public static let useDoubleURIEncode = AttributeKey<Bool>(name: "UseDoubleURIEncode")
+    public static let shouldNormalizeURIPath = AttributeKey<Bool>(name: "ShouldNormalizeURIPath")
+    public static let omitSessionToken = AttributeKey<Bool>(name: "OmitSessionToken")
+    public static let signatureType = AttributeKey<AWSSignatureType>(name: "SignatureType")
 }

--- a/Sources/Core/AWSClientRuntime/Middlewares/SigV4Middleware.swift
+++ b/Sources/Core/AWSClientRuntime/Middlewares/SigV4Middleware.swift
@@ -78,7 +78,7 @@ public struct SigV4Middleware<OperationStackOutput: HttpResponseBinding,
             config: signingConfig.toCRTType()
         )
 
-        context.attributes.set(key: HttpContext.requestSignature, value: crtSignedRequest.signature)
+        context.attributes.set(key: AttributeKeys.requestSignature, value: crtSignedRequest.signature)
 
         let sdkSignedRequest = input.update(from: crtSignedRequest, originalRequest: originalRequest)
 

--- a/Sources/Core/AWSClientRuntime/Signing/AWSSigV4Signer.swift
+++ b/Sources/Core/AWSClientRuntime/Signing/AWSSigV4Signer.swift
@@ -36,7 +36,7 @@ public class AWSSigV4Signer: ClientRuntime.Signer {
             request: crtUnsignedRequest,
             config: signingConfig.toCRTType()
         )
-        
+
         // Return signed request
         return requestBuilder.update(from: crtSignedRequest, originalRequest: unsignedRequest)
     }

--- a/Sources/Core/AWSClientRuntime/Signing/AWSSigV4Signer.swift
+++ b/Sources/Core/AWSClientRuntime/Signing/AWSSigV4Signer.swift
@@ -10,7 +10,7 @@ import ClientRuntime
 import Foundation
 
 public class AWSSigV4Signer: ClientRuntime.Signer {
-    public typealias IdObj = Credentials
+    public typealias IdentityT = Credentials
 
     public func sign(
         requestBuilder: SdkHttpRequestBuilder,

--- a/Sources/Core/AWSClientRuntime/Signing/AWSSigV4Signer.swift
+++ b/Sources/Core/AWSClientRuntime/Signing/AWSSigV4Signer.swift
@@ -11,7 +11,7 @@ import Foundation
 
 public class AWSSigV4Signer: ClientRuntime.Signer {
     public typealias IdObj = Credentials
-    
+
     public func sign(
         requestBuilder: SdkHttpRequestBuilder,
         identity: Credentials,
@@ -20,9 +20,9 @@ public class AWSSigV4Signer: ClientRuntime.Signer {
         guard let isBidirectionalStreamingEnabled = signingProperties.get(key: AttributeKeys.bidirectionalStreaming) else {
             throw ClientError.authError("Signing properties passed to the AWSSigV4Signer must contain T/F flag for bidirectional streaming.")
         }
-        
+    
         let signingConfig = try constructSigningConfig(identity: identity, signingProperties: signingProperties)
-        
+    
         let unsignedRequest = requestBuilder.build()
         let crtUnsignedRequest: HTTPRequestBase
         if isBidirectionalStreamingEnabled {
@@ -38,7 +38,7 @@ public class AWSSigV4Signer: ClientRuntime.Signer {
         let signedRequest = requestBuilder.update(from: crtSignedRequest, originalRequest: unsignedRequest)
         return signedRequest
     }
-    
+
     private func constructSigningConfig(identity: Credentials, signingProperties: ClientRuntime.Attributes) throws -> AWSSigningConfig {
         guard let unsignedBody = signingProperties.get(key: AttributeKeys.unsignedBody) else {
             throw ClientError.authError("Signing properties passed to the AWSSigV4Signer must contain T/F flag for unsigned body.")
@@ -52,7 +52,7 @@ public class AWSSigV4Signer: ClientRuntime.Signer {
         guard let signingAlgorithm = signingProperties.get(key: AttributeKeys.signingAlgorithm) else {
             throw ClientError.authError("Signing properties passed to the AWSSigV4Signer must contain signing algorithm.")
         }
-        
+    
         let expiration: TimeInterval = signingProperties.get(key: AttributeKeys.expiration) ?? 0
         let signedBodyHeader: AWSSignedBodyHeader = signingProperties.get(key: AttributeKeys.signedBodyHeader) ?? .none
         let signedBodyValue: AWSSignedBodyValue = unsignedBody ? .unsignedPayload : .empty
@@ -62,7 +62,7 @@ public class AWSSigV4Signer: ClientRuntime.Signer {
             omitSessionToken: signingProperties.get(key: AttributeKeys.omitSessionToken) ?? false
         )
         let signatureType: AWSSignatureType = signingProperties.get(key: AttributeKeys.signatureType) ?? .requestHeaders
-        
+    
         return AWSSigningConfig(
             credentials: identity,
             expiration: expiration,
@@ -76,7 +76,7 @@ public class AWSSigV4Signer: ClientRuntime.Signer {
             signingAlgorithm: signingAlgorithm
         )
     }
-    
+
     static let logger: SwiftLogger = SwiftLogger(label: "AWSSigV4Signer")
 
     public static func sigV4SignedURL(

--- a/Sources/Core/AWSClientRuntime/Signing/AWSSigV4Signer.swift
+++ b/Sources/Core/AWSClientRuntime/Signing/AWSSigV4Signer.swift
@@ -17,12 +17,16 @@ public class AWSSigV4Signer: ClientRuntime.Signer {
         identity: Credentials,
         signingProperties: ClientRuntime.Attributes
     ) async throws -> SdkHttpRequestBuilder {
-        guard let isBidirectionalStreamingEnabled = signingProperties.get(key: AttributeKeys.bidirectionalStreaming) else {
-            throw ClientError.authError("Signing properties passed to the AWSSigV4Signer must contain T/F flag for bidirectional streaming.")
+        guard let isBidirectionalStreamingEnabled = signingProperties.get(
+            key: AttributeKeys.bidirectionalStreaming
+        ) else {
+            throw ClientError.authError(
+                "Signing properties passed to the AWSSigV4Signer must contain T/F flag for bidirectional streaming."
+            )
         }
-    
+
         let signingConfig = try constructSigningConfig(identity: identity, signingProperties: signingProperties)
-    
+
         let unsignedRequest = requestBuilder.build()
         let crtUnsignedRequest: HTTPRequestBase
         if isBidirectionalStreamingEnabled {
@@ -39,20 +43,31 @@ public class AWSSigV4Signer: ClientRuntime.Signer {
         return signedRequest
     }
 
-    private func constructSigningConfig(identity: Credentials, signingProperties: ClientRuntime.Attributes) throws -> AWSSigningConfig {
+    private func constructSigningConfig(
+        identity: Credentials,
+        signingProperties: ClientRuntime.Attributes
+    ) throws -> AWSSigningConfig {
         guard let unsignedBody = signingProperties.get(key: AttributeKeys.unsignedBody) else {
-            throw ClientError.authError("Signing properties passed to the AWSSigV4Signer must contain T/F flag for unsigned body.")
+            throw ClientError.authError(
+                "Signing properties passed to the AWSSigV4Signer must contain T/F flag for unsigned body."
+            )
         }
         guard let signingName = signingProperties.get(key: AttributeKeys.signingName) else {
-            throw ClientError.authError("Signing properties passed to the AWSSigV4Signer must contain signing name.")
+            throw ClientError.authError(
+                "Signing properties passed to the AWSSigV4Signer must contain signing name."
+            )
         }
         guard let signingRegion = signingProperties.get(key: AttributeKeys.signingRegion) else {
-            throw ClientError.authError("Signing properties passed to the AWSSigV4Signer must contain signing region.")
+            throw ClientError.authError(
+                "Signing properties passed to the AWSSigV4Signer must contain signing region."
+            )
         }
         guard let signingAlgorithm = signingProperties.get(key: AttributeKeys.signingAlgorithm) else {
-            throw ClientError.authError("Signing properties passed to the AWSSigV4Signer must contain signing algorithm.")
+            throw ClientError.authError(
+                "Signing properties passed to the AWSSigV4Signer must contain signing algorithm."
+            )
         }
-    
+
         let expiration: TimeInterval = signingProperties.get(key: AttributeKeys.expiration) ?? 0
         let signedBodyHeader: AWSSignedBodyHeader = signingProperties.get(key: AttributeKeys.signedBodyHeader) ?? .none
         let signedBodyValue: AWSSignedBodyValue = unsignedBody ? .unsignedPayload : .empty
@@ -62,7 +77,7 @@ public class AWSSigV4Signer: ClientRuntime.Signer {
             omitSessionToken: signingProperties.get(key: AttributeKeys.omitSessionToken) ?? false
         )
         let signatureType: AWSSignatureType = signingProperties.get(key: AttributeKeys.signatureType) ?? .requestHeaders
-    
+
         return AWSSigningConfig(
             credentials: identity,
             expiration: expiration,

--- a/Sources/Core/AWSClientRuntime/Signing/AWSSigV4Signer.swift
+++ b/Sources/Core/AWSClientRuntime/Signing/AWSSigV4Signer.swift
@@ -28,7 +28,7 @@ public class AWSSigV4Signer: ClientRuntime.Signer {
                 "Identity passed to the AWSSigV4Signer must be of type Credentials."
             )
         }
-        
+
         let signingConfig = try constructSigningConfig(identity: identity, signingProperties: signingProperties)
 
         let unsignedRequest = requestBuilder.build()

--- a/Sources/Core/AWSClientRuntime/Signing/AWSSigV4Signer.swift
+++ b/Sources/Core/AWSClientRuntime/Signing/AWSSigV4Signer.swift
@@ -10,11 +10,9 @@ import ClientRuntime
 import Foundation
 
 public class AWSSigV4Signer: ClientRuntime.Signer {
-    public typealias IdentityT = Credentials
-
-    public func sign(
+    public func sign<IdentityT: Identity>(
         requestBuilder: SdkHttpRequestBuilder,
-        identity: Credentials,
+        identity: IdentityT,
         signingProperties: ClientRuntime.Attributes
     ) async throws -> SdkHttpRequestBuilder {
         guard let isBidirectionalStreamingEnabled = signingProperties.get(
@@ -25,6 +23,12 @@ public class AWSSigV4Signer: ClientRuntime.Signer {
             )
         }
 
+        guard let identity = identity as? Credentials else {
+            throw ClientError.authError(
+                "Identity passed to the AWSSigV4Signer must be of type Credentials."
+            )
+        }
+        
         let signingConfig = try constructSigningConfig(identity: identity, signingProperties: signingProperties)
 
         let unsignedRequest = requestBuilder.build()

--- a/Sources/Core/AWSClientRuntime/Signing/AWSSigV4Signer.swift
+++ b/Sources/Core/AWSClientRuntime/Signing/AWSSigV4Signer.swift
@@ -28,19 +28,17 @@ public class AWSSigV4Signer: ClientRuntime.Signer {
         let signingConfig = try constructSigningConfig(identity: identity, signingProperties: signingProperties)
 
         let unsignedRequest = requestBuilder.build()
-        let crtUnsignedRequest: HTTPRequestBase
-        if isBidirectionalStreamingEnabled {
-            crtUnsignedRequest = try unsignedRequest.toHttp2Request()
-        } else {
-            crtUnsignedRequest = try unsignedRequest.toHttpRequest()
-        }
+        let crtUnsignedRequest: HTTPRequestBase = isBidirectionalStreamingEnabled ?
+            try unsignedRequest.toHttp2Request() :
+            try unsignedRequest.toHttpRequest()
 
         let crtSignedRequest = try await Signer.signRequest(
             request: crtUnsignedRequest,
             config: signingConfig.toCRTType()
         )
-        let signedRequest = requestBuilder.update(from: crtSignedRequest, originalRequest: unsignedRequest)
-        return signedRequest
+        
+        // Return signed request
+        return requestBuilder.update(from: crtSignedRequest, originalRequest: unsignedRequest)
     }
 
     private func constructSigningConfig(

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/EndpointResolverMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/EndpointResolverMiddleware.kt
@@ -103,13 +103,13 @@ class EndpointResolverMiddleware(
         }.write("")
 
         writer.openBlock("if let signingRegion = signingRegion {", "}") {
-            writer.write("context.attributes.set(key: HttpContext.signingRegion, value: signingRegion)")
+            writer.write("context.attributes.set(key: AttributeKeys.signingRegion, value: signingRegion)")
         }
         writer.openBlock("if let signingName = signingName {", "}") {
-            writer.write("context.attributes.set(key: HttpContext.signingName, value: signingName)")
+            writer.write("context.attributes.set(key: AttributeKeys.signingName, value: signingName)")
         }
         writer.openBlock("if let signingAlgorithm = signingAlgorithm {", "}") {
-            writer.write("context.attributes.set(key: HttpContext.signingAlgorithm, value: signingAlgorithm)")
+            writer.write("context.attributes.set(key: AttributeKeys.signingAlgorithm, value: signingAlgorithm)")
         }.write("")
 
         writer.openBlock("if let headers = endpoint.headers {", "}") {

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/EndpointResolverMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/EndpointResolverMiddleware.kt
@@ -109,7 +109,7 @@ class EndpointResolverMiddleware(
             writer.write("context.attributes.set(key: AttributeKeys.signingName, value: signingName)")
         }
         writer.openBlock("if let signingAlgorithm = signingAlgorithm {", "}") {
-            writer.write("context.attributes.set(key: AttributeKeys.signingAlgorithm, value: signingAlgorithm)")
+            writer.write("context.attributes.set(key: AttributeKeys.signingAlgorithm, value: AWSSigningAlgorithm(rawValue: signingAlgorithm))")
         }.write("")
 
         writer.openBlock("if let headers = endpoint.headers {", "}") {

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/EndpointResolverMiddlewareTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/EndpointResolverMiddlewareTests.kt
@@ -83,13 +83,13 @@ class EndpointResolverMiddlewareTests {
                     }
             
                     if let signingRegion = signingRegion {
-                        context.attributes.set(key: HttpContext.signingRegion, value: signingRegion)
+                        context.attributes.set(key: AttributeKeys.signingRegion, value: signingRegion)
                     }
                     if let signingName = signingName {
-                        context.attributes.set(key: HttpContext.signingName, value: signingName)
+                        context.attributes.set(key: AttributeKeys.signingName, value: signingName)
                     }
                     if let signingAlgorithm = signingAlgorithm {
-                        context.attributes.set(key: HttpContext.signingAlgorithm, value: signingAlgorithm)
+                        context.attributes.set(key: AttributeKeys.signingAlgorithm, value: signingAlgorithm)
                     }
             
                     if let headers = endpoint.headers {

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/EndpointResolverMiddlewareTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/EndpointResolverMiddlewareTests.kt
@@ -89,7 +89,7 @@ class EndpointResolverMiddlewareTests {
                         context.attributes.set(key: AttributeKeys.signingName, value: signingName)
                     }
                     if let signingAlgorithm = signingAlgorithm {
-                        context.attributes.set(key: AttributeKeys.signingAlgorithm, value: signingAlgorithm)
+                        context.attributes.set(key: AttributeKeys.signingAlgorithm, value: AWSSigningAlgorithm(rawValue: signingAlgorithm))
                     }
             
                     if let headers = endpoint.headers {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->
Milestone ticket: https://github.com/awslabs/aws-sdk-swift/issues/1143

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Corresponding PR in `smithy-swift`: https://github.com/smithy-lang/smithy-swift/pull/598

Make pre-existing `AWSSigV4Signer` conform to new `Signer` protocol added to `smithy-swift` in corresponding PR.
Change is required to allow dynamic dispatching of `sign` method based on which concrete implementation of `Signer` is fetched from resolved auth scheme in SRA identity & auth flow.

Refactor `HttpContext` extension following same pattern as in the corresponding PR in `smithy-swift`.

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.