### PR TITLE
chore: Remove all models before copying in latest versions

### DIFF
--- a/codegen/sdk-codegen/scripts/updatemodels.sh
+++ b/codegen/sdk-codegen/scripts/updatemodels.sh
@@ -33,6 +33,10 @@ fetchGitHubRepo
 
 JSON_MODEL_FILES=`find ${TEMPDIR}/aws-models |grep -e "smithy\/model\.json$"`
 
+# Delete all current model files before copying latest models in.
+# This ensures that removed models will not be included in the next release.
+rm -rf $OUTPUT_DIR/*
+
 for model in ${JSON_MODEL_FILES}; do
     SDKID=`cat ${model} |grep \"sdkId\": | sed 's/.*: \(.*\)/\1/g' | tr -d "\"" | tr -d "," | tr '[:upper:]' '[:lower:]' | tr " " "-"`
     NUM_VERSIONS=`cat "${model}" | grep -e "\"version\": \"[0-9]*-[0-9]*-[0-9]*\"" |wc -l |awk '{print $1}'`


### PR DESCRIPTION
## Issue \#
#1184

## Description of changes
Delete all models before copying latest models into the SDK project.
This ensures that models deleted in the latest published set of models will be deleted in the Swift SDK as well. 

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.