### PR TITLE
fix: Add overwrite behavior for endpoints 2.0 for signing properties

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/EndpointResolverMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/EndpointResolverMiddleware.kt
@@ -102,11 +102,11 @@ class EndpointResolverMiddleware(
 
         writer.openBlock("if let signingRegion = signingRegion {", "}") {
             writer.write("context.attributes.set(key: AttributeKeys.signingRegion, value: signingRegion)")
-            writer.write("context.attributes.set(key: AttributeKeys.selectedAuthScheme, value: context.getSelectedAuthScheme()?.getCopyWithUpdatedSigningProperty(key: AttributeKeys.signingRegion, value: signingRegion)")
+            writer.write("context.attributes.set(key: AttributeKeys.selectedAuthScheme, value: context.getSelectedAuthScheme()?.getCopyWithUpdatedSigningProperty(key: AttributeKeys.signingRegion, value: signingRegion))")
         }
         writer.openBlock("if let signingName = signingName {", "}") {
             writer.write("context.attributes.set(key: AttributeKeys.signingName, value: signingName)")
-            writer.write("context.attributes.set(key: AttributeKeys.selectedAuthScheme, value: context.getSelectedAuthScheme()?.getCopyWithUpdatedSigningProperty(key: AttributeKeys.signingName, value: signingName)")
+            writer.write("context.attributes.set(key: AttributeKeys.selectedAuthScheme, value: context.getSelectedAuthScheme()?.getCopyWithUpdatedSigningProperty(key: AttributeKeys.signingName, value: signingName))")
         }
         writer.openBlock("if let signingAlgorithm = signingAlgorithm {", "}") {
             writer.write("context.attributes.set(key: AttributeKeys.signingAlgorithm, value: AWSSigningAlgorithm(rawValue: signingAlgorithm))")

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/EndpointResolverMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/EndpointResolverMiddleware.kt
@@ -102,9 +102,11 @@ class EndpointResolverMiddleware(
 
         writer.openBlock("if let signingRegion = signingRegion {", "}") {
             writer.write("context.attributes.set(key: AttributeKeys.signingRegion, value: signingRegion)")
+            writer.write("context.attributes.set(key: AttributeKeys.selectedAuthScheme, value: context.getSelectedAuthScheme()?.getCopyWithUpdatedSigningProperty(key: AttributeKeys.signingRegion, value: signingRegion)")
         }
         writer.openBlock("if let signingName = signingName {", "}") {
             writer.write("context.attributes.set(key: AttributeKeys.signingName, value: signingName)")
+            writer.write("context.attributes.set(key: AttributeKeys.selectedAuthScheme, value: context.getSelectedAuthScheme()?.getCopyWithUpdatedSigningProperty(key: AttributeKeys.signingName, value: signingName)")
         }
         writer.openBlock("if let signingAlgorithm = signingAlgorithm {", "}") {
             writer.write("context.attributes.set(key: AttributeKeys.signingAlgorithm, value: AWSSigningAlgorithm(rawValue: signingAlgorithm))")

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/EndpointResolverMiddlewareTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/EndpointResolverMiddlewareTests.kt
@@ -84,9 +84,11 @@ public struct EndpointResolverMiddleware<OperationStackOutput>: ClientRuntime.Mi
 
         if let signingRegion = signingRegion {
             context.attributes.set(key: AttributeKeys.signingRegion, value: signingRegion)
+            context.attributes.set(key: AttributeKeys.selectedAuthScheme, value: context.getSelectedAuthScheme()?.getCopyWithUpdatedSigningProperty(key: AttributeKeys.signingRegion, value: signingRegion)
         }
         if let signingName = signingName {
             context.attributes.set(key: AttributeKeys.signingName, value: signingName)
+            context.attributes.set(key: AttributeKeys.selectedAuthScheme, value: context.getSelectedAuthScheme()?.getCopyWithUpdatedSigningProperty(key: AttributeKeys.signingName, value: signingName)
         }
         if let signingAlgorithm = signingAlgorithm {
             context.attributes.set(key: AttributeKeys.signingAlgorithm, value: AWSSigningAlgorithm(rawValue: signingAlgorithm))

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/EndpointResolverMiddlewareTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/EndpointResolverMiddlewareTests.kt
@@ -84,11 +84,11 @@ public struct EndpointResolverMiddleware<OperationStackOutput>: ClientRuntime.Mi
 
         if let signingRegion = signingRegion {
             context.attributes.set(key: AttributeKeys.signingRegion, value: signingRegion)
-            context.attributes.set(key: AttributeKeys.selectedAuthScheme, value: context.getSelectedAuthScheme()?.getCopyWithUpdatedSigningProperty(key: AttributeKeys.signingRegion, value: signingRegion)
+            context.attributes.set(key: AttributeKeys.selectedAuthScheme, value: context.getSelectedAuthScheme()?.getCopyWithUpdatedSigningProperty(key: AttributeKeys.signingRegion, value: signingRegion))
         }
         if let signingName = signingName {
             context.attributes.set(key: AttributeKeys.signingName, value: signingName)
-            context.attributes.set(key: AttributeKeys.selectedAuthScheme, value: context.getSelectedAuthScheme()?.getCopyWithUpdatedSigningProperty(key: AttributeKeys.signingName, value: signingName)
+            context.attributes.set(key: AttributeKeys.selectedAuthScheme, value: context.getSelectedAuthScheme()?.getCopyWithUpdatedSigningProperty(key: AttributeKeys.signingName, value: signingName))
         }
         if let signingAlgorithm = signingAlgorithm {
             context.attributes.set(key: AttributeKeys.signingAlgorithm, value: AWSSigningAlgorithm(rawValue: signingAlgorithm))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Add codegen for overwriting signing property value for `signingName` and `signingRegion` if auth scheme is resolved from the resolved endpoint and it has custom values for these.
- Update a codegen test

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.