### PR TITLE
fix: Fix ref used for smithy-swift checkout in codegen-build-test-on-comment

### DIFF
--- a/.github/workflows/codegen-build-test-on-comment.yml
+++ b/.github/workflows/codegen-build-test-on-comment.yml
@@ -31,7 +31,7 @@ jobs:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
       - name: Select smithy-swift branch
         run: |
-          ORIGINAL_REPO_HEAD_REF="$GITHUB_HEAD_REF" \
+          ORIGINAL_REPO_HEAD_REF="${{ steps.comment-branch.outputs.head_ref }}" \
           DEPENDENCY_REPO_URL="https://github.com/smithy-lang/smithy-swift.git" \
           ./scripts/ci_steps/select_dependency_branch.sh
       - name: Checkout smithy-swift


### PR DESCRIPTION
## Description of changes
Uses the correct ref to check out `smithy-swift` to match the branch used for the SDK.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.