### PR TITLE
chore: Require smithy-swift 0.41.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -232,7 +232,7 @@ func addResolvedTargets() {
 // MARK: - Generated
 
 addDependencies(
-    clientRuntimeVersion: "0.41.0",
+    clientRuntimeVersion: "0.41.1",
     crtVersion: "0.26.0"
 )
 

--- a/packageDependencies.plist
+++ b/packageDependencies.plist
@@ -9,6 +9,6 @@
 	<key>clientRuntimeBranch</key>
 	<string>main</string>
 	<key>clientRuntimeVersion</key>
-	<string>0.41.0</string>
+	<string>0.41.1</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1457
https://github.com/awslabs/aws-sdk-swift/issues/1467

## Description of changes
Require new smithy-swift version `0.41.1`, which includes fixes to the `URLSessionHTTPClient` that were hotfixed onto smithy-swift `0.41.0`.

This PR merges to release candidate branch `jbe/0_36_2_rc`.  After this PR merges, the RC branch will be published as AWS SDK for Swift hotfix version `0.36.2`.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.