### PR TITLE
chore: End the SDK package manifest with a newline

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Models/PackageManifestBuilder.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Models/PackageManifestBuilder.swift
@@ -90,6 +90,7 @@ struct PackageManifestBuilder {
             buildIntegrationTestsTargets(),
             "",
             buildProtocolTests(),
+            "\n"
         ]
         return contents.joined(separator: .newline)
     }

--- a/Package.swift
+++ b/Package.swift
@@ -556,3 +556,4 @@ servicesWithIntegrationTests.forEach(addIntegrationTestTarget)
 
 // Uncomment this line to enable protocol tests
 // addProtocolTests()
+


### PR DESCRIPTION
## Description of changes
Add a newline character at the end of `Package.swift`, as is convention for Swift source files, and so as to prevent editors from auto-adding it themselves.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.