### PR TITLE
fix: Only codegen-build-test when repo is main repo

### DIFF
--- a/.github/workflows/codegen-build-test-on-comment.yml
+++ b/.github/workflows/codegen-build-test-on-comment.yml
@@ -14,7 +14,10 @@ jobs:
     runs-on: macos-13-xl
     env:
       DEVELOPER_DIR: /Applications/Xcode_15.0.app/Contents/Developer
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/test')
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/test')
     steps:
       - name: Get PR branch
         uses: xt0rted/pull-request-comment-branch@v2


### PR DESCRIPTION
## Description of changes
Trigger codegen-build-test workflow only on main project repo.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.