### PR TITLE
fix: Integration test crashes on failure, build warning

### DIFF
--- a/IntegrationTests/Services/AWSS3IntegrationTests/SSOCredentialsProviderTests.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/SSOCredentialsProviderTests.swift
@@ -80,7 +80,7 @@ class SSOCredentialsProviderTests : XCTestCase {
     private func getIamIdentityCenterArn() async throws -> String {
         // Get IAM identity center instanceArn
         let listInstancesOutput = try await ssoClient.listInstances(input: ListInstancesInput())
-        guard let iamCenterInstances = listInstancesOutput.instances, let iamCenterArn = iamCenterInstances[0].instanceArn else {
+        guard let iamCenterInstances = listInstancesOutput.instances, !iamCenterInstances.isEmpty, let iamCenterArn = iamCenterInstances[0].instanceArn else {
             throw ClientError.dataNotFound("No IAM Identity Center instance found. Check AWS organization is enabled for the account.")
         }
         return iamCenterArn


### PR DESCRIPTION
## Description of changes
- The SSO credential provider test can crash on failure, due to accessing the first element of an empty array.  A check is added to prevent this and allow the test to fail and the rest of the test suite to proceed.
- A `Resources` folder is added to the SQS integration test folder to prevent a build warning.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.