### PR TITLE
chore: Use Xcode 15.1 as CI latest version

### DIFF
--- a/.github/workflows/codegen-build-test.yml
+++ b/.github/workflows/codegen-build-test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-13
     environment: Codegen-Build-Test
     env:
-      DEVELOPER_DIR: /Applications/Xcode_15.0.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_15.1.app/Contents/Developer
     steps:
       - name: Checkout aws-sdk-swift
         uses: actions/checkout@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,29 +21,29 @@ jobs:
           - macos-13
         xcode:
           - Xcode_14.0.1
-          - Xcode_15.0
+          - Xcode_15.1
         destination:
-          - 'platform=iOS Simulator,OS=16.0,name=iPhone 13'
-          - 'platform=iOS Simulator,OS=17.0,name=iPhone 14'
+          - 'platform=iOS Simulator,OS=16.0,name=iPhone 14'
+          - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
           - 'platform=tvOS Simulator,OS=16.0,name=Apple TV 4K (at 1080p) (2nd generation)'
-          - 'platform=tvOS Simulator,OS=17.0,name=Apple TV 4K (3rd generation) (at 1080p)'
+          - 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=OS X'
         exclude:
           # Don't run old macOS with new Xcode
           - runner: macos-12
-            xcode: Xcode_15.0
+            xcode: Xcode_15.1
           # Don't run new macOS with old Xcode
           - runner: macos-13
             xcode: Xcode_14.0.1
           # Don't run old simulators with new Xcode
           - destination: 'platform=tvOS Simulator,OS=16.0,name=Apple TV 4K (at 1080p) (2nd generation)'
-            xcode: Xcode_15.0
-          - destination: 'platform=iOS Simulator,OS=16.0,name=iPhone 13'
-            xcode: Xcode_15.0
+            xcode: Xcode_15.1
+          - destination: 'platform=iOS Simulator,OS=16.0,name=iPhone 14'
+            xcode: Xcode_15.1
           # Don't run new simulators with old Xcode
-          - destination: 'platform=tvOS Simulator,OS=17.0,name=Apple TV 4K (3rd generation) (at 1080p)'
+          - destination: 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_14.0.1
-          - destination: 'platform=iOS Simulator,OS=17.0,name=iPhone 14'
+          - destination: 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
             xcode: Xcode_14.0.1
     steps:
       - name: Checkout aws-sdk-swift


### PR DESCRIPTION
## Description of changes
- Use macOS 12 / Xcode 14.0.1 / iOS 16.0 / tvOS 16.0 as "earliest" versions on CI.
- Use macOS 13 / Xcode 15.1 / iOS 17.2 / tvOS 17.2 as "latest" versions on CI.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.