### PR TITLE
Update .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,20 +1,5 @@
 version: 1
 builder:
   configs:
-  - platform: macosXcodebuild
-    target: AWSSTS
-  - platform: ios
-    target: AWSSTS
-  - platform: linux
-    swift_version: '5.7'
-    image: registry.gitlab.com/finestructure/spi-images:basic-5.7-latest
-    target: AWSSTS
-  - platform: linux
-    swift_version: '5.8'
-    image: registry.gitlab.com/finestructure/spi-images:basic-5.8-latest
-    target: AWSSTS
-  - platform: linux
-    swift_version: '5.9'
-    image: registry.gitlab.com/finestructure/spi-images:basic-5.9-latest
-    target: AWSSTS
-
+  - target: AWSSTS
+    scheme: AWSSTS


### PR DESCRIPTION
Update `.spi.yml` to fix some issues (more detail inline)

I noticed that the builds are all failing in our compatibility test suite and I believe this can be fixed with a couple of tweaks to the SPI config file.

There's also a real build failure on Linux:

```
/host/spi-builder-workspace/.build/checkouts/aws-crt-swift/aws-common-runtime/aws-c-cal/include/aws/cal/private/opensslcrypto_common.h:10:10: fatal error: 'openssl/crypto.h' file not found
#include <openssl/crypto.h>
         ^~~~~~~~~~~~~~~~~~
```

because we didn't yet install `libssl-dev` in our images. I've fixed this and Linux builds now pass:

![CleanShot 2024-01-11 at 11 51 01@2x](https://github.com/awslabs/aws-sdk-swift/assets/65520/4e39ff10-a7c2-47ad-a066-e4c74476ec27)

(at least for 0.33.0, there's a [genuine build failure on `main`](https://swiftpackageindex.com/builds/3E63E721-AA2F-423D-8C35-196D214DCC74):

```
error: Dependencies could not be resolved because root depends on 'aws-crt-swift' 0.20.0.
'aws-crt-swift' 0.17.0 is required because 'smithy-swift' 0.37.0 depends on 'aws-crt-swift' 0.17.0 and root depends on 'smithy-swift' 0.37.0.
BUILD FAILURE 5.9 linux
```
)