### PR TITLE
fix: Change Transcribe integration test to match service transcription

### DIFF
--- a/IntegrationTests/Services/AWSTranscribeStreamingIntegrationTests/TranscribeStreamingTests.swift
+++ b/IntegrationTests/Services/AWSTranscribeStreamingIntegrationTests/TranscribeStreamingTests.swift
@@ -70,6 +70,6 @@ final class TranscribeStreamingTests: XCTestCase {
             }
         }
 
-        XCTAssertEqual("Hello transcribed streaming from Swift S. D. K.", fullMessage)
+        XCTAssertEqual("Hello transcribed streaming from swift sdk.", fullMessage)
     }
 }


### PR DESCRIPTION
## Description of changes
AWS Transcribe changed the way spoken letters are transcribed.  This changes expected text to match what is returned by the service.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.