### PR TITLE
feat: Update STS web identity credentials provider & add integration test

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
@@ -136,6 +136,8 @@ func addIntegrationTestTarget(_ name: String) {
         ]
     case "AWSS3":
         additionalDependencies = ["AWSSSOAdmin"]
+    case "AWSSTS":
+        additionalDependencies = ["AWSIAM", "AWSCognitoIdentity"]
     default:
         break
     }

--- a/IntegrationTests/Services/AWSSTSIntegrationTests/STSWebIdentityCredentialsProviderTests.swift
+++ b/IntegrationTests/Services/AWSSTSIntegrationTests/STSWebIdentityCredentialsProviderTests.swift
@@ -41,41 +41,41 @@ class STSWebIdentityCredentialsProviderTests: XCTestCase {
 
     // JSON assume role policy
     private let assumeRolePolicy = """
+    {
+      "Version": "2012-10-17",
+      "Statement": [
         {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Sid": "",
-              "Effect": "Allow",
-              "Principal": {
-                "Federated": "cognito-identity.amazonaws.com"
-              },
-              "Action": [
-                "sts:AssumeRoleWithWebIdentity"
-              ],
-              "Condition": {
-                 "ForAnyValue:StringLike": {
-                   "cognito-identity.amazonaws.com:amr": "unauthenticated"
-                 }
-              }
-            }
-          ]
+          "Sid": "",
+          "Effect": "Allow",
+          "Principal": {
+            "Federated": "cognito-identity.amazonaws.com"
+          },
+          "Action": [
+            "sts:AssumeRoleWithWebIdentity"
+          ],
+          "Condition": {
+             "ForAnyValue:StringLike": {
+               "cognito-identity.amazonaws.com:amr": "unauthenticated"
+             }
+          }
         }
+      ]
+    }
     """
     // Identity policy name & JSON identity policy
     private let identityPolicyName = "allow-STS-getCallerIdentity"
     private let roleIdentityPolicy = """
-        {
-            "Version": "2012-10-17",
-            "Statement": [
-                {
-                    "Sid": "",
-                    "Effect": "Allow",
-                    "Action": "sts:GetCallerIdentity",
-                    "Resource": "*"
-                }
-            ]
-        }
+    {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "",
+                "Effect": "Allow",
+                "Action": "sts:GetCallerIdentity",
+                "Resource": "*"
+            }
+        ]
+    }
     """
 
     override func setUp() async throws {

--- a/IntegrationTests/Services/AWSSTSIntegrationTests/STSWebIdentityCredentialsProviderTests.swift
+++ b/IntegrationTests/Services/AWSSTSIntegrationTests/STSWebIdentityCredentialsProviderTests.swift
@@ -127,7 +127,7 @@ class STSWebIdentityCredentialsProviderTests: XCTestCase {
             assumeRolePolicyDocument: assumeRolePolicy,
             roleName: roleName
         )).role?.arn
-        // Return after role creation finishes
+        // This wait is necessary for role creation to propagate everywhere
         let seconds = 10
         let NSEC_PER_SEC = 1_000_000_000
         try await Task.sleep(nanoseconds: UInt64(seconds * NSEC_PER_SEC))

--- a/IntegrationTests/Services/AWSSTSIntegrationTests/STSWebIdentityCredentialsProviderTests.swift
+++ b/IntegrationTests/Services/AWSSTSIntegrationTests/STSWebIdentityCredentialsProviderTests.swift
@@ -61,7 +61,7 @@ class STSWebIdentityCredentialsProviderTests: XCTestCase {
             }
           ]
         }
