### PR TITLE
chore: Run tvOS old & new in CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -40,7 +40,7 @@ jobs:
             xcode: Xcode_15.0.1
           - destination: 'platform=iOS Simulator,OS=16.0,name=iPhone 13'
             xcode: Xcode_15.0.1
-          # Don't run new iOS simulator with old Xcode
+          # Don't run new iOS/tvOS simulator with old Xcode
           - destination: 'platform=tvOS Simulator,OS=17.0,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_14.0.1
           - destination: 'platform=iOS Simulator,OS=17.0,name=iPhone 14'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,22 +21,28 @@ jobs:
           - macos-13
         xcode:
           - Xcode_14.0.1
-          - Xcode_15.0
+          - Xcode_15.0.1
         destination:
           - 'platform=iOS Simulator,OS=16.0,name=iPhone 13'
           - 'platform=iOS Simulator,OS=17.0,name=iPhone 14'
+          - 'platform=tvOS Simulator,OS=16.0,name=Apple TV 4K (at 1080p) (2nd generation)'
+          - 'platform=tvOS Simulator,OS=17.0,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=OS X'
         exclude:
           # Don't run old macOS with new Xcode
           - runner: macos-12
-            xcode: Xcode_15.0
+            xcode: Xcode_15.0.1
           # Don't run new macOS with old Xcode
           - runner: macos-13
             xcode: Xcode_14.0.1
-          # Don't run old iOS simulator with new Xcode
+          # Don't run old iOS/tvOS simulator with new Xcode
+          - destination: 'platform=tvOS Simulator,OS=16.0,name=Apple TV 4K (at 1080p) (2nd generation)'
+            xcode: Xcode_15.0.1
           - destination: 'platform=iOS Simulator,OS=16.0,name=iPhone 13'
-            xcode: Xcode_15.0
+            xcode: Xcode_15.0.1
           # Don't run new iOS simulator with old Xcode
+          - destination: 'platform=tvOS Simulator,OS=17.0,name=Apple TV 4K (3rd generation) (at 1080p)'
+            xcode: Xcode_14.0.1
           - destination: 'platform=iOS Simulator,OS=17.0,name=iPhone 14'
             xcode: Xcode_14.0.1
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,7 +21,7 @@ jobs:
           - macos-13
         xcode:
           - Xcode_14.0.1
-          - Xcode_15.0.1
+          - Xcode_15.0
         destination:
           - 'platform=iOS Simulator,OS=16.0,name=iPhone 13'
           - 'platform=iOS Simulator,OS=17.0,name=iPhone 14'
@@ -31,16 +31,16 @@ jobs:
         exclude:
           # Don't run old macOS with new Xcode
           - runner: macos-12
-            xcode: Xcode_15.0.1
+            xcode: Xcode_15.0
           # Don't run new macOS with old Xcode
           - runner: macos-13
             xcode: Xcode_14.0.1
-          # Don't run old iOS/tvOS simulator with new Xcode
+          # Don't run old simulators with new Xcode
           - destination: 'platform=tvOS Simulator,OS=16.0,name=Apple TV 4K (at 1080p) (2nd generation)'
-            xcode: Xcode_15.0.1
+            xcode: Xcode_15.0
           - destination: 'platform=iOS Simulator,OS=16.0,name=iPhone 13'
