### PR TITLE
fix: Change config variables to let to avoid warning

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/plugins/AuthSchemePlugin.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/plugins/AuthSchemePlugin.kt
@@ -42,7 +42,7 @@ class AuthSchemePlugin(private val serviceConfig: ServiceConfig) : Plugin {
                 writer.write("self.awsCredentialIdentityResolver = awsCredentialIdentityResolver")
             }
             writer.openBlock("public func configureClient(clientConfiguration: ClientRuntime.ClientConfiguration) throws {", "}") {
-                writer.openBlock("if var config = clientConfiguration as? ${serviceConfig.typeName} {", "}") {
+                writer.openBlock("if let config = clientConfiguration as? ${serviceConfig.typeName} {", "}") {
                     writer.openBlock("if (self.authSchemes != nil) {", "}") {
                         writer.write("config.authSchemes = self.authSchemes")
                     }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/plugins/DefaultAWSAuthSchemePlugin.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/plugins/DefaultAWSAuthSchemePlugin.kt
@@ -24,7 +24,7 @@ class DefaultAWSAuthSchemePlugin(private val serviceConfig: ServiceConfig) : Plu
             }
 
             writer.openBlock("public func configureClient(clientConfiguration: ClientRuntime.ClientConfiguration) throws {", "}") {
-                writer.openBlock("if var config = clientConfiguration as? ${serviceConfig.typeName} {", "}") {
+                writer.openBlock("if let config = clientConfiguration as? ${serviceConfig.typeName} {", "}") {
                     writer.write("config.authSchemeResolver = \$L", "Default${AuthSchemeResolverGenerator.getSdkId(ctx)}AuthSchemeResolver()")
                     writer.write("config.authSchemes = \$L", getModeledAuthSchemesSupportedBySDK(ctx))
                     writer.write("config.awsCredentialIdentityResolver = try AWSClientConfigDefaultsProvider.awsCredentialIdentityResolver()")

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/plugins/EndpointPlugin.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/plugins/EndpointPlugin.kt
@@ -28,7 +28,7 @@ class EndpointPlugin(private val serviceConfig: ServiceConfig) : Plugin {
                 writer.write("self.init(endpointResolver: try \$L())", AWSServiceTypes.DefaultEndpointResolver)
             }
             writer.openBlock("public func configureClient(clientConfiguration: ClientRuntime.ClientConfiguration) throws {", "}") {
-                writer.openBlock("if var config = clientConfiguration as? ${serviceConfig.typeName} {", "}") {
+                writer.openBlock("if let config = clientConfiguration as? ${serviceConfig.typeName} {", "}") {
                     writer.write("config.endpointResolver = self.endpointResolver")
                 }
             }


### PR DESCRIPTION
## Description of changes
Plugin code references config objects as `var` in several places without modifying the value, resulting in compile warnings.

This PR changes these references to `let` to avoid the warning.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.