-        """
+    """
     // Identity policy name & JSON identity policy
     private let identityPolicyName = "allow-STS-getCallerIdentity"
     private let roleIdentityPolicy = """
@@ -76,7 +76,7 @@ class STSWebIdentityCredentialsProviderTests: XCTestCase {
                 }
             ]
         }
-        """
+    """
 
     override func setUp() async throws {
         try await super.setUp()

--- a/IntegrationTests/Services/AWSSTSIntegrationTests/STSWebIdentityCredentialsProviderTests.swift
+++ b/IntegrationTests/Services/AWSSTSIntegrationTests/STSWebIdentityCredentialsProviderTests.swift
@@ -17,8 +17,7 @@ import Foundation
 class STSWebIdentityCredentialsProviderTests: XCTestCase {
     private let region = "us-west-2"
     private var oidcToken: String!
-    // File path for the cached OIDC token.
-    private var tokenFilePath: String!
+    private var oidcTokenFilePath: String!
 
     // STS client with only the STS web identity credentials provider configured.
     private var webIdentityStsClient: STSClient!
@@ -26,158 +25,81 @@ class STSWebIdentityCredentialsProviderTests: XCTestCase {
 
     // Used to create identity pools and fetch cognito ID & OIDC token from it.
     private var cognitoIdentityClient: CognitoIdentityClient!
-    // Regular STS client; used to fetch the account ID used in fetching cognito ID.
+    // Regular STS client used to fetch the account ID used in fetching cognito ID.
     private var stsClient: STSClient!
-    // Cognito identity pool name & ID
     private let identityPoolName = "aws-sts-integration-test-\(UUID().uuidString.split(separator: "-").first!.lowercased())"
     private var identityPoolId: String!
 
     // Used to create temporary role assumed by STS web identity credentials provider.
     private var iamClient: IAMClient!
-    // Role properties
+
     private let roleName = "aws-sts-integration-test-\(UUID().uuidString.split(separator: "-").first!.lowercased())"
     private let roleSessionName = "aws-sts-integration-test-\(UUID().uuidString.split(separator: "-").first!.lowercased())"
     private var roleArn: String!
 
     // JSON assume role policy
     private let assumeRolePolicy = """
-    {
-      "Version": "2012-10-17",
-      "Statement": [
-        {
-          "Sid": "",
-          "Effect": "Allow",
-          "Principal": {
-            "Federated": "cognito-identity.amazonaws.com"
-          },
-          "Action": [
-            "sts:AssumeRoleWithWebIdentity"
-          ],
-          "Condition": {
-             "ForAnyValue:StringLike": {
-               "cognito-identity.amazonaws.com:amr": "unauthenticated"
-             }
-          }
-        }
-      ]
-    }
+    {"Version": "2012-10-17","Statement": [{"Sid": "","Effect": "Allow",
+    "Principal": {"Federated": "cognito-identity.amazonaws.com"},"Action": [
+    "sts:AssumeRoleWithWebIdentity"],"Condition": {"ForAnyValue:StringLike": {
+    "cognito-identity.amazonaws.com:amr": "unauthenticated"}}}]}
     """
-    // Identity policy name & JSON identity policy
     private let identityPolicyName = "allow-STS-getCallerIdentity"
+    // JSON identity policy
     private let roleIdentityPolicy = """
