### PR TITLE
fix: Require aws-crt-swift 0.17.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -184,8 +184,8 @@ func addProtocolTests() {
 // MARK: - Generated
 
 addDependencies(
-    clientRuntimeVersion: "0.30.0",
-    crtVersion: "0.13.0"
+    clientRuntimeVersion: "0.30.1",
+    crtVersion: "0.17.0"
 )
 
 let serviceTargets: [String] = [

--- a/packageDependencies.plist
+++ b/packageDependencies.plist
@@ -5,10 +5,10 @@
 	<key>awsCRTSwiftBranch</key>
 	<string>main</string>
 	<key>awsCRTSwiftVersion</key>
-	<string>0.13.0</string>
+	<string>0.17.0</string>
 	<key>clientRuntimeBranch</key>
 	<string>main</string>
 	<key>clientRuntimeVersion</key>
-	<string>0.30.0</string>
+	<string>0.30.1</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Issue \#
https://github.com/aws-amplify/amplify-swift/issues/3324

## Description of changes
Update aws-crt-swift to 0.17.0 to fix an issue with App Store submission.
smithy-swift 0.30.1 (which also requires aws-crt-swift 0.17.0) is required as well.

This PR will be used to create aws-sdk-swift patch release 0.26.1

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.