### PR TITLE
feat: bump kotlin version to 1.9.24

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@
  */
 
 plugins {
-    kotlin("jvm") version "1.5.31" apply false
+    kotlin("jvm")
     id("org.jetbrains.dokka")
 }
 

--- a/codegen/smithy-aws-swift-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-swift-codegen/build.gradle.kts
@@ -2,6 +2,9 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     kotlin("jvm")
     jacoco
@@ -21,7 +24,7 @@ val junitVersion: String by project
 val jacocoVersion: String by project
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
+    implementation(kotlin("stdlib"))
     api("software.amazon.smithy:smithy-swift-codegen:$smithySwiftVersion")
     api("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
     api("software.amazon.smithy:smithy-aws-iam-traits:$smithyVersion")
@@ -31,6 +34,17 @@ dependencies {
     testImplementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
     implementation("software.amazon.smithy:smithy-rules-engine:$smithyVersion")
     implementation("software.amazon.smithy:smithy-aws-endpoints:$smithyVersion")
+}
+
+tasks.withType<KotlinCompile> {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
+tasks.withType<JavaCompile> {
+    sourceCompatibility = JavaVersion.VERSION_17.toString()
+    targetCompatibility = JavaVersion.VERSION_17.toString()
 }
 
 jacoco {

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHttpBindingProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHttpBindingProtocolGenerator.kt
@@ -76,7 +76,7 @@ abstract class AWSHttpBindingProtocolGenerator : HttpBindingProtocolGenerator() 
         var testCount = 0
 
         ctx.service.getTrait<EndpointTestsTrait>()?.let { testsTrait ->
-            if (testsTrait?.testCases.isEmpty()) {
+            if (testsTrait.testCases?.isEmpty() == true) {
                 return 0
             }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,8 +9,8 @@ smithyGradleVersion=0.6.0
 smithySwiftVersion = 0.1.0
 
 # kotlin
-kotlinVersion=1.5.31
-dokkaVersion=1.5.31
+kotlinVersion=1.9.24
+dokkaVersion=1.9.20
 kotlin.native.ignoreDisabledTargets=true
 
 # testing/utility

--- a/scripts/ci_steps/log_tool_versions.sh
+++ b/scripts/ci_steps/log_tool_versions.sh
@@ -55,6 +55,15 @@ else
 fi
 echo
 
+if command -v kotlin &> /dev/null
+then
+  which kotlin
+  kotlin -version
+else
+  echo "kotlin not installed"
+fi
+echo
+
 if command -v xcbeautify &> /dev/null
 then
   which xcbeautify


### PR DESCRIPTION
## Issue \#

There were a lot of noisy logs from Gradle / Kotlin, e.g.

```log
java.rmi.ServerError: Error occurred in server thread; nested exception is: 
Could not connect to kotlin daemon. Using fallback strategy.
	java.lang.AssertionError: symbolic reference class is not accessible: class sun.nio.ch.FileChannelImpl, from class org.jetbrains.kotlin.com.intellij.util.io.FileChannelUtil (unnamed module @46805db7)
...
```

This PR should fix all of the noise (at least locally).

See related links:

- https://youtrack.jetbrains.com/issue/KT-47152/Incremental-Compilation-with-Kotlin-compile-daemon-and-JDK-17-fails-with-IllegalAccessException
- https://kotlinlang.org/docs/whatsnew18.html#updated-jvm-compilation-target
- https://stackoverflow.com/questions/77607619/android-studio-kotlin-inconsistent-jvm-target-compatibility-detected-for-task

## Description of changes

Corresponding smithy-swift PR: smithy-lang/smithy-swift#717

Bump kotlin version to 1.9.24

Also:

- bump dokka version to 1.9.20
- target JVM 17 output

## New/existing dependencies impact assessment, if applicable

Kotlin and Dokka versions updated to the latest version, and JVM 17 targeted.

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.