### PR TITLE
chore: Remove Github environment for integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -13,7 +13,6 @@ permissions:
 jobs:
   apple:
     runs-on: ${{ matrix.runner }}
-    environment: Integration-Test
     env:
       DEVELOPER_DIR: /Applications/${{ matrix.xcode }}.app/Contents/Developer
     strategy:
@@ -90,7 +89,6 @@ jobs:
 
   linux:
     runs-on: ubuntu-latest
-    environment: Integration-Test
     container: swift:${{ matrix.version }}-${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Issue \#
#1409

## Description of changes
Removes the deploy environment when running integration tests.
The environment has no benefit & is unused.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.