### PR TITLE
chore: Update aws-crt-swift to 0.26.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -231,7 +231,7 @@ func addResolvedTargets() {
 
 addDependencies(
     clientRuntimeVersion: "0.39.0",
-    crtVersion: "0.22.0"
+    crtVersion: "0.26.0"
 )
 
 // Uncomment this line to exclude runtime unit tests

--- a/packageDependencies.plist
+++ b/packageDependencies.plist
@@ -5,7 +5,7 @@
 	<key>awsCRTSwiftBranch</key>
 	<string>main</string>
 	<key>awsCRTSwiftVersion</key>
-	<string>0.22.0</string>
+	<string>0.26.0</string>
 	<key>clientRuntimeBranch</key>
 	<string>main</string>
 	<key>clientRuntimeVersion</key>


### PR DESCRIPTION
## Issue \#
#1334

## Description of changes
Updates aws-crt-swift to 0.26.0. This version of aws-crt-swift removes the swift-collections dependency to avoid a build failure.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.