### PR TITLE
chore: Add Dockerfiles for Swift 5.10

### DIFF
--- a/Docker/5.10.0/amazonlinux/2/Dockerfile
+++ b/Docker/5.10.0/amazonlinux/2/Dockerfile
@@ -1,0 +1,95 @@
+FROM swift:5.10-amazonlinux2
+
+# Install Open SSL -- dependency of CRT
+RUN yum -y install openssl-devel
+
+## The rest of this file is from https://github.com/aws/aws-codebuild-docker-images/blob/master/al2/x86_64/standard/4.0/Dockerfile
+
+# Install other utilities
+RUN yum install -y -q \
+  wget unzip
+
+## Install Java
+
+#****************      JAVA     ****************************************************
+
+ENV JAVA_17_HOME="/usr/lib/jvm/java-17-amazon-corretto.x86_64" \
+    JDK_17_HOME="/usr/lib/jvm/java-17-amazon-corretto.x86_64" \
+    JRE_17_HOME="/usr/lib/jvm/java-17-amazon-corretto.x86_64" \
+    ANT_VERSION=1.10.12 \
+    MAVEN_HOME="/opt/maven" \
+    MAVEN_VERSION=3.8.7 \
+    INSTALLED_GRADLE_VERSIONS="7.6" \
+    GRADLE_VERSION=7.6 \
+    SBT_VERSION=1.8.2 \
+    GRADLE_PATH="$SRC_DIR/gradle" \
+    ANT_DOWNLOAD_SHA512="2287dc5cfc21043c14e5413f9afb1c87c9f266ec2a9ba2d3bf2285446f6e4ccb59b558bf2e5c57911a05dfa293c7d5c7ad60ac9f744ba11406f4e6f9a27b2403" \
+    MAVEN_DOWNLOAD_SHA512="21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27" \
+    GRADLE_DOWNLOADS_SHA256="312eb12875e1747e05c2f81a4789902d7e4ec5defbd1eefeaccc08acf096505d 7.6" \
+    SBT_DOWNLOAD_SHA256="1f65344da074dbd66dfefa93c0eff8d319d772e5cad47fcbeb6ae178bbdf4686" \
+    LOG4J_UNSAFE_VERSIONS="2.11.1 1.2.8"
+
+ARG MAVEN_CONFIG_HOME="/root/.m2"
+ENV JAVA_HOME="$JAVA_17_HOME" \
+    JDK_HOME="$JDK_17_HOME" \
+    JRE_HOME="$JRE_17_HOME"
+
+RUN set -x \
+    # Install Amazon Corretto 17
+    && rpm --import https://yum.corretto.aws/corretto.key \
+    && curl -L -o /etc/yum.repos.d/corretto.repo https://yum.corretto.aws/corretto.repo \
+    && yum install -y -q java-17-amazon-corretto java-17-amazon-corretto-devel \
+    && update-ca-trust \
+    && for tool_path in $JAVA_HOME/bin/*; do \
+          tool=`basename $tool_path`; \
+          update-alternatives --install /usr/bin/$tool $tool $tool_path 10000; \
+          update-alternatives --set $tool $tool_path; \
+        done \
+    && rm $JAVA_HOME/lib/security/cacerts && ln -s /etc/pki/java/cacerts $JAVA_HOME/lib/security/cacerts \
+    # Install Ant
+    && curl -LSso /var/tmp/apache-ant-$ANT_VERSION-bin.tar.gz https://archive.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz  \
+    && echo "$ANT_DOWNLOAD_SHA512 /var/tmp/apache-ant-$ANT_VERSION-bin.tar.gz" | sha512sum -c - \
+    && tar -xzf /var/tmp/apache-ant-$ANT_VERSION-bin.tar.gz -C /opt \
+    && rm /var/tmp/apache-ant-$ANT_VERSION-bin.tar.gz \
+    && update-alternatives --install /usr/bin/ant ant /opt/apache-ant-$ANT_VERSION/bin/ant 10000
+
+RUN set -ex \
+    # Install Maven
+    && mkdir -p $MAVEN_HOME \
+    && curl -LSso /var/tmp/apache-maven-$MAVEN_VERSION-bin.tar.gz https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz \
+    && echo "$MAVEN_DOWNLOAD_SHA512 /var/tmp/apache-maven-$MAVEN_VERSION-bin.tar.gz" | sha512sum -c - \
+    && tar xzf /var/tmp/apache-maven-$MAVEN_VERSION-bin.tar.gz -C $MAVEN_HOME --strip-components=1 \
+    && rm /var/tmp/apache-maven-$MAVEN_VERSION-bin.tar.gz \
+    && update-alternatives --install /usr/bin/mvn mvn /opt/maven/bin/mvn 10000 \
+    && mkdir -p $MAVEN_CONFIG_HOME \
+    # Install Gradle
+    && mkdir -p $GRADLE_PATH \
+    && for version in $INSTALLED_GRADLE_VERSIONS; do { \
+       wget -q "https://services.gradle.org/distributions/gradle-$version-all.zip" -O "$GRADLE_PATH/gradle-$version-all.zip" \
+       && unzip -q "$GRADLE_PATH/gradle-$version-all.zip" -d /usr/local \
+       && echo -e "$GRADLE_DOWNLOADS_SHA256" | grep "$version" | sed "s|$version|$GRADLE_PATH/gradle-$version-all.zip|" | sha256sum -c - \
+       && rm "$GRADLE_PATH/gradle-$version-all.zip" \
+       && mkdir "/tmp/gradle-$version" \
+       && "/usr/local/gradle-$version/bin/gradle" -p "/tmp/gradle-$version" init \
+       && "/usr/local/gradle-$version/bin/gradle" -p "/tmp/gradle-$version" wrapper \
+       # Android Studio uses the "-all" distribution for it's wrapper script.
+       && perl -pi -e "s/gradle-$version-bin.zip/gradle-$version-all.zip/" "/tmp/gradle-$version/gradle/wrapper/gradle-wrapper.properties" \
+       && "/tmp/gradle-$version/gradlew" -p "/tmp/gradle-$version" init \
+       && rm -rf "/tmp/gradle-$version" \
+       && if [ "$version" != "$GRADLE_VERSION" ]; then rm -rf "/usr/local/gradle-$version"; fi; \
+     }; done \
+    # Install default GRADLE_VERSION to path
+    && ln -s /usr/local/gradle-$GRADLE_VERSION/bin/gradle /usr/bin/gradle \
+    && rm -rf $GRADLE_PATH \
+    # Install SBT
+    && curl -fSL "https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz" -o sbt.tgz \
+    && echo "${SBT_DOWNLOAD_SHA256} *sbt.tgz" | sha256sum -c - \
+    && tar xzf sbt.tgz -C /usr/local/bin/ \
+    && rm sbt.tgz \
+    && for version in $LOG4J_UNSAFE_VERSIONS; do find / -name log4j*-$version.jar | xargs rm -f; done
+
+ENV PATH "/usr/local/bin/sbt/bin:$PATH"
+RUN sbt version -Dsbt.rootdir=true
+# Cleanup
+RUN rm -fr /tmp/* /var/tmp/*
+#****************     END JAVA     ****************************************************

--- a/Docker/5.10.0/ubuntu/22.04/Dockerfile
+++ b/Docker/5.10.0/ubuntu/22.04/Dockerfile
@@ -1,0 +1,106 @@
+FROM swift:5.10-jammy
+
+# Install Open SSL -- dependency of CRT
+RUN apt-get -q update && \
+  apt-get -q install -y libssl-dev
+
+## The rest of this file is from https://github.com/aws/aws-codebuild-docker-images/blob/master/ubuntu/standard/5.0/Dockerfile
+
+# Install other utilities
+RUN apt-get install -y -qq --no-install-recommends \
+  curl unzip wget
+
+## Install Java
+
+#****************      JAVA     ****************************************************
+ENV JAVA_17_HOME="/usr/lib/jvm/java-17-amazon-corretto" \
+    JDK_17_HOME="/usr/lib/jvm/java-17-amazon-corretto" \
+    JRE_17_HOME="/usr/lib/jvm/java-17-amazon-corretto"
+ARG ANT_VERSION=1.10.12
+ARG MAVEN_HOME="/opt/maven"
+ARG MAVEN_VERSION=3.8.7
+ARG INSTALLED_GRADLE_VERSIONS="7.6"
+ARG GRADLE_VERSION=7.6
+ARG SBT_VERSION=1.8.2
+ARG GRADLE_PATH="$SRC_DIR/gradle"
+ARG ANT_DOWNLOAD_SHA512="2287dc5cfc21043c14e5413f9afb1c87c9f266ec2a9ba2d3bf2285446f6e4ccb59b558bf2e5c57911a05dfa293c7d5c7ad60ac9f744ba11406f4e6f9a27b2403"
+ARG MAVEN_DOWNLOAD_SHA512="21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27"
+ARG GRADLE_DOWNLOADS_SHA256="312eb12875e1747e05c2f81a4789902d7e4ec5defbd1eefeaccc08acf096505d 7.6"
+ARG SBT_DOWNLOAD_SHA256="1f65344da074dbd66dfefa93c0eff8d319d772e5cad47fcbeb6ae178bbdf4686"
+ENV LOG4J_UNSAFE_VERSIONS="2.11.1 1.2.8"
+
+ARG MAVEN_CONFIG_HOME="/root/.m2"
+
+ENV JAVA_HOME="$JAVA_17_HOME" \
+    JDK_HOME="$JDK_17_HOME" \
+    JRE_HOME="$JRE_17_HOME"
+
+ENV PATH="${PATH}:/opt/tools"
+
+RUN set -ex \
+    && apt-get update \
+    && apt-get install -y -qq software-properties-common apt-utils \
+    # Install Corretto 17
+    && wget -qO- https://apt.corretto.aws/corretto.key | apt-key add - \
+    && add-apt-repository 'deb https://apt.corretto.aws stable main' \
+    && apt-get update \
+    && apt-get install -y -qq java-17-amazon-corretto-jdk \
+    && apt-get install -y -qq --no-install-recommends ca-certificates-java \
+    # Ensure Java cacerts symlink points to valid location
+    && update-ca-certificates -f \
+    && dpkg --add-architecture i386 \
+    && apt-get update \
+    && for tool_path in $JAVA_HOME/bin/*; do \
+          tool=`basename $tool_path`; \
+          update-alternatives --install /usr/bin/$tool $tool $tool_path 10000; \
+          update-alternatives --set $tool $tool_path; \
+        done \
+     && rm $JAVA_HOME/lib/security/cacerts && ln -s /etc/ssl/certs/java/cacerts $JAVA_HOME/lib/security/cacerts \
+    # Install Ant
+    && curl -LSso /var/tmp/apache-ant-$ANT_VERSION-bin.tar.gz https://archive.apache.org/dist/ant/binaries/apache-ant-$ANT_VERSION-bin.tar.gz  \
+    && echo "$ANT_DOWNLOAD_SHA512 /var/tmp/apache-ant-$ANT_VERSION-bin.tar.gz" | sha512sum -c - \
+    && tar -xzf /var/tmp/apache-ant-$ANT_VERSION-bin.tar.gz -C /opt \
+    && rm /var/tmp/apache-ant-$ANT_VERSION-bin.tar.gz \
+    && update-alternatives --install /usr/bin/ant ant /opt/apache-ant-$ANT_VERSION/bin/ant 10000
+
+RUN set -ex \
+    # Install Maven
+    && mkdir -p $MAVEN_HOME \
+    && curl -LSso /var/tmp/apache-maven-$MAVEN_VERSION-bin.tar.gz https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz \
+    && echo "$MAVEN_DOWNLOAD_SHA512 /var/tmp/apache-maven-$MAVEN_VERSION-bin.tar.gz" | sha512sum -c - \
+    && tar xzf /var/tmp/apache-maven-$MAVEN_VERSION-bin.tar.gz -C $MAVEN_HOME --strip-components=1 \
+    && rm /var/tmp/apache-maven-$MAVEN_VERSION-bin.tar.gz \
+    && update-alternatives --install /usr/bin/mvn mvn /opt/maven/bin/mvn 10000 \
+    && mkdir -p $MAVEN_CONFIG_HOME \
+    # Install Gradle
+    && mkdir -p $GRADLE_PATH \
+    && for version in $INSTALLED_GRADLE_VERSIONS; do { \
+       wget -q "https://services.gradle.org/distributions/gradle-$version-all.zip" -O "$GRADLE_PATH/gradle-$version-all.zip" \
+       && unzip -q "$GRADLE_PATH/gradle-$version-all.zip" -d /usr/local \
+       && echo "$GRADLE_DOWNLOADS_SHA256" | grep "$version" | sed "s|$version|$GRADLE_PATH/gradle-$version-all.zip|" | sha256sum -c - \
+       && rm "$GRADLE_PATH/gradle-$version-all.zip" \
+       && mkdir "/tmp/gradle-$version" \
+       && "/usr/local/gradle-$version/bin/gradle" -p "/tmp/gradle-$version" init \
+       && "/usr/local/gradle-$version/bin/gradle" -p "/tmp/gradle-$version" wrapper \
+       # Android Studio uses the "-all" distribution for it's wrapper script.
+       && perl -pi -e "s/gradle-$version-bin.zip/gradle-$version-all.zip/" "/tmp/gradle-$version/gradle/wrapper/gradle-wrapper.properties" \
+       && "/tmp/gradle-$version/gradlew" -p "/tmp/gradle-$version" init \
+       && rm -rf "/tmp/gradle-$version" \
+       && if [ "$version" != "$GRADLE_VERSION" ]; then rm -rf "/usr/local/gradle-$version"; fi; \
+     }; done \
+    # Install default GRADLE_VERSION to path
+    && ln -s /usr/local/gradle-$GRADLE_VERSION/bin/gradle /usr/bin/gradle \
+    && rm -rf $GRADLE_PATH \
+    # Install SBT
+    && curl -fSL "https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz" -o sbt.tgz \
+    && echo "${SBT_DOWNLOAD_SHA256} *sbt.tgz" | sha256sum -c - \
+    && tar xzf sbt.tgz -C /usr/local/bin/ \
+    && rm sbt.tgz \
+    && for version in $LOG4J_UNSAFE_VERSIONS; do find / -name log4j*-$version.jar | xargs rm -f; done
+
+ENV PATH "/usr/local/bin/sbt/bin:$PATH"
+RUN sbt version -Dsbt.rootdir=true
+# Cleanup
+RUN rm -fr /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && apt-get clean
+#****************     END JAVA     ****************************************************


### PR DESCRIPTION
## Description of changes
Adds Dockerfiles for Amazon Linux 2 & Ubuntu 22.04 LTS for using Swift 5.10 with the automated build system.

These Dockerfiles build without error, but have not yet been tested.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.