### PR TITLE
chore: Improve two integration tests

### DIFF
--- a/IntegrationTests/Services/AWSCloudFrontKeyValueStoreIntegrationTests/CloudFrontKeyValueStoreSigV4ATests.swift
+++ b/IntegrationTests/Services/AWSCloudFrontKeyValueStoreIntegrationTests/CloudFrontKeyValueStoreSigV4ATests.swift
@@ -55,7 +55,7 @@ class CloudFrontKeyValueStoreSigV4ATests: XCTestCase {
         var status: String? = wipStatus
         repeat {
             status = try await client.describeKeyValueStore(input: DescribeKeyValueStoreInput(name: kvsName)).keyValueStore?.status
-            let seconds = 20.0
+            let seconds = 2.5
             try await Task.sleep(nanoseconds: UInt64(seconds * Double(NSEC_PER_SEC)))
         } while status == wipStatus
 

--- a/IntegrationTests/Services/AWSMediaConvertIntegrationTests/AWSMediaConvertTests.swift
+++ b/IntegrationTests/Services/AWSMediaConvertIntegrationTests/AWSMediaConvertTests.swift
@@ -12,22 +12,7 @@ import AWSMediaConvert
 class AWSMediaConvertTests: XCTestCase {
 
     func test_getJobTemplate_handlesSpecialCharacters() async throws {
-        let region = "us-west-2"
-
-        // MediaConvert requires that you use a provided endpoint for all requests.
-        // Retrieve the endpoint for all subsequent requests.
-        let client0 = try MediaConvertClient(region: region)
-        let input0 = DescribeEndpointsInput()
-        let output0 = try await client0.describeEndpoints(input: input0)
-        guard let endpoint = output0.endpoints?.first?.url else {
-            XCTFail("Unable to retrieve endpoint")
-            return
-        }
-
-        // Create a client, configured to use the endpoint you just retrieved.
-        let config = try await MediaConvertClient.MediaConvertClientConfiguration(region: region, signingRegion: region, endpoint: endpoint)
-        let client = MediaConvertClient(config: config)
-
+        let client = try MediaConvertClient(region: "us-west-2")
         let name = "Android TV Template"
 
         // These job template settings are filled in just enough to form a valid job template for creation.


### PR DESCRIPTION
## Description of changes
- The MediaConvert service no longer requires endpoint discovery; the regional endpoint accepts requests directly.  Code to request a MediaConvert endpoint is removed.
- The time delay while waiting for a CloudFront KVS to provision is reduced from 20 to 2.5 seconds, to avoid unneeded wait during test runs.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.