### PR TITLE
chore: Update CI to run on Apple Silicon

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Move smithy-swift into place
         run: mv smithy-swift ..
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -139,7 +139,7 @@ jobs:
             1-${{ runner.os }}-gradle-${{ hashFiles('settings.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
             1-${{ runner.os }}-gradle-
       - name: Cache Swift
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: |
             ~/Library/Caches/org.swift.swiftpm
@@ -149,7 +149,7 @@ jobs:
             1-${{ runner.os }}-swift-${{ matrix.version }}-spm-${{ hashFiles('Package.swift', 'AWSSDKSwiftCLI/Package.swift') }}
             1-${{ runner.os }}-swift-${{ matrix.version }}-spm-
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v3
         with:
           distribution: corretto
           java-version: 17

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,7 @@ jobs:
         destination:
           - 'platform=iOS Simulator,OS=16.1,name=iPhone 14'
           - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-          - 'platform=tvOS Simulator,OS=16.1,name=Apple TV 4K (3rd generation) (at 1080p)'`
+          - 'platform=tvOS Simulator,OS=16.1,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=OS X'
         exclude:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -114,14 +114,14 @@ jobs:
           - 5.9
     steps:
       - name: Checkout aws-sdk-swift
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - name: Select smithy-swift branch
         run: |
           ORIGINAL_REPO_HEAD_REF="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-main}}" \
           DEPENDENCY_REPO_URL="https://github.com/smithy-lang/smithy-swift.git" \
           ./scripts/ci_steps/select_dependency_branch.sh
       - name: Checkout smithy-swift
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           repository: smithy-lang/smithy-swift
           ref: ${{ env.DEPENDENCY_REPO_SHA }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,7 @@ jobs:
         destination:
           - 'platform=iOS Simulator,OS=16.1,name=iPhone 14'
           - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-          - 'platform=tvOS Simulator,OS=16.1,name=Apple TV 4K (at 1080p) (2nd generation)'
+          - 'platform=tvOS Simulator,OS=16.1,name=Apple TV 4K (3rd generation) (at 1080p)'`
           - 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=OS X'
         exclude:
@@ -36,7 +36,7 @@ jobs:
           - runner: macos-14-xlarge
             xcode: Xcode_14.1
           # Don't run old simulators with new Xcode
-          - destination: 'platform=tvOS Simulator,OS=16.1,name=Apple TV 4K (at 1080p) (2nd generation)'
+          - destination: 'platform=tvOS Simulator,OS=16.1,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_15.2
           - destination: 'platform=iOS Simulator,OS=16.1,name=iPhone 14'
             xcode: Xcode_15.2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,44 +17,44 @@ jobs:
       matrix:
         # This matrix runs tests on iOS sim & Mac, on oldest & newest supported Xcodes
         runner:
-          - macos-12
-          - macos-13
+          - macos-13-xlarge
+          - macos-14-xlarge
         xcode:
-          - Xcode_14.0.1
-          - Xcode_15.1
+          - Xcode_14.1
+          - Xcode_15.2
         destination:
-          - 'platform=iOS Simulator,OS=16.0,name=iPhone 14'
+          - 'platform=iOS Simulator,OS=16.1,name=iPhone 14'
           - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-          - 'platform=tvOS Simulator,OS=16.0,name=Apple TV 4K (at 1080p) (2nd generation)'
+          - 'platform=tvOS Simulator,OS=16.1,name=Apple TV 4K (at 1080p) (2nd generation)'
           - 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=OS X'
         exclude:
           # Don't run old macOS with new Xcode
-          - runner: macos-12
-            xcode: Xcode_15.1
+          - runner: macos-13-xlarge
+            xcode: Xcode_15.2
           # Don't run new macOS with old Xcode
-          - runner: macos-13
-            xcode: Xcode_14.0.1
+          - runner: macos-14-xlarge
+            xcode: Xcode_14.1
           # Don't run old simulators with new Xcode
-          - destination: 'platform=tvOS Simulator,OS=16.0,name=Apple TV 4K (at 1080p) (2nd generation)'
-            xcode: Xcode_15.1
-          - destination: 'platform=iOS Simulator,OS=16.0,name=iPhone 14'
-            xcode: Xcode_15.1
+          - destination: 'platform=tvOS Simulator,OS=16.1,name=Apple TV 4K (at 1080p) (2nd generation)'
+            xcode: Xcode_15.2
+          - destination: 'platform=iOS Simulator,OS=16.1,name=iPhone 14'
+            xcode: Xcode_15.2
           # Don't run new simulators with old Xcode
           - destination: 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
-            xcode: Xcode_14.0.1
+            xcode: Xcode_14.1
           - destination: 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-            xcode: Xcode_14.0.1
+            xcode: Xcode_14.1
     steps:
       - name: Checkout aws-sdk-swift
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Select smithy-swift branch
         run: |
           ORIGINAL_REPO_HEAD_REF="$GITHUB_HEAD_REF" \
           DEPENDENCY_REPO_URL="https://github.com/smithy-lang/smithy-swift.git" \
           ./scripts/ci_steps/select_dependency_branch.sh
       - name: Checkout smithy-swift
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: smithy-lang/smithy-swift
           ref: ${{ env.DEPENDENCY_REPO_SHA }}
@@ -62,7 +62,7 @@ jobs:
       - name: Move smithy-swift into place
         run: mv smithy-swift ..
       - name: Cache Gradle
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -72,7 +72,7 @@ jobs:
             1-${{ runner.os }}-gradle-${{ hashFiles('settings.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
             1-${{ runner.os }}-gradle-
       - name: Cache Swift
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/Library/Caches/org.swift.swiftpm
@@ -82,7 +82,7 @@ jobs:
             1-${{ runner.os }}-${{ matrix.xcode }}-${{ hashFiles('Package.swift', 'AWSSDKSwiftCLI/Package.swift') }}
             1-${{ runner.os }}-${{ matrix.xcode }}-
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: corretto
           java-version: 17
@@ -114,14 +114,14 @@ jobs:
           - 5.9
     steps:
       - name: Checkout aws-sdk-swift
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Select smithy-swift branch
         run: |
           ORIGINAL_REPO_HEAD_REF="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-main}}" \
           DEPENDENCY_REPO_URL="https://github.com/smithy-lang/smithy-swift.git" \
           ./scripts/ci_steps/select_dependency_branch.sh
       - name: Checkout smithy-swift
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: smithy-lang/smithy-swift
           ref: ${{ env.DEPENDENCY_REPO_SHA }}
@@ -129,7 +129,7 @@ jobs:
       - name: Move smithy-swift into place
         run: mv smithy-swift ..
       - name: Cache Gradle
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -139,7 +139,7 @@ jobs:
             1-${{ runner.os }}-gradle-${{ hashFiles('settings.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties') }}
             1-${{ runner.os }}-gradle-
       - name: Cache Swift
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/Library/Caches/org.swift.swiftpm
@@ -149,7 +149,7 @@ jobs:
             1-${{ runner.os }}-swift-${{ matrix.version }}-spm-${{ hashFiles('Package.swift', 'AWSSDKSwiftCLI/Package.swift') }}
             1-${{ runner.os }}-swift-${{ matrix.version }}-spm-
       - name: Setup Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: corretto
           java-version: 17


### PR DESCRIPTION
## Issue \#
#1339

## Description of changes
Moves the CI workflow to use M1 Mac instead of Intel Mac for substantially faster builds.
- "Oldest" build moves from Intel Mac / macOS 12 / Xcode 14.0.1 to M1 Mac / macOS 13 / Xcode 14.1
- "Newest" build moves from Intel Mac / macOS 13 / Xcode 15.1 to M1 Mac / macOS 14 / Xcode 15.2
- "Oldest" simulators adjusted to match Xcode versions.

Also:
- Some actions updated to newer major versions.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.