### PR TITLE
feat: Add codegen-build-test workflow to pull requests

### DIFF
--- a/.github/workflows/codegen-build-test.yml
+++ b/.github/workflows/codegen-build-test.yml
@@ -4,6 +4,7 @@ name: Codegen, Build, and Test
 
 on:
   workflow_dispatch:
+  pull_request:
 
 env:
   AWS_SWIFT_SDK_USE_LOCAL_DEPS: 1
@@ -11,6 +12,7 @@ env:
 jobs:
   codegen-build-test:
     runs-on: macos-13
+    environment: Codegen-Build-Test
     env:
       DEVELOPER_DIR: /Applications/Xcode_15.0.app/Contents/Developer
     steps:


### PR DESCRIPTION
## Issue \#
#1264

## Description of changes
- Trigger the codegen-build-test workflow on `pull_request`
- Use the `Codegen-Build-Test` deployment environment for the `codegen-build-test` workflow.
Reference for Github Action environments: https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment#using-an-environment

The deployment environment is configured to require manual permissions from any member of our Github team to run.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.