### PR TITLE
fix: Use new manifest generator options to run protocol & unit tests in CI

### DIFF
--- a/scripts/ci_steps/prepare_protocol_and_unit_tests.sh
+++ b/scripts/ci_steps/prepare_protocol_and_unit_tests.sh
@@ -2,13 +2,9 @@
 
 set -e
 
-# Delete all generated services & their tests
-rm -rf Sources/Services/*
-rm -rf Tests/Services/*
-
-# Regenerate the SDK Package.swift without the services and with protocol tests
+# Regenerate the SDK Package.swift to run only protocol tests and runtime unit tests
 cd AWSSDKSwiftCLI
-swift run AWSSDKSwiftCLI generate-package-manifest --include-protocol-tests ..
+swift run AWSSDKSwiftCLI generate-package-manifest --include-protocol-tests --exclude-aws-services ..
 cd ..
 
 # Dump the Package.swift contents to the logs


### PR DESCRIPTION
## Description of changes
Uses the new manifest generator options to run unit & protocol tests rather than deleting services.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.