### PR TITLE
fix: Fall back to GITHUB_REF_NAME when building on workflow dispatch

### DIFF
--- a/.github/workflows/codegen-build-test.yml
+++ b/.github/workflows/codegen-build-test.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Select smithy-swift branch
         run: |
-          ORIGINAL_REPO_HEAD_REF="$GITHUB_HEAD_REF" \
+          ORIGINAL_REPO_HEAD_REF="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}" \
           DEPENDENCY_REPO_URL="https://github.com/smithy-lang/smithy-swift.git" \
           ./scripts/ci_steps/select_dependency_branch.sh
       - name: Checkout smithy-swift


### PR DESCRIPTION
## Description of changes
Ensures that a matching branch name in `smithy-swift` is used when starting `codegen-build-test` using workflow dispatch.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.