### PR TITLE
fix: integration tests to conform to latest HTTPClient change

### DIFF
--- a/IntegrationTests/Services/AWSS3IntegrationTests/S3ErrorIn200Test.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/S3ErrorIn200Test.swift
@@ -12,7 +12,7 @@ import AWSClientRuntime
 import AwsCommonRuntimeKit
 import ClientRuntime
 
-public class MockHttpClientEngine: HttpClientEngine {
+public class MockHttpClientEngine: HTTPClient {
 
     // Public initializer
     public init() {}
@@ -33,7 +33,7 @@ public class MockHttpClientEngine: HttpClientEngine {
         )
     }
 
-    public func execute(request: SdkHttpRequest) async throws -> HttpResponse {
+    public func send(request: SdkHttpRequest) async throws -> HttpResponse {
         return successHttpResponse(request: request)
     }
 }


### PR DESCRIPTION
Fixes integration test that fails to compile due to recent change from HttpClientEngine -> HTTPClient and execute -> send. Tested locally

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.