### PR TITLE
chore: Use Apple Silicon for codegen-build-test on CI

### DIFF
--- a/.github/workflows/codegen-build-test.yml
+++ b/.github/workflows/codegen-build-test.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   codegen-build-test:
-    runs-on: macos-14
+    runs-on: macos-14-xlarge
     environment: Codegen-Build-Test
     env:
       DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer

--- a/.github/workflows/codegen-build-test.yml
+++ b/.github/workflows/codegen-build-test.yml
@@ -11,10 +11,10 @@ env:
 
 jobs:
   codegen-build-test:
-    runs-on: macos-13
+    runs-on: macos-14
     environment: Codegen-Build-Test
     env:
-      DEVELOPER_DIR: /Applications/Xcode_15.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer
     steps:
       - name: Checkout aws-sdk-swift
         uses: actions/checkout@v3

--- a/scripts/ci_steps/log_tool_versions.sh
+++ b/scripts/ci_steps/log_tool_versions.sh
@@ -2,6 +2,16 @@
 
 set -e
 
+# Log CPU for hardware in use, if running on Mac
+
+if command -v sysctl &> /dev/null
+then
+  sysctl -a | grep machdep.cpu
+  echo
+else
+  echo "sysctl not installed (not a Mac)"
+fi
+
 # Log location & version for swiftc, xcodebuild, java, xcbeautify
 
 if command -v swiftc &> /dev/null

--- a/scripts/ci_steps/log_tool_versions.sh
+++ b/scripts/ci_steps/log_tool_versions.sh
@@ -2,16 +2,18 @@
 
 set -e
 
+echo
+
 # Log CPU for hardware in use, if running on Mac
 
 if [[ "$OSTYPE" == "darwin"* ]];
 then
   which sysctl
   sysctl -a | grep machdep.cpu || true
-  echo
 else
   echo "sysctl not run (not a Mac)"
 fi
+echo
 
 # Log location & version for swiftc, xcodebuild, java, xcbeautify
 
@@ -19,34 +21,33 @@ if command -v swiftc &> /dev/null
 then
   which swiftc
   swiftc --version
-  echo
 else
   echo "swiftc not installed"
 fi
+echo
 
 if command -v xcodebuild &> /dev/null
 then
   which xcodebuild
   xcodebuild -version
-  echo
 else
   echo "xcodebuild not installed"
 fi
+echo
 
 if command -v java &> /dev/null
 then
   which java
   java --version
-  echo
 else
   echo "java not installed"
 fi
+echo
 
 if command -v xcbeautify &> /dev/null
 then
   which xcbeautify
   xcbeautify --version
-  echo
 else
   echo "xcbeautify not installed"
 fi

--- a/scripts/ci_steps/log_tool_versions.sh
+++ b/scripts/ci_steps/log_tool_versions.sh
@@ -4,12 +4,13 @@ set -e
 
 # Log CPU for hardware in use, if running on Mac
 
-if command -v sysctl &> /dev/null
+if [[ "$OSTYPE" == "darwin"* ]];
 then
-  sysctl -a | grep machdep.cpu
+  which sysctl
+  sysctl -a | grep machdep.cpu || true
   echo
 else
-  echo "sysctl not installed (not a Mac)"
+  echo "sysctl not run (not a Mac)"
 fi
 
 # Log location & version for swiftc, xcodebuild, java, xcbeautify


### PR DESCRIPTION
## Issue \#
#1337

## Description of changes
Uses a M1-based Github action runner (`macos-14-xlarge`) instead of the standard Intel Mac runner for faster codegen-build-test runs.

Testing shows that this runner takes less than half the time that the standard Intel Mac runner does for this job.

(At some point in the future, this runner may be moved over to Pro-level Apple Silicon.)

Also:
- Use Xcode 15.2, the current latest version.
- Log Mac CPU info along with tools versions.
- Fix formatting in log-tools-versions script.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.