-    {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Sid": "",
-                "Effect": "Allow",
-                "Action": "sts:GetCallerIdentity",
-                "Resource": "*"
-            }
-        ]
-    }
+    {"Version": "2012-10-17","Statement": [{"Sid": "","Effect": "Allow",
+    "Action": "sts:GetCallerIdentity","Resource": "*"}]}
     """
+
+    /* ////////////////
+     * SETUP & TEARDOWN
+     * ////////////////
+     */
 
     override func setUp() async throws {
         try await super.setUp()
 
         // Create the role to be assumed in exchange for web identity token
-        iamClient = try IAMClient(region: region)
-        let role = try await iamClient.createRole(input: CreateRoleInput(
-            assumeRolePolicyDocument: assumeRolePolicy,
-            roleName: roleName
-        ))
-        roleArn = role.role?.arn
-
-        // This wait is necessary for role creation to propagate everywhere
-        let seconds = 10
-        let NSEC_PER_SEC = 1_000_000_000
-        try await Task.sleep(nanoseconds: UInt64(seconds * NSEC_PER_SEC))
+        try await createRoleToBeAssumed()
 
         // Attach identity policy to role
-        _ = try await iamClient.putRolePolicy(input: PutRolePolicyInput(
-            policyDocument: roleIdentityPolicy,
-            policyName: identityPolicyName,
-            roleName: roleName
-        ))
+        try await attachIdentityPolicyToRole()
 
         // Create the Cognito identity pool that allows unauthenticated identities
-        cognitoIdentityClient = try CognitoIdentityClient(region: region)
-        let identityPool = try await cognitoIdentityClient.createIdentityPool(
-            input: CreateIdentityPoolInput(
-                allowUnauthenticatedIdentities: true,
-                identityPoolName: identityPoolName
-        ))
-        identityPoolId = identityPool.identityPoolId
+        try await createCognitoIdentityPool()
 
-        // Get Cognito ID from Cognito identity pool
-        stsClient = try STSClient(region: region)
-        let accountId = try await stsClient.getCallerIdentity(input: GetCallerIdentityInput()).account
-        let cognitoId = try await cognitoIdentityClient.getId(input: GetIdInput(
-            accountId: accountId, identityPoolId: identityPoolId
-        ))
+        // Get OIDC token from Cognito
+        try await getAndCacheOIDCTokenFromCognito()
 
-        // Get OIDC token from Cognito identity pool using Cognito ID
-        oidcToken  = try await cognitoIdentityClient.getOpenIdToken(
-            input: GetOpenIdTokenInput(identityId: cognitoId.identityId)
-        ).token
-        // Save OIDC token to a file then save filepath
-        try saveTokenIntoFile()
+        // Construct STS Client config with only STS web identity crednentials provider
+        try await constructSTSConfigWithWebIdentityCredentialsProvider()
 
-        // Construct STS web identity credentials provider
-        let webIdentityCredentialsProvider = try STSWebIdentityCredentialsProvider(
-            region: region,
-            roleArn: roleArn,
-            roleSessionName: roleSessionName,
-            tokenFilePath: tokenFilePath
-        )
-
-        // Construct STS config with STS web identity credentials provider
-        stsConfig = try await STSClient.STSClientConfiguration(
-            credentialsProvider: webIdentityCredentialsProvider,
-            region: region
-        )
-
-        // Construct STS client with just the...
-        // ...STS web identity credentials provider configured
+        // Construct STS client that uses STS web identity credentials provider
         webIdentityStsClient = STSClient(config: stsConfig)
     }
 
     override func tearDown() async throws {
         // Delete inline identity policy of the role
-        let policyName = try await iamClient.listRolePolicies(input: ListRolePoliciesInput(roleName: roleName)).policyNames
-        _ = try await iamClient.deleteRolePolicy(input: DeleteRolePolicyInput(
-            policyName: policyName?[0], roleName: roleName
-        ))
+        try await deleteInlineRolePolicy()
+
         // Delete role
         _ = try await iamClient.deleteRole(input: DeleteRoleInput(roleName: roleName))
+
         // Delete Cognito identity pool
-        _ = try await cognitoIdentityClient.deleteIdentityPool(input: DeleteIdentityPoolInput(identityPoolId: identityPoolId))
+        _ = try await cognitoIdentityClient.deleteIdentityPool(
+            input: DeleteIdentityPoolInput(identityPoolId: identityPoolId)
+        )
+
         // Delete token file
         try deleteTokenFile()
     }
 
-    // Helper methods for saving & deleting token file
-    private func saveTokenIntoFile() throws {
-        tokenFilePath = NSHomeDirectory() + "/token.txt"
-        let tokenData = oidcToken.data(using: String.Encoding.utf8)
-        let fileCreated = FileManager.default.createFile(
-            atPath: tokenFilePath, contents: tokenData, attributes: nil
-        )
-        if !fileCreated {
-            throw TokenFileError.TokenFileCreationFailed("Failed to create token text file.")
-        }
-    }
-    private func deleteTokenFile() throws {
-        do {
-            try FileManager.default.removeItem(atPath: tokenFilePath)
-        } catch {
-            throw TokenFileError.TokenFileDeletionFailed("Failed to delete token text file.")
-        }
-    }
+    /* /////////
+     * TEST CASE
+     * /////////
+     */
 
-    // Confirm STS web identity credentials provider gave valid credentials
-    // ...by checking response was returned successfully.
+    // Confirm STS web identity credentials provider works by validating response.
     func testGetCallerIdentity() async throws {
         let response = try await webIdentityStsClient.getCallerIdentity(
             input: GetCallerIdentityInput()
@@ -193,14 +115,113 @@ class STSWebIdentityCredentialsProviderTests: XCTestCase {
         XCTAssertNotEqual(userId, "")
         XCTAssertNotEqual(arn, "")
     }
-}
 
-enum TokenFileError: Error {
-    case TokenFileCreationFailed(String)
-    case TokenFileDeletionFailed(String)
-}
+    /* //////////////////////
+     * SETUP HELPER FUNCTIONS
+     * //////////////////////
+     */
 
-enum IdentityPoolStatus {
-    case INITIALIZING
-    case DONE
+    private func createRoleToBeAssumed() async throws {
+        iamClient = try IAMClient(region: region)
+        roleArn = try await iamClient.createRole(input: CreateRoleInput(
+            assumeRolePolicyDocument: assumeRolePolicy,
+            roleName: roleName
+        )).role?.arn
+        // Return after role creation finishes
+        let seconds = 10
+        let NSEC_PER_SEC = 1_000_000_000
+        try await Task.sleep(nanoseconds: UInt64(seconds * NSEC_PER_SEC))
+    }
+
+    private func attachIdentityPolicyToRole() async throws {
+        _ = try await iamClient.putRolePolicy(input: PutRolePolicyInput(
+            policyDocument: roleIdentityPolicy,
+            policyName: identityPolicyName,
+            roleName: roleName
+        ))
+    }
+
+    private func createCognitoIdentityPool() async throws {
+        cognitoIdentityClient = try CognitoIdentityClient(region: region)
+        let identityPool = try await cognitoIdentityClient.createIdentityPool(
+            input: CreateIdentityPoolInput(
+                allowUnauthenticatedIdentities: true,
+                identityPoolName: identityPoolName
+        ))
+        identityPoolId = identityPool.identityPoolId
+    }
+
+    private func saveTokenIntoFile() throws {
+        oidcTokenFilePath = FileManager.default.temporaryDirectory.appending(path: "/token.txt").path()
+        let tokenData = oidcToken.data(using: String.Encoding.utf8)
+        let fileCreated = FileManager.default.createFile(
+            atPath: oidcTokenFilePath, contents: tokenData, attributes: nil
+        )
+        if !fileCreated {
+            throw TokenFileError.TokenFileCreationFailed("Failed to create token text file.")
+        }
+    }
+
+    private func getAndCacheOIDCTokenFromCognito() async throws {
+        // Get Cognito ID from Cognito identity pool
+        stsClient = try STSClient(region: region)
+        let accountId = try await stsClient.getCallerIdentity(input: GetCallerIdentityInput()).account
+        let cognitoId = try await cognitoIdentityClient.getId(input: GetIdInput(
+            accountId: accountId, identityPoolId: identityPoolId
+        ))
+        // Get OIDC token from Cognito identity pool using Cognito ID
+        oidcToken  = try await cognitoIdentityClient.getOpenIdToken(
+            input: GetOpenIdTokenInput(identityId: cognitoId.identityId)
+        ).token
+        // Save OIDC token to a file then save filepath
+        try saveTokenIntoFile()
+    }
+
+    private func constructSTSConfigWithWebIdentityCredentialsProvider() async throws {
+        let webIdentityCredentialsProvider = try STSWebIdentityCredentialsProvider(
+            region: region,
+            roleArn: roleArn,
+            roleSessionName: roleSessionName,
+            tokenFilePath: oidcTokenFilePath
+        )
+        stsConfig = try await STSClient.STSClientConfiguration(
+            credentialsProvider: webIdentityCredentialsProvider,
+            region: region
+        )
+    }
+
+    /* /////////////////////////
+     * TEARDOWN HELPER FUNCTIONS
+     * /////////////////////////
+     */
+
+    private func deleteInlineRolePolicy() async throws {
+        let policyName = try await iamClient.listRolePolicies(input: ListRolePoliciesInput(roleName: roleName)).policyNames
+        _ = try await iamClient.deleteRolePolicy(input: DeleteRolePolicyInput(
+            policyName: policyName?[0], roleName: roleName
+        ))
+    }
+
+    private func deleteTokenFile() throws {
+        do {
+            try FileManager.default.removeItem(atPath: oidcTokenFilePath)
+        } catch {
+            throw TokenFileError.TokenFileDeletionFailed("Failed to delete token text file.")
+        }
+    }
+
+    /* //////////////////////////////
+     * ENUMS USED IN SETUP & TEARDOWN
+     * //////////////////////////////
+     */
+
+    enum TokenFileError: Error {
+        case TokenFileCreationFailed(String)
+        case TokenFileDeletionFailed(String)
+    }
+
+    enum IdentityPoolStatus {
+        case INITIALIZING
+        case DONE
+    }
 }

--- a/IntegrationTests/Services/AWSSTSIntegrationTests/STSWebIdentityCredentialsProviderTests.swift
+++ b/IntegrationTests/Services/AWSSTSIntegrationTests/STSWebIdentityCredentialsProviderTests.swift
@@ -152,7 +152,11 @@ class STSWebIdentityCredentialsProviderTests: XCTestCase {
     }
 
     private func saveTokenIntoFile() throws {
+        #if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS) || os(macOS)
         oidcTokenFilePath = FileManager.default.temporaryDirectory.appending(path: "/token.txt").path()
+        #else
+        oidcTokenFilePath = FileManager.default.temporaryDirectory.appendingPathComponent(partialName: "token", conformingTo: .utf8PlainText)
+        #endif
         let tokenData = oidcToken.data(using: String.Encoding.utf8)
         let fileCreated = FileManager.default.createFile(
             atPath: oidcTokenFilePath, contents: tokenData, attributes: nil

--- a/IntegrationTests/Services/AWSSTSIntegrationTests/STSWebIdentityCredentialsProviderTests.swift
+++ b/IntegrationTests/Services/AWSSTSIntegrationTests/STSWebIdentityCredentialsProviderTests.swift
@@ -1,0 +1,206 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import AWSSTS
+import AWSIAM
+import AWSCognitoIdentity
+import ClientRuntime
+import AWSClientRuntime
+import Foundation
+
+/// Tests STS web identity credentials provider using STS::getCallerIdentity.
+class STSWebIdentityCredentialsProviderTests: XCTestCase {
+    private let region = "us-west-2"
+    private var oidcToken: String!
+    // File path for the cached OIDC token.
+    private var tokenFilePath: String!
+
+    // STS client with only the STS web identity credentials provider configured.
+    private var webIdentityStsClient: STSClient!
+    private var stsConfig: STSClient.STSClientConfiguration!
+
+    // Used to create identity pools and fetch cognito ID & OIDC token from it.
+    private var cognitoIdentityClient: CognitoIdentityClient!
+    // Regular STS client; used to fetch the account ID used in fetching cognito ID.
+    private var stsClient: STSClient!
+    // Cognito identity pool name & ID
+    private let identityPoolName = "aws-sts-integration-test-\(UUID().uuidString.split(separator: "-").first!.lowercased())"
+    private var identityPoolId: String!
+
+    // Used to create temporary role assumed by STS web identity credentials provider.
+    private var iamClient: IAMClient!
+    // Role properties
+    private let roleName = "aws-sts-integration-test-\(UUID().uuidString.split(separator: "-").first!.lowercased())"
+    private let roleSessionName = "aws-sts-integration-test-\(UUID().uuidString.split(separator: "-").first!.lowercased())"
+    private var roleArn: String!
+
+    // JSON assume role policy
+    private let assumeRolePolicy = """
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "",
+              "Effect": "Allow",
+              "Principal": {
+                "Federated": "cognito-identity.amazonaws.com"
+              },
+              "Action": [
+                "sts:AssumeRoleWithWebIdentity"
+              ],
+              "Condition": {
+                 "ForAnyValue:StringLike": {
+                   "cognito-identity.amazonaws.com:amr": "unauthenticated"
+                 }
+              }
+            }
+          ]
+        }
+        """
+    // Identity policy name & JSON identity policy
+    private let identityPolicyName = "allow-STS-getCallerIdentity"
+    private let roleIdentityPolicy = """
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "",
+                    "Effect": "Allow",
+                    "Action": "sts:GetCallerIdentity",
+                    "Resource": "*"
+                }
+            ]
+        }
+        """
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        // Create the role to be assumed in exchange for web identity token
+        iamClient = try IAMClient(region: region)
+        let role = try await iamClient.createRole(input: CreateRoleInput(
+            assumeRolePolicyDocument: assumeRolePolicy,
+            roleName: roleName
+        ))
+        roleArn = role.role?.arn
+
+        // This wait is necessary for role creation to propagate everywhere
+        let seconds = 10
+        let NSEC_PER_SEC = 1_000_000_000
+        try await Task.sleep(nanoseconds: UInt64(seconds * NSEC_PER_SEC))
+
+        // Attach identity policy to role
+        _ = try await iamClient.putRolePolicy(input: PutRolePolicyInput(
+            policyDocument: roleIdentityPolicy,
+            policyName: identityPolicyName,
+            roleName: roleName
+        ))
+
+        // Create the Cognito identity pool that allows unauthenticated identities
+        cognitoIdentityClient = try CognitoIdentityClient(region: region)
+        let identityPool = try await cognitoIdentityClient.createIdentityPool(
+            input: CreateIdentityPoolInput(
+                allowUnauthenticatedIdentities: true,
+                identityPoolName: identityPoolName
+        ))
+        identityPoolId = identityPool.identityPoolId
+
+        // Get Cognito ID from Cognito identity pool
+        stsClient = try STSClient(region: region)
+        let accountId = try await stsClient.getCallerIdentity(input: GetCallerIdentityInput()).account
+        let cognitoId = try await cognitoIdentityClient.getId(input: GetIdInput(
+            accountId: accountId, identityPoolId: identityPoolId
+        ))
+
+        // Get OIDC token from Cognito identity pool using Cognito ID
+        oidcToken  = try await cognitoIdentityClient.getOpenIdToken(
+            input: GetOpenIdTokenInput(identityId: cognitoId.identityId)
+        ).token
+        // Save OIDC token to a file then save filepath
+        try saveTokenIntoFile()
+
+        // Construct STS web identity credentials provider
+        let webIdentityCredentialsProvider = try STSWebIdentityCredentialsProvider(
+            region: region,
+            roleArn: roleArn,
+            roleSessionName: roleSessionName,
+            tokenFilePath: tokenFilePath
+        )
+
+        // Construct STS config with STS web identity credentials provider
+        stsConfig = try await STSClient.STSClientConfiguration(
+            credentialsProvider: webIdentityCredentialsProvider,
+            region: region
+        )
+
+        // Construct STS client with just the...
+        // ...STS web identity credentials provider configured
+        webIdentityStsClient = STSClient(config: stsConfig)
+    }
+
+    override func tearDown() async throws {
+        // Delete inline identity policy of the role
+        let policyName = try await iamClient.listRolePolicies(input: ListRolePoliciesInput(roleName: roleName)).policyNames
+        _ = try await iamClient.deleteRolePolicy(input: DeleteRolePolicyInput(
+            policyName: policyName?[0], roleName: roleName
+        ))
+        // Delete role
+        _ = try await iamClient.deleteRole(input: DeleteRoleInput(roleName: roleName))
+        // Delete Cognito identity pool
+        _ = try await cognitoIdentityClient.deleteIdentityPool(input: DeleteIdentityPoolInput(identityPoolId: identityPoolId))
+        // Delete token file
+        try deleteTokenFile()
+    }
+
+    // Helper methods for saving & deleting token file
+    private func saveTokenIntoFile() throws {
+        tokenFilePath = NSHomeDirectory() + "/token.txt"
+        let tokenData = oidcToken.data(using: String.Encoding.utf8)
+        let fileCreated = FileManager.default.createFile(
+            atPath: tokenFilePath, contents: tokenData, attributes: nil
+        )
+        if !fileCreated {
+            throw TokenFileError.TokenFileCreationFailed("Failed to create token text file.")
+        }
+    }
+    private func deleteTokenFile() throws {
+        do {
+            try FileManager.default.removeItem(atPath: tokenFilePath)
+        } catch {
+            throw TokenFileError.TokenFileDeletionFailed("Failed to delete token text file.")
+        }
+    }
+
+    // Confirm STS web identity credentials provider gave valid credentials
+    // ...by checking response was returned successfully.
+    func testGetCallerIdentity() async throws {
+        let response = try await webIdentityStsClient.getCallerIdentity(
+            input: GetCallerIdentityInput()
+        )
+
+        // Ensure returned caller info aren't nil
+        let account = try XCTUnwrap(response.account)
+        let userId = try XCTUnwrap(response.userId)
+        let arn = try XCTUnwrap(response.arn)
+
+        // Ensure returned caller info aren't empty strings
+        XCTAssertNotEqual(account, "")
+        XCTAssertNotEqual(userId, "")
+        XCTAssertNotEqual(arn, "")
+    }
+}
+
+enum TokenFileError: Error {
+    case TokenFileCreationFailed(String)
+    case TokenFileDeletionFailed(String)
+}
+
+enum IdentityPoolStatus {
+    case INITIALIZING
+    case DONE
+}

--- a/IntegrationTests/Services/AWSSTSIntegrationTests/STSWebIdentityCredentialsProviderTests.swift
+++ b/IntegrationTests/Services/AWSSTSIntegrationTests/STSWebIdentityCredentialsProviderTests.swift
@@ -152,11 +152,7 @@ class STSWebIdentityCredentialsProviderTests: XCTestCase {
     }
 
     private func saveTokenIntoFile() throws {
-        #if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS) || os(macOS)
-        oidcTokenFilePath = FileManager.default.temporaryDirectory.appending(path: "token.txt").path()
-        #else
-        oidcTokenFilePath = FileManager.default.temporaryDirectory.appendingPathComponent("token.txt")
-        #endif
+        oidcTokenFilePath = FileManager.default.temporaryDirectory.appendingPathComponent("token.txt").path()
         let tokenData = oidcToken.data(using: String.Encoding.utf8)
         let fileCreated = FileManager.default.createFile(
             atPath: oidcTokenFilePath, contents: tokenData, attributes: nil

--- a/IntegrationTests/Services/AWSSTSIntegrationTests/STSWebIdentityCredentialsProviderTests.swift
+++ b/IntegrationTests/Services/AWSSTSIntegrationTests/STSWebIdentityCredentialsProviderTests.swift
@@ -153,9 +153,9 @@ class STSWebIdentityCredentialsProviderTests: XCTestCase {
 
     private func saveTokenIntoFile() throws {
         #if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS) || os(macOS)
-        oidcTokenFilePath = FileManager.default.temporaryDirectory.appending(path: "/token.txt").path()
+        oidcTokenFilePath = FileManager.default.temporaryDirectory.appending(path: "token.txt").path()
         #else
-        oidcTokenFilePath = FileManager.default.temporaryDirectory.appendingPathComponent(partialName: "token", conformingTo: .utf8PlainText)
+        oidcTokenFilePath = FileManager.default.temporaryDirectory.appendingPathComponent("token.txt")
         #endif
         let tokenData = oidcToken.data(using: String.Encoding.utf8)
         let fileCreated = FileManager.default.createFile(

--- a/IntegrationTests/Services/AWSSTSIntegrationTests/STSWebIdentityCredentialsProviderTests.swift
+++ b/IntegrationTests/Services/AWSSTSIntegrationTests/STSWebIdentityCredentialsProviderTests.swift
@@ -152,7 +152,7 @@ class STSWebIdentityCredentialsProviderTests: XCTestCase {
     }
 
     private func saveTokenIntoFile() throws {
-        oidcTokenFilePath = FileManager.default.temporaryDirectory.appendingPathComponent("token.txt").path()
+        oidcTokenFilePath = FileManager.default.temporaryDirectory.appendingPathComponent("token.txt").pathExtension
         let tokenData = oidcToken.data(using: String.Encoding.utf8)
         let fileCreated = FileManager.default.createFile(
             atPath: oidcTokenFilePath, contents: tokenData, attributes: nil

--- a/Sources/Core/AWSClientRuntime/Auth/CredentialsProviders/STSWebIdentityCredentialsProvider.swift
+++ b/Sources/Core/AWSClientRuntime/Auth/CredentialsProviders/STSWebIdentityCredentialsProvider.swift
@@ -26,9 +26,17 @@ public struct STSWebIdentityCredentialsProvider: CredentialsSourcedByCRT {
     /// - Parameters:
     ///   - configFilePath: The path to the configuration file to use. If not provided it will be resolved internally via the `AWS_CONFIG_FILE` environment variable or defaulted  to `~/.aws/config` if not configured.
     ///   - credentialsFilePath: The path to the shared credentials file to use. If not provided it will be resolved internally via the `AWS_SHARED_CREDENTIALS_FILE` environment variable or defaulted `~/.aws/credentials` if not configured.
+    ///   - region: (Optional) region override.
+    ///   - roleArn: (Optional) roleArn override.
+    ///   - roleSessionName: (Optional) roleSessionName override.
+    ///   - tokenFilePath: (Optional) tokenFilePath override.
     public init(
         configFilePath: String? = nil,
-        credentialsFilePath: String? = nil
+        credentialsFilePath: String? = nil,
+        region: String? = nil,
+        roleArn: String? = nil,
+        roleSessionName: String? = nil,
+        tokenFilePath: String? = nil
     ) throws {
         let fileBasedConfig = try CRTFileBasedConfiguration(
             configFilePath: configFilePath,
@@ -38,6 +46,10 @@ public struct STSWebIdentityCredentialsProvider: CredentialsSourcedByCRT {
             bootstrap: SDKDefaultIO.shared.clientBootstrap,
             tlsContext: SDKDefaultIO.shared.tlsContext,
             fileBasedConfiguration: fileBasedConfig,
+            region: region,
+            roleArn: roleArn,
+            roleSessionName: roleSessionName,
+            tokenFilePath: tokenFilePath,
             shutdownCallback: nil
         ))
     }

--- a/scripts/integration-test-sdk.properties
+++ b/scripts/integration-test-sdk.properties
@@ -1,2 +1,2 @@
 # Only include services needed for running integration tests
-onlyIncludeModels=kinesis.2013-12-02,s3.2006-03-01,sso-admin.2020-07-20,translate.2017-07-01,sqs.2012-11-05,mediaconvert.2017-08-29,sts.2011-06-15
+onlyIncludeModels=kinesis.2013-12-02,s3.2006-03-01,sso-admin.2020-07-20,translate.2017-07-01,sqs.2012-11-05,mediaconvert.2017-08-29,sts.2011-06-15,cognito-identity.2014-06-30,iam.2010-05-08


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-swift/issues/1189

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Updates the SDK wrapper for STS web identity credentials provider following CRT changes here: https://github.com/awslabs/aws-crt-swift/pull/199/files
- Add the integration test for STS web identity credentials provider that uses STS, IAM, and Cognito.

## Integration test structure overview:
1. Create a temporary role with assume role policy that accepts unauthenticated OIDC tokens made by Cognito
2. Create a Cognito identity pool, then fetch Cognito ID from it, then fetch OIDC token from it using Cognito ID
3. Save the fetched OIDC token to a file
4. Construct STS web identity credentials provider using the role and the file path to cached token
5. Call `STS::getCallerIdentity` using a STS client that has just the STS web identity credentials provider configured
6. Confirm request succeeded by checking response fields (not nil & not empty string)
7. Clean up role policy, role, Cognito identity pool, and token file after the test

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.