-            xcode: Xcode_15.0.1
-          # Don't run new iOS/tvOS simulator with old Xcode
+            xcode: Xcode_15.0
+          # Don't run new simulators with old Xcode
           - destination: 'platform=tvOS Simulator,OS=17.0,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_14.0.1
           - destination: 'platform=iOS Simulator,OS=17.0,name=iPhone 14'

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
@@ -28,7 +28,8 @@ let package = Package(
     name: "aws-sdk-swift",
     platforms: [
         .macOS(.v10_15),
-        .iOS(.v13)
+        .iOS(.v13),
+        .tvOS(.v13)
     ],
     products: [
         .library(name: "AWSClientRuntime", targets: ["AWSClientRuntime"])

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
@@ -29,7 +29,8 @@ let package = Package(
     platforms: [
         .macOS(.v10_15),
         .iOS(.v13),
-        .tvOS(.v13)
+        .tvOS(.v13),
+        .watchOS(.v6)
     ],
     products: [
         .library(name: "AWSClientRuntime", targets: ["AWSClientRuntime"])

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,8 @@ let package = Package(
     name: "aws-sdk-swift",
     platforms: [
         .macOS(.v10_15),
-        .iOS(.v13)
+        .iOS(.v13),
+        .tvOS(.v13)
     ],
     products: [
         .library(name: "AWSClientRuntime", targets: ["AWSClientRuntime"])

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,8 @@ let package = Package(
     platforms: [
         .macOS(.v10_15),
         .iOS(.v13),
-        .tvOS(.v13)
+        .tvOS(.v13),
+        .watchOS(.v6)
     ],
     products: [
         .library(name: "AWSClientRuntime", targets: ["AWSClientRuntime"])

--- a/Tests/Core/AWSClientRuntimeTests/UserAgent/AWSUserAgentMetadataTests.swift
+++ b/Tests/Core/AWSClientRuntimeTests/UserAgent/AWSUserAgentMetadataTests.swift
@@ -105,6 +105,12 @@ class AWSUseragentMetadataTests: XCTestCase {
             expected = "aws-sdk-swift/1.2.3 ua/2.0 api/test_service#1.2.3 os/macos#11.4 lang/swift#9.9"
         case .iOS:
             expected = "aws-sdk-swift/1.2.3 ua/2.0 api/test_service#1.2.3 os/ios#11.4 lang/swift#9.9"
+        case .tvOS:
+            expected = "aws-sdk-swift/1.2.3 ua/2.0 api/test_service#1.2.3 os/tvos#11.4 lang/swift#9.9"
+        case .visionOS:
+            expected = "aws-sdk-swift/1.2.3 ua/2.0 api/test_service#1.2.3 os/visionos#11.4 lang/swift#9.9"
+        case .watchOS:
+            expected = "aws-sdk-swift/1.2.3 ua/2.0 api/test_service#1.2.3 os/watchgit add os#11.4 lang/swift#9.9"
         case .unknown:
             expected = "aws-sdk-swift/1.2.3 ua/2.0 api/test_service#1.2.3 os/unknown#11.4 lang/swift#9.9"
         default:

--- a/Tests/Core/AWSClientRuntimeTests/UserAgent/AWSUserAgentMetadataTests.swift
+++ b/Tests/Core/AWSClientRuntimeTests/UserAgent/AWSUserAgentMetadataTests.swift
@@ -110,7 +110,7 @@ class AWSUseragentMetadataTests: XCTestCase {
         case .visionOS:
             expected = "aws-sdk-swift/1.2.3 ua/2.0 api/test_service#1.2.3 os/visionos#11.4 lang/swift#9.9"
         case .watchOS:
-            expected = "aws-sdk-swift/1.2.3 ua/2.0 api/test_service#1.2.3 os/watchgit add os#11.4 lang/swift#9.9"
+            expected = "aws-sdk-swift/1.2.3 ua/2.0 api/test_service#1.2.3 os/watchos#11.4 lang/swift#9.9"
         case .unknown:
             expected = "aws-sdk-swift/1.2.3 ua/2.0 api/test_service#1.2.3 os/unknown#11.4 lang/swift#9.9"
         default:


### PR DESCRIPTION
## Issue \#
#376

## Description of changes
Adds a Xcode 14 / tvOS 16 and a Xcode 15 / tvOS 17 job to SDK continuous integration.
- `xcodebuild` is used to target the tvOS simulator on 2 new CI jobs
- Set minimum tvOS version of 13.0 and minimum watchOS version to 6.0, to match CRT minimums

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.