### PR TITLE
chore: Use Xcode 15.3 as 'latest' on CI

### DIFF
--- a/.github/workflows/codegen-build-test.yml
+++ b/.github/workflows/codegen-build-test.yml
@@ -13,7 +13,7 @@ jobs:
   codegen-build-test:
     runs-on: macos-14-xlarge
     env:
-      DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_15.3.app/Contents/Developer
     steps:
       - name: Checkout aws-sdk-swift
         uses: actions/checkout@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -31,15 +31,15 @@ jobs:
         exclude:
           # Don't run old macOS with new Xcode
           - runner: macos-13-xlarge
-            xcode: Xcode_15.2
+            xcode: Xcode_15.3
           # Don't run new macOS with old Xcode
           - runner: macos-14-xlarge
             xcode: Xcode_14.1
           # Don't run old simulators with new Xcode
           - destination: 'platform=tvOS Simulator,OS=16.1,name=Apple TV 4K (3rd generation) (at 1080p)'
-            xcode: Xcode_15.2
+            xcode: Xcode_15.3
           - destination: 'platform=iOS Simulator,OS=16.1,name=iPhone 14'
-            xcode: Xcode_15.2
+            xcode: Xcode_15.3
           # Don't run new simulators with old Xcode
           - destination: 'platform=tvOS Simulator,OS=17.4,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_14.1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,12 +21,12 @@ jobs:
           - macos-14-xlarge
         xcode:
           - Xcode_14.1
-          - Xcode_15.2
+          - Xcode_15.3
         destination:
           - 'platform=iOS Simulator,OS=16.1,name=iPhone 14'
-          - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
+          - 'platform=iOS Simulator,OS=17.4,name=iPhone 15'
           - 'platform=tvOS Simulator,OS=16.1,name=Apple TV 4K (3rd generation) (at 1080p)'
-          - 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
+          - 'platform=tvOS Simulator,OS=17.4,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=OS X'
         exclude:
           # Don't run old macOS with new Xcode
@@ -41,9 +41,9 @@ jobs:
           - destination: 'platform=iOS Simulator,OS=16.1,name=iPhone 14'
             xcode: Xcode_15.2
           # Don't run new simulators with old Xcode
-          - destination: 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
+          - destination: 'platform=tvOS Simulator,OS=17.4,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_14.1
-          - destination: 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
+          - destination: 'platform=iOS Simulator,OS=17.4,name=iPhone 15'
             xcode: Xcode_14.1
     steps:
       - name: Checkout aws-sdk-swift
@@ -107,7 +107,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - focal
+          - jammy
           - amazonlinux2
         version:
           - "5.7"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -24,11 +24,11 @@ jobs:
           - macos-14-xlarge
         xcode:
           - Xcode_14.1
-          - Xcode_15.2
+          - Xcode_15.3
         exclude:
           # Don't run old macOS with new Xcode
           - runner: macos-13-xlarge
-            xcode: Xcode_15.2
+            xcode: Xcode_15.3
           # Don't run new macOS with old Xcode
           - runner: macos-14-xlarge
             xcode: Xcode_14.1
@@ -94,7 +94,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - focal
+          - jammy
           #- amazonlinux2
         version:
           - "5.7"

--- a/.github/workflows/release-configuration-build.yml
+++ b/.github/workflows/release-configuration-build.yml
@@ -17,7 +17,7 @@ jobs:
   codegen-build-with-release-configuration:
     runs-on: macos-14-xlarge
     env:
-      DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_15.3.app/Contents/Developer
     steps:
       - name: Checkout aws-sdk-swift
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description of changes
- Use Xcode 15.3 as the "latest" version when performing CI builds.
- Use Ubuntu Jammy instead of Focal for all Ubuntu builds.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.