### PR TITLE
chore: Fix release system bug

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/PrepareRelease.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/PrepareRelease.swift
@@ -81,7 +81,16 @@ struct PrepareRelease {
         try FileManager.default.changeWorkingDirectory(repoPath)
         
         let previousVersion = try getPreviousVersion()
-        guard try repoHasChanges(previousVersion) else { return }
+        guard try repoHasChanges(previousVersion) else {
+            /// If repo has no changes, create an empty release-manifest.json file.
+            /// Empty manifest file makes GitHubReleasePublisher be no-op.
+            /// The manifest file is required regardless of whether there should
+            /// be a release or not.
+            try createEmptyReleaseManifest()
+            /// Return without creating new commit or tag in local repos.
+            /// This makes GitPublisher be no-op.
+            return
+        }
         let newVersion = try createNewVersion(previousVersion)
         
         try stageFiles()
@@ -95,7 +104,16 @@ struct PrepareRelease {
     }
     
     // MARK: - Helpers
-    
+
+    /// Creates an empty release-manifest.json file.
+    func createEmptyReleaseManifest() throws {
+        let savedReleaseManifest = FileManager.default.createFile(atPath: "release-manifest.json", contents: nil)
+
+        guard savedReleaseManifest else {
+            throw Error("Failed to save release manifest to release_manifest.json")
+        }
+    }
+
     /// Returns the version of the previous release.
     /// This version is read from the version defined in the `Package.version` file.
     ///


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-swift/issues/1060

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- If a repo (smithy-swift or aws-sdk-swift) has had no new commit since the last release, the build system does not create the release-manifest.json file which is an expected artifact. And this missing artifact causes the build system to fail.
- Create the expected file even when there's no change detected, but make it empty to make consumers of the file be no-op. Confirmed with build system owners that this will result in no-op by consumers of the file.

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.