### PR TITLE
feat!: Make Expires member in S3 always be a String

### DIFF
--- a/Sources/Services/AWSS3/models/Models.swift
+++ b/Sources/Services/AWSS3/models/Models.swift
@@ -1911,7 +1911,7 @@ extension CopyObjectInput {
             items.add(Header(name: "x-amz-source-expected-bucket-owner", value: Swift.String(expectedSourceBucketOwner)))
         }
         if let expires = value.expires {
-            items.add(Header(name: "Expires", value: Swift.String(TimestampFormatter(format: .httpDate).string(from: expires))))
+            items.add(Header(name: "Expires", value: Swift.String(expires)))
         }
         if let grantFullControl = value.grantFullControl {
             items.add(Header(name: "x-amz-grant-full-control", value: Swift.String(grantFullControl)))
@@ -2076,7 +2076,7 @@ public struct CopyObjectInput {
     /// The account ID of the expected source bucket owner. If the account ID that you provide does not match the actual owner of the source bucket, the request fails with the HTTP status code 403 Forbidden (access denied).
     public var expectedSourceBucketOwner: Swift.String?
     /// The date and time at which the object is no longer cacheable.
-    public var expires: ClientRuntime.Date?
+    public var expires: Swift.String?
     /// Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object.
     ///
     /// * This functionality is not supported for directory buckets.
@@ -2205,7 +2205,7 @@ public struct CopyObjectInput {
         copySourceSSECustomerKeyMD5: Swift.String? = nil,
         expectedBucketOwner: Swift.String? = nil,
         expectedSourceBucketOwner: Swift.String? = nil,
-        expires: ClientRuntime.Date? = nil,
+        expires: Swift.String? = nil,
         grantFullControl: Swift.String? = nil,
         grantRead: Swift.String? = nil,
         grantReadACP: Swift.String? = nil,
@@ -2732,7 +2732,7 @@ extension CreateMultipartUploadInput {
             items.add(Header(name: "x-amz-expected-bucket-owner", value: Swift.String(expectedBucketOwner)))
         }
         if let expires = value.expires {
-            items.add(Header(name: "Expires", value: Swift.String(TimestampFormatter(format: .httpDate).string(from: expires))))
+            items.add(Header(name: "Expires", value: Swift.String(expires)))
         }
         if let grantFullControl = value.grantFullControl {
             items.add(Header(name: "x-amz-grant-full-control", value: Swift.String(grantFullControl)))
@@ -2841,7 +2841,7 @@ public struct CreateMultipartUploadInput {
     /// The account ID of the expected bucket owner. If the account ID that you provide does not match the actual owner of the bucket, the request fails with the HTTP status code 403 Forbidden (access denied).
     public var expectedBucketOwner: Swift.String?
     /// The date and time at which the object is no longer cacheable.
-    public var expires: ClientRuntime.Date?
+    public var expires: Swift.String?
     /// Specify access permissions explicitly to give the grantee READ, READ_ACP, and WRITE_ACP permissions on the object. By default, all objects are private. Only the owner has full access control. When uploading an object, you can use this header to explicitly grant access permissions to specific Amazon Web Services accounts or groups. This header maps to specific permissions that Amazon S3 supports in an ACL. For more information, see [Access Control List (ACL) Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html) in the Amazon S3 User Guide. You specify each grantee as a type=value pair, where the type is one of the following:
     ///
     /// * id – if the value specified is the canonical user ID of an Amazon Web Services account
@@ -3025,7 +3025,7 @@ public struct CreateMultipartUploadInput {
         contentLanguage: Swift.String? = nil,
         contentType: Swift.String? = nil,
         expectedBucketOwner: Swift.String? = nil,
-        expires: ClientRuntime.Date? = nil,
+        expires: Swift.String? = nil,
         grantFullControl: Swift.String? = nil,
         grantRead: Swift.String? = nil,
         grantReadACP: Swift.String? = nil,
@@ -17961,7 +17961,7 @@ extension PutObjectInput {
             items.add(Header(name: "x-amz-expected-bucket-owner", value: Swift.String(expectedBucketOwner)))
         }
         if let expires = value.expires {
-            items.add(Header(name: "Expires", value: Swift.String(TimestampFormatter(format: .httpDate).string(from: expires))))
+            items.add(Header(name: "Expires", value: Swift.String(expires)))
         }
         if let grantFullControl = value.grantFullControl {
             items.add(Header(name: "x-amz-grant-full-control", value: Swift.String(grantFullControl)))
@@ -18218,7 +18218,7 @@ public struct PutObjectInput {
     /// The account ID of the expected bucket owner. If the account ID that you provide does not match the actual owner of the bucket, the request fails with the HTTP status code 403 Forbidden (access denied).
     public var expectedBucketOwner: Swift.String?
     /// The date and time at which the object is no longer cacheable. For more information, see [https://www.rfc-editor.org/rfc/rfc7234#section-5.3](https://www.rfc-editor.org/rfc/rfc7234#section-5.3).
-    public var expires: ClientRuntime.Date?
+    public var expires: Swift.String?
     /// Gives the grantee READ, READ_ACP, and WRITE_ACP permissions on the object.
     ///
     /// * This functionality is not supported for directory buckets.
@@ -18297,7 +18297,7 @@ public struct PutObjectInput {
         contentMD5: Swift.String? = nil,
         contentType: Swift.String? = nil,
         expectedBucketOwner: Swift.String? = nil,
-        expires: ClientRuntime.Date? = nil,
+        expires: Swift.String? = nil,
         grantFullControl: Swift.String? = nil,
         grantRead: Swift.String? = nil,
         grantReadACP: Swift.String? = nil,
@@ -22559,7 +22559,7 @@ extension WriteGetObjectResponseInput {
             items.add(Header(name: "x-amz-fwd-header-x-amz-expiration", value: Swift.String(expiration)))
         }
         if let expires = value.expires {
-            items.add(Header(name: "x-amz-fwd-header-Expires", value: Swift.String(TimestampFormatter(format: .httpDate).string(from: expires))))
+            items.add(Header(name: "x-amz-fwd-header-Expires", value: Swift.String(expires)))
         }
         if let lastModified = value.lastModified {
             items.add(Header(name: "x-amz-fwd-header-Last-Modified", value: Swift.String(TimestampFormatter(format: .httpDate).string(from: lastModified))))
@@ -22683,7 +22683,7 @@ public struct WriteGetObjectResponseInput {
     /// If the object expiration is configured (see PUT Bucket lifecycle), the response includes this header. It includes the expiry-date and rule-id key-value pairs that provide the object expiration information. The value of the rule-id is URL-encoded.
     public var expiration: Swift.String?
     /// The date and time at which the object is no longer cacheable.
-    public var expires: ClientRuntime.Date?
+    public var expires: Swift.String?
     /// The date and time that the object was last modified.
     public var lastModified: ClientRuntime.Date?
     /// A map of metadata to store with the object in S3.
@@ -22775,7 +22775,7 @@ public struct WriteGetObjectResponseInput {
         errorCode: Swift.String? = nil,
         errorMessage: Swift.String? = nil,
         expiration: Swift.String? = nil,
-        expires: ClientRuntime.Date? = nil,
+        expires: Swift.String? = nil,
         lastModified: ClientRuntime.Date? = nil,
         metadata: [Swift.String:Swift.String]? = nil,
         missingMeta: Swift.Int? = nil,

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/s3/S3Expires.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/s3/S3Expires.kt
@@ -18,7 +18,6 @@ class S3Expires : SwiftIntegration {
         // Find all the members named "Expires" in all of the output structures
         // and change their shape from `Timestamp` to `String`
         val updates = model.structureShapes
-            .filter { it.defaultName().endsWith("Output") }
             .flatMap { it.allMembers.values }
             .filter { it.memberName == "Expires" }
             .map {

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/s3/S3Expires.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/s3/S3Expires.kt
@@ -5,7 +5,6 @@ import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.transform.ModelTransformer
 import software.amazon.smithy.swift.codegen.SwiftSettings
 import software.amazon.smithy.swift.codegen.integration.SwiftIntegration
-import software.amazon.smithy.swift.codegen.model.defaultName
 import software.amazon.smithy.swift.codegen.model.expectShape
 
 class S3Expires : SwiftIntegration {
@@ -15,7 +14,7 @@ class S3Expires : SwiftIntegration {
     }
 
     override fun preprocessModel(model: Model, settings: SwiftSettings): Model {
-        // Find all the members named "Expires" in all of the output structures
+        // Find all the members named "Expires" in all of the structures
         // and change their shape from `Timestamp` to `String`
         val updates = model.structureShapes
             .flatMap { it.allMembers.values }

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/S3ExpiresTest.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/S3ExpiresTest.kt
@@ -35,18 +35,18 @@ class S3ExpiresTest {
     }
 
     @Test
-    fun `002 test S3 input members named expires are not changed`() {
+    fun `002 test S3 input members named expires are changed to string type`() {
         val context = setupTests("s3-expires.smithy", "com.amazonaws.s3#S3", "S3")
         val contents = TestUtils.getFileContents(context.manifest, "/Example/models/FooInput.swift")
         contents.shouldSyntacticSanityCheck()
         val expectedContents =
             """
             public struct FooInput {
-                public var expires: ClientRuntime.Date?
+                public var expires: Swift.String?
                 public var payload1: Swift.String?
             
                 public init(
-                    expires: ClientRuntime.Date? = nil,
+                    expires: Swift.String? = nil,
                     payload1: Swift.String? = nil
                 )
                 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->
GH issue: https://github.com/awslabs/aws-sdk-swift/issues/1400
SEP: `--/seps/accepted/shared/s3-expires-shape-customization.md`

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Resulting codegen change in S3 model is included in PR for quick reference.
- Expand pre-existing model preprocessing where `Expires` member shape gets changed from targeting timestamp to string shape if it were nested under output shapes, to change it regardless of where it is.
- This change future-proofs our SDK for this particular SEP. Regardless of whether Smithy team makes the change to the C2J tool to remove the reshaping logic before we GA or not, our SDK's behavior will stay the same (treat Expires as string).

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.