### PR TITLE
Delete unnecessary TODO item.

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/AwsQueryProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/AwsQueryProtocolGenerator.kt
@@ -30,11 +30,6 @@ import software.amazon.smithy.swift.codegen.middleware.MiddlewareStep
 import software.amazon.smithy.swift.codegen.model.ShapeMetadata
 
 open class AwsQueryProtocolGenerator : AWSHttpBindingProtocolGenerator() {
-    // TODO: Rename defaultContentType to differentiate between request & response
-    // Requests are:
-    //  application/x-www-form-urlencoded
-    // Responses are:
-    //  text/xml
     override val codingKeysGenerator = DefaultCodingKeysGenerator(CodingKeysCustomizationXmlName())
     override val defaultContentType = "application/x-www-form-urlencoded"
     override val defaultTimestampFormat = TimestampFormatTrait.Format.DATE_TIME


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->
#1196 

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
After investigation, reached conclusion that the mentioned TODO item isn't referring to renaming the _value_ of the variable but rather the _name_ of the variable itself. The value of the variable _is_ supposed to be fixed at `"application/x-www-form-urlencoded"` and no change is needed. TODO item is likely referring to renaming `defaultContentType` variable to something like `defaultRequestContentType` to erase possible confusion arising from different default content types of response and request of AWS query protocol (response content type is `text/xml`).

Confirmed that the SDK works correctly currently, using STS::GetCallerIdentity which uses AWS query protocol. The returned content type is `text/xml` as expected and response is correctly deserialized.

System works correctly already, and the original thought process behind adding this TODO doesn't really make sense given the SDK obviously only sets content type of requests, so I'll proceed with just deleting TODO item.

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.