### PR TITLE
Move integration tests to M1 CI runners, use xcodebuild to test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -85,23 +85,8 @@ jobs:
         run: ./scripts/ci_steps/prepare_integration_tests.sh
       - name: Build Integration Tests
         run: swift build --build-tests
-        #run: |
-        #  set -o pipefail && \
-        #  NSUnbufferedIO=YES \
-        #  xcodebuild \
-        #    -scheme aws-sdk-swift-Package \
-        #    -destination 'platform=OS X' \
-        #    build-for-testing 2>&1 \
-        #    | xcpretty
       - name: Run Integration Tests
         run: swift test
-        #run: |
-          #set -o pipefail && \
-          #NSUnbufferedIO=YES xcodebuild \
-            #-scheme aws-sdk-swift-Package \
-            #-destination 'platform=OS X' \
-            #test 2>&1 \
-            #| xcpretty
 
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           set -o pipefail && \
           NSUnbufferedIO=YES xcodebuild \
-            -scheme aws-sdk-swift \
+            -scheme aws-sdk-swift-Package \
             -destination 'platform=OS X' \
             test 2>&1 \
             | xcpretty

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -88,7 +88,7 @@ jobs:
           set -o pipefail && \
           NSUnbufferedIO=YES \
           xcodebuild \
-            -list/
+            -list \
             -destination 'platform=OS X'
       - name: Run Integration Tests
         run: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -84,7 +84,12 @@ jobs:
       - name: Prepare Integration Tests
         run: ./scripts/ci_steps/prepare_integration_tests.sh
       - name: Build Integration Tests
-        run: swift build --build-tests
+        run: |
+          set -o pipefail && \
+          NSUnbufferedIO=YES \
+          xcodebuild \
+            -list/
+            -destination 'platform=OS X'
       - name: Run Integration Tests
         run: |
           set -o pipefail && \

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -88,8 +88,10 @@ jobs:
           set -o pipefail && \
           NSUnbufferedIO=YES \
           xcodebuild \
-            -list \
+            -scheme aws-sdk-swift-Package \
             -destination 'platform=OS X'
+            build-for-testing 2>&1 \
+            | xcpretty
       - name: Run Integration Tests
         run: |
           set -o pipefail && \

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -86,7 +86,13 @@ jobs:
       - name: Build Integration Tests
         run: swift build --build-tests
       - name: Run Integration Tests
-        run: swift test
+        run: |
+          set -o pipefail && \
+          NSUnbufferedIO=YES xcodebuild \
+            -scheme aws-sdk-swift \
+            -destination 'platform=OS X' \
+            test 2>&1 \
+            | xcpretty
 
   linux:
     runs-on: ubuntu-latest
@@ -156,10 +162,4 @@ jobs:
       - name: Build Integration Tests
         run: swift build --build-tests
       - name: Run Integration Tests
-        run: |
-          set -o pipefail && \
-          NSUnbufferedIO=YES xcodebuild \
-            -scheme aws-sdk-swift \
-            -destination 'platform=OS X' \
-            test 2>&1 \
-            | xcpretty
+        run: swift test

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -89,7 +89,7 @@ jobs:
           NSUnbufferedIO=YES \
           xcodebuild \
             -scheme aws-sdk-swift-Package \
-            -destination 'platform=OS X'
+            -destination 'platform=OS X' \
             build-for-testing 2>&1 \
             | xcpretty
       - name: Run Integration Tests

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -21,18 +21,18 @@ jobs:
       matrix:
         # This matrix runs tests on Mac, on oldest & newest supported Xcodes
         runner:
-          - macos-12
-          - macos-13
+          - macos-13-xlarge
+          - macos-14-xlarge
         xcode:
-          - Xcode_14.0.1
+          - Xcode_14.1
           - Xcode_15.2
         exclude:
           # Don't run old macOS with new Xcode
-          - runner: macos-12
+          - runner: macos-13-xlarge
             xcode: Xcode_15.2
           # Don't run new macOS with old Xcode
-          - runner: macos-13
-            xcode: Xcode_14.0.1
+          - runner: macos-14-xlarge
+            xcode: Xcode_14.1
     steps:
       - name: Configure AWS Credentials for Integration Tests
         uses: aws-actions/configure-aws-credentials@v4
@@ -156,4 +156,10 @@ jobs:
       - name: Build Integration Tests
         run: swift build --build-tests
       - name: Run Integration Tests
-        run: swift test
+        run: |
+          set -o pipefail && \
+          NSUnbufferedIO=YES xcodebuild \
+            -scheme aws-sdk-swift \
+            -destination 'platform=OS X' \
+            test 2>&1 \
+            | xcpretty

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -84,22 +84,24 @@ jobs:
       - name: Prepare Integration Tests
         run: ./scripts/ci_steps/prepare_integration_tests.sh
       - name: Build Integration Tests
-        run: |
-          set -o pipefail && \
-          NSUnbufferedIO=YES \
-          xcodebuild \
-            -scheme aws-sdk-swift-Package \
-            -destination 'platform=OS X' \
-            build-for-testing 2>&1 \
-            | xcpretty
+        run: swift build --build-tests
+        #run: |
+        #  set -o pipefail && \
+        #  NSUnbufferedIO=YES \
+        #  xcodebuild \
+        #    -scheme aws-sdk-swift-Package \
+        #    -destination 'platform=OS X' \
+        #    build-for-testing 2>&1 \
+        #    | xcpretty
       - name: Run Integration Tests
-        run: |
-          set -o pipefail && \
-          NSUnbufferedIO=YES xcodebuild \
-            -scheme aws-sdk-swift-Package \
-            -destination 'platform=OS X' \
-            test 2>&1 \
-            | xcpretty
+        run: swift test
+        #run: |
+          #set -o pipefail && \
+          #NSUnbufferedIO=YES xcodebuild \
+            #-scheme aws-sdk-swift-Package \
+            #-destination 'platform=OS X' \
+            #test 2>&1 \
+            #| xcpretty
 
   linux:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Issue \#
#1353

## Description of changes
Changes CI runners from Intel Mac to M1 Mac, and adjusts Xcode/macOS to match those used for continuous integration testing.

Also: provide a `Resources/` folder in STS integration tests to prevent a build warning.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.