### PR TITLE
feat: Require Swift DocC only when env var is set

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     container: swift:5.10-jammy
     env:
+      AWS_SWIFT_SDK_ENABLE_DOCC: 1
       IGNORE: none
     outputs:
       version: ${{ steps.set-version.outputs.version }}

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
@@ -95,6 +95,7 @@ func addCRTDependency(_ version: Version) {
 }
 
 func addDoccDependency() {
+    guard ProcessInfo.processInfo.environment["AWS_SWIFT_SDK_ENABLE_DOCC"] != nil else { return }
     package.dependencies += [
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -95,6 +95,7 @@ func addCRTDependency(_ version: Version) {
 }
 
 func addDoccDependency() {
+    guard ProcessInfo.processInfo.environment["AWS_SWIFT_SDK_ENABLE_DOCC"] != nil else { return }
     package.dependencies += [
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
     ]


### PR DESCRIPTION
## Description of changes
Removes DocC as a SDK dependency unless the env var `AWS_SWIFT_SDK_ENABLE_DOCC` is set, since it is essentially unused unless documentation is actually being generated.  There is generally not a reason to enable it by default for customers.

`AWS_SWIFT_SDK_ENABLE_DOCC` is set for the "generate documentation" job on Github, where DocC is actually used.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.