### PR TITLE
feat: Add integration tests to CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,6 +9,7 @@ env:
 
 jobs:
   apple:
+    if: false
     runs-on: ${{ matrix.runner }}
     env:
       DEVELOPER_DIR: /Applications/${{ matrix.xcode }}.app/Contents/Developer
@@ -101,6 +102,7 @@ jobs:
             | xcpretty
 
   linux:
+    if: false
     runs-on: ubuntu-latest
     container: swift:${{ matrix.version }}-${{ matrix.os }}
     strategy:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,7 +9,6 @@ env:
 
 jobs:
   apple:
-    if: false
     runs-on: ${{ matrix.runner }}
     env:
       DEVELOPER_DIR: /Applications/${{ matrix.xcode }}.app/Contents/Developer
@@ -102,7 +101,6 @@ jobs:
             | xcpretty
 
   linux:
-    if: false
     runs-on: ubuntu-latest
     container: swift:${{ matrix.version }}-${{ matrix.os }}
     strategy:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,166 @@
+name: Integration Tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  AWS_SWIFT_SDK_USE_LOCAL_DEPS: 1
+
+permissions:
+  id-token: write
+
+jobs:
+  apple:
+    runs-on: ${{ matrix.runner }}
+    environment: Integration-Test
+    env:
+      DEVELOPER_DIR: /Applications/${{ matrix.xcode }}.app/Contents/Developer
+    strategy:
+      fail-fast: false
+      matrix:
+        # This matrix runs tests on iOS sim & Mac, on oldest & newest supported Xcodes
+        runner:
+          #- macos-12
+          - macos-13
+        xcode:
+          #- Xcode_14.0.1
+          - Xcode_15.1
+        destination:
+          #- 'platform=iOS Simulator,OS=16.0,name=iPhone 14'
+          #- 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
+          #- 'platform=tvOS Simulator,OS=16.0,name=Apple TV 4K (at 1080p) (2nd generation)'
+          #- 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
+          - 'platform=OS X'
+        exclude:
+          # Don't run old macOS with new Xcode
+          #- runner: macos-12
+          #  xcode: Xcode_15.1
+          # Don't run new macOS with old Xcode
+          #- runner: macos-13
+          #  xcode: Xcode_14.0.1
+          # Don't run old simulators with new Xcode
+          #- destination: 'platform=tvOS Simulator,OS=16.0,name=Apple TV 4K (at 1080p) (2nd generation)'
+          #  xcode: Xcode_15.1
+          #- destination: 'platform=iOS Simulator,OS=16.0,name=iPhone 14'
+          #  xcode: Xcode_15.1
+          # Don't run new simulators with old Xcode
+          #- destination: 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
+          #  xcode: Xcode_14.0.1
+          #- destination: 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
+          #  xcode: Xcode_14.0.1
+    steps:
+      - name: Configure AWS Credentials for Integration Tests
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.INTEGRATION_TEST_ROLE_ARN }}
+          aws-region: us-west-2
+      - name: Checkout aws-sdk-swift
+        uses: actions/checkout@v3
+      - name: Select smithy-swift branch
+        run: |
+          ORIGINAL_REPO_HEAD_REF="$GITHUB_HEAD_REF" \
+          DEPENDENCY_REPO_URL="https://github.com/smithy-lang/smithy-swift.git" \
+          ./scripts/ci_steps/select_dependency_branch.sh
+      - name: Checkout smithy-swift
+        uses: actions/checkout@v3
+        with:
+          repository: smithy-lang/smithy-swift
+          ref: ${{ env.DEPENDENCY_REPO_SHA }}
+          path: smithy-swift
+      - name: Move smithy-swift into place
+        run: mv smithy-swift ..
+      - name: Cache Gradle
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: 1-${{ runner.os }}-gradle-${{ hashFiles('settings.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            1-${{ runner.os }}-gradle-${{ hashFiles('settings.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
+            1-${{ runner.os }}-gradle-
+      - name: Cache Swift
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            ~/.cache/org.swift.swiftpm
+          key: 1-${{ runner.os }}-${{ matrix.xcode }}-${{ hashFiles('Package.swift', 'AWSSDKSwiftCLI/Package.swift') }}
+          restore-keys: |
+            1-${{ runner.os }}-${{ matrix.xcode }}-${{ hashFiles('Package.swift', 'AWSSDKSwiftCLI/Package.swift') }}
+            1-${{ runner.os }}-${{ matrix.xcode }}-
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 17
+      - name: Tools Versions
+        run: ./scripts/ci_steps/log_tool_versions.sh
+      - name: Prepare Integration Tests
+        run: ./scripts/ci_steps/prepare_integration_tests.sh
+      - name: Build and Run Integration Tests
+        run: swift test
+
+  linux:
+    if: false
+    runs-on: ubuntu-latest
+    container: swift:${{ matrix.version }}-${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - focal
+          - amazonlinux2
+        version:
+          - 5.7
+          - 5.9
+    steps:
+      - name: Checkout aws-sdk-swift
+        uses: actions/checkout@v3
+      - name: Select smithy-swift branch
+        run: |
+          ORIGINAL_REPO_HEAD_REF="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-main}}" \
+          DEPENDENCY_REPO_URL="https://github.com/smithy-lang/smithy-swift.git" \
+          ./scripts/ci_steps/select_dependency_branch.sh
+      - name: Checkout smithy-swift
+        uses: actions/checkout@v3
+        with:
+          repository: smithy-lang/smithy-swift
+          ref: ${{ env.DEPENDENCY_REPO_SHA }}
+          path: smithy-swift
+      - name: Move smithy-swift into place
+        run: mv smithy-swift ..
+      - name: Cache Gradle
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: 1-${{ runner.os }}-gradle-${{ hashFiles('settings.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            1-${{ runner.os }}-gradle-${{ hashFiles('settings.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
+            1-${{ runner.os }}-gradle-
+      - name: Cache Swift
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            ~/.cache/org.swift.swiftpm
+          key: 1-${{ runner.os }}-swift-${{ matrix.version }}-spm-${{ hashFiles('Package.swift', 'AWSSDKSwiftCLI/Package.swift') }}
+          restore-keys: |
+            1-${{ runner.os }}-swift-${{ matrix.version }}-spm-${{ hashFiles('Package.swift', 'AWSSDKSwiftCLI/Package.swift') }}
+            1-${{ runner.os }}-swift-${{ matrix.version }}-spm-
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 17
+      - name: Install OpenSSL (all OS) and which (AL2 only)
+        run: ./scripts/ci_steps/install_native_linux_dependencies.sh
+      - name: Tools Versions
+        run: ./scripts/ci_steps/log_tool_versions.sh
+      - name: Prepare Protocol & Unit Tests
+        run: ./scripts/ci_steps/prepare_protocol_and_unit_tests.sh
+      - name: Build and Run Protocol & Unit Tests on Linux
+        run: swift test

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -32,7 +32,7 @@ jobs:
           #- 'platform=tvOS Simulator,OS=16.0,name=Apple TV 4K (at 1080p) (2nd generation)'
           #- 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=OS X'
-        exclude:
+        #exclude:
           # Don't run old macOS with new Xcode
           #- runner: macos-12
           #  xcode: Xcode_15.1

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -99,7 +99,9 @@ jobs:
         run: ./scripts/ci_steps/log_tool_versions.sh
       - name: Prepare Integration Tests
         run: ./scripts/ci_steps/prepare_integration_tests.sh
-      - name: Build and Run Integration Tests
+      - name: Build Integration Tests
+        run: swift build --build-tests
+      - name: Run Integration Tests
         run: swift test
 
   linux:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -105,19 +105,24 @@ jobs:
         run: swift test
 
   linux:
-    if: false
     runs-on: ubuntu-latest
+    environment: Integration-Test
     container: swift:${{ matrix.version }}-${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os:
           - focal
-          - amazonlinux2
+          #- amazonlinux2
         version:
-          - 5.7
+          #- 5.7
           - 5.9
     steps:
+      - name: Configure AWS Credentials for Integration Tests
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.INTEGRATION_TEST_ROLE_ARN }}
+          aws-region: us-west-2
       - name: Checkout aws-sdk-swift
         uses: actions/checkout@v3
       - name: Select smithy-swift branch
@@ -162,7 +167,9 @@ jobs:
         run: ./scripts/ci_steps/install_native_linux_dependencies.sh
       - name: Tools Versions
         run: ./scripts/ci_steps/log_tool_versions.sh
-      - name: Prepare Protocol & Unit Tests
-        run: ./scripts/ci_steps/prepare_protocol_and_unit_tests.sh
-      - name: Build and Run Protocol & Unit Tests on Linux
+      - name: Prepare Integration Tests
+        run: ./scripts/ci_steps/prepare_integration_tests.sh
+      - name: Build Integration Tests
+        run: swift build --build-tests
+      - name: Run Integration Tests
         run: swift test

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -96,7 +96,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - amazonlinux2
+          - focal
+          #- amazonlinux2
         version:
           - 5.7
           - 5.9

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -19,36 +19,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # This matrix runs tests on iOS sim & Mac, on oldest & newest supported Xcodes
+        # This matrix runs tests on Mac, on oldest & newest supported Xcodes
         runner:
-          #- macos-12
+          - macos-12
           - macos-13
         xcode:
-          #- Xcode_14.0.1
-          - Xcode_15.1
-        destination:
-          #- 'platform=iOS Simulator,OS=16.0,name=iPhone 14'
-          #- 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-          #- 'platform=tvOS Simulator,OS=16.0,name=Apple TV 4K (at 1080p) (2nd generation)'
-          #- 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
-          - 'platform=OS X'
-        #exclude:
+          - Xcode_14.0.1
+          - Xcode_15.2
+        exclude:
           # Don't run old macOS with new Xcode
-          #- runner: macos-12
-          #  xcode: Xcode_15.1
+          - runner: macos-12
+            xcode: Xcode_15.2
           # Don't run new macOS with old Xcode
-          #- runner: macos-13
-          #  xcode: Xcode_14.0.1
-          # Don't run old simulators with new Xcode
-          #- destination: 'platform=tvOS Simulator,OS=16.0,name=Apple TV 4K (at 1080p) (2nd generation)'
-          #  xcode: Xcode_15.1
-          #- destination: 'platform=iOS Simulator,OS=16.0,name=iPhone 14'
-          #  xcode: Xcode_15.1
-          # Don't run new simulators with old Xcode
-          #- destination: 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
-          #  xcode: Xcode_14.0.1
-          #- destination: 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-          #  xcode: Xcode_14.0.1
+          - runner: macos-13
+            xcode: Xcode_14.0.1
     steps:
       - name: Configure AWS Credentials for Integration Tests
         uses: aws-actions/configure-aws-credentials@v4
@@ -112,10 +96,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - focal
-          #- amazonlinux2
+          - amazonlinux2
         version:
-          #- 5.7
+          - 5.7
           - 5.9
     steps:
       - name: Configure AWS Credentials for Integration Tests

--- a/IntegrationTests/Services/AWSECSIntegrationTests/ECSCredentialsProviderTests.swift
+++ b/IntegrationTests/Services/AWSECSIntegrationTests/ECSCredentialsProviderTests.swift
@@ -37,7 +37,7 @@ class ECSCredentialsProviderTests: XCTestCase {
         )
     }
     
-    func test_ecsCredentialsProvider() async throws {
+    func xtest_ecsCredentialsProvider() async throws {
         let ecsClient = try await ECSClient()
         
         // create cluster

--- a/IntegrationTests/Services/AWSECSIntegrationTests/ECSCredentialsProviderTests.swift
+++ b/IntegrationTests/Services/AWSECSIntegrationTests/ECSCredentialsProviderTests.swift
@@ -37,6 +37,7 @@ class ECSCredentialsProviderTests: XCTestCase {
         )
     }
     
+    // TODO: Re-enable this test once CI is configured to run it. See https://github.com/awslabs/aws-sdk-swift/issues/1310
     func xtest_ecsCredentialsProvider() async throws {
         let ecsClient = try await ECSClient()
         

--- a/IntegrationTests/Services/AWSS3IntegrationTests/ProcessCredentialsProviderTests.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/ProcessCredentialsProviderTests.swift
@@ -31,7 +31,7 @@ class ProcessCredentialProviderTests: XCTestCase {
     }
 
     // This test calls listBuckets() and forces S3Client to use ProcessCredentialsProvider
-    func test_listBuckets() async throws {
+    func xtest_listBuckets() async throws {
         _ = try await client.listBuckets(input: ListBucketsInput())
     }
 }

--- a/IntegrationTests/Services/AWSS3IntegrationTests/ProcessCredentialsProviderTests.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/ProcessCredentialsProviderTests.swift
@@ -31,6 +31,7 @@ class ProcessCredentialProviderTests: XCTestCase {
     }
 
     // This test calls listBuckets() and forces S3Client to use ProcessCredentialsProvider
+    // TODO: Re-enable this test once CI is configured to run it.  See https://github.com/awslabs/aws-sdk-swift/issues/1309
     func xtest_listBuckets() async throws {
         _ = try await client.listBuckets(input: ListBucketsInput())
     }

--- a/IntegrationTests/Services/AWSS3IntegrationTests/S3URLEncodingTests.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/S3URLEncodingTests.swift
@@ -7,8 +7,6 @@
 
 #if canImport(FoundationNetworking)
 import FoundationNetworking
-#else
-inport Foundation
 #endif
 import XCTest
 import AWSS3

--- a/IntegrationTests/Services/AWSS3IntegrationTests/S3URLEncodingTests.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/S3URLEncodingTests.swift
@@ -5,6 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#else
+inport Foundation
+#endif
 import XCTest
 import AWSS3
 

--- a/IntegrationTests/Services/AWSS3IntegrationTests/S3XCTestCase.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/S3XCTestCase.swift
@@ -7,8 +7,6 @@
 
 #if canImport(FoundationNetworking)
 import FoundationNetworking
-#else
-inport Foundation
 #endif
 import XCTest
 import AWSS3

--- a/IntegrationTests/Services/AWSS3IntegrationTests/S3XCTestCase.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/S3XCTestCase.swift
@@ -5,6 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#else
+inport Foundation
+#endif
 import XCTest
 import AWSS3
 

--- a/IntegrationTests/Services/AWSS3IntegrationTests/SSOCredentialsProviderTests.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/SSOCredentialsProviderTests.swift
@@ -54,7 +54,7 @@ class SSOCredentialsProviderTests : XCTestCase {
     }
 
     // The test calls listBuckets() and forces S3Client to use SSOCredentialsProvider
-    func test_listBuckets() async throws {
+    func xtest_listBuckets() async throws {
         _ = try await client.listBuckets(input: ListBucketsInput())
     }
     

--- a/IntegrationTests/Services/AWSS3IntegrationTests/SSOCredentialsProviderTests.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/SSOCredentialsProviderTests.swift
@@ -54,6 +54,7 @@ class SSOCredentialsProviderTests : XCTestCase {
     }
 
     // The test calls listBuckets() and forces S3Client to use SSOCredentialsProvider
+    // TODO: Re-enable this test once CI is configured to run it. See https://github.com/awslabs/aws-sdk-swift/issues/1311
     func xtest_listBuckets() async throws {
         _ = try await client.listBuckets(input: ListBucketsInput())
     }

--- a/scripts/ci_steps/prepare_integration_tests.sh
+++ b/scripts/ci_steps/prepare_integration_tests.sh
@@ -5,6 +5,10 @@ set -e
 # Only enable codegen for integration test services
 cp scripts/integration-test-sdk.properties sdk.properties
 
+# Delete all staged, generated code
+rm -rf Sources/Services/*
+rm -rf Tests/Services/*
+
 # Code-generate all enabled AWS services
 ./gradlew -p codegen/sdk-codegen build
 ./gradlew -p codegen/sdk-codegen stageSdks

--- a/scripts/ci_steps/prepare_integration_tests.sh
+++ b/scripts/ci_steps/prepare_integration_tests.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+# Code-generate all enabled AWS services
+./gradlew -p codegen/sdk-codegen build
+./gradlew -p codegen/sdk-codegen stageSdks
+./gradlew --stop
+
+# Merge model files
+./scripts/mergeModels.sh Sources/Services
+
+# Regenerate the SDK Package.swift to run only integration tests
+cd AWSSDKSwiftCLI
+swift run AWSSDKSwiftCLI generate-package-manifest --include-integration-tests --exclude-aws-services --exclude-runtime-tests ..
+cd ..
+
+# Dump the Package.swift contents to the logs
+cat Package.swift
+
+# Run aws-sdk-swift integration tests as a separate step
+# (allows for use of either Xcode or pure Swift toolchains)

--- a/scripts/ci_steps/prepare_integration_tests.sh
+++ b/scripts/ci_steps/prepare_integration_tests.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Only enable codegen for integration test services
+cp scripts/integration-test-sdk.properties sdk.properties
+
 # Code-generate all enabled AWS services
 ./gradlew -p codegen/sdk-codegen build
 ./gradlew -p codegen/sdk-codegen stageSdks

--- a/scripts/integration-test-sdk.properties
+++ b/scripts/integration-test-sdk.properties
@@ -1,0 +1,2 @@
+# Only include services needed for running integration tests
+onlyIncludeModels=kinesis.2013-12-02,s3.2006-03-01,sso-admin.2020-07-20,translate.2017-07-01,sqs.2012-11-05,ec2.2016-11-15,mediaconvert.2017-08-29,ecs.2014-11-13,cloudwatch-logs.2014-03-28,iam.2010-05-08,sts.2011-06-15


### PR DESCRIPTION
## Issue \#
#769

## Description of changes
Adds a Github CI workflow that runs integration tests on Mac & Linux.  Tests are run against a dedicated AWS account to be used solely for integration testing.

The general workflow for integration tests:
- Get AWS credentials for the integration test account.
- Code-generate only the services needed for integration tests.
- Build the integration tests.
- Run the integration tests.

Tests run on:
- macOS 12 + Xcode 14.0.1 (Swift 5.7)
- macOS 13 + Xcode 15.2 (Swift 5.9)
- Ubuntu Focal + Swift 5.7
- Ubuntu Focal + Swift 5.9

(AL2 is not enabled because of incompatibility between the AWS credentials GH action and AL2):
https://github.com/aws-actions/configure-aws-credentials/issues/862#issuecomment-1901732082

The three credential provider integration tests are disabled, because they will require extra configuration to enable and it is desired to get most of the test suite running as swiftly as possible.  Tracking tickets have been added for the following credential provider tests, which should be worked and re-added to the suite as soon as possible:

#1309 (Process Credential Provider)
#1310 (ECS Credential Provider)
#1311 (SSO Credential Provider)

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.