### PR TITLE
chore: Remove client properties feature

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHTTPProtocolCustomizations.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHTTPProtocolCustomizations.kt
@@ -65,8 +65,7 @@ abstract class AWSHTTPProtocolCustomizations : DefaultHTTPProtocolCustomizations
         serviceConfig: ServiceConfig
     ): HttpProtocolServiceClient {
         writer.addImport(AWSSwiftDependency.AWS_CLIENT_RUNTIME.target, false, "FileBasedConfig")
-        val clientProperties = getClientProperties()
-        return AWSHttpProtocolServiceClient(ctx, writer, clientProperties, serviceConfig)
+        return AWSHttpProtocolServiceClient(ctx, writer, serviceConfig)
     }
 
     override val messageDecoderSymbol: Symbol = AWSClientRuntimeTypes.AWSEventStream.AWSMessageDecoder

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHttpProtocolServiceClient.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHttpProtocolServiceClient.kt
@@ -12,7 +12,6 @@ import software.amazon.smithy.swift.codegen.ClientRuntimeTypes
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.config.ConfigProperty
 import software.amazon.smithy.swift.codegen.config.DefaultProvider
-import software.amazon.smithy.swift.codegen.integration.ClientProperty
 import software.amazon.smithy.swift.codegen.integration.HttpProtocolServiceClient
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.ServiceConfig

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHttpProtocolServiceClient.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHttpProtocolServiceClient.kt
@@ -22,9 +22,8 @@ import software.amazon.smithy.swift.codegen.utils.toUpperCamelCase
 class AWSHttpProtocolServiceClient(
     private val ctx: ProtocolGenerator.GenerationContext,
     private val writer: SwiftWriter,
-    properties: List<ClientProperty>,
     private val serviceConfig: ServiceConfig
-) : HttpProtocolServiceClient(ctx, writer, properties, serviceConfig) {
+) : HttpProtocolServiceClient(ctx, writer, serviceConfig) {
     override fun renderConvenienceInitFunctions(serviceSymbol: Symbol) {
         writer.openBlock("public convenience init(region: Swift.String) throws {", "}") {
             writer.write("let config = try ${serviceConfig.typeName}(region: region)")

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGenerator.kt
@@ -89,7 +89,8 @@ class PresignerGenerator : SwiftIntegration {
                 writer.write("let serviceName = \$S", ctx.settings.sdkId)
                 writer.write("let input = self")
                 if (protocolGeneratorContext.settings.useInterceptors) {
-                    writer.write("""
+                    writer.write(
+                        """
                         let client: (SdkHttpRequest, HttpContext) async throws -> HttpResponse = { (_, _) in
                             throw ClientRuntime.ClientError.unknownError("No HTTP client configured for presigned request")
                         }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGenerator.kt
@@ -89,8 +89,7 @@ class PresignerGenerator : SwiftIntegration {
                 writer.write("let serviceName = \$S", ctx.settings.sdkId)
                 writer.write("let input = self")
                 if (protocolGeneratorContext.settings.useInterceptors) {
-                    writer.write(
-                        """
+                    writer.write("""
                         let client: (SdkHttpRequest, HttpContext) async throws -> HttpResponse = { (_, _) in
                             throw ClientRuntime.ClientError.unknownError("No HTTP client configured for presigned request")
                         }
@@ -98,12 +97,6 @@ class PresignerGenerator : SwiftIntegration {
                     )
                 }
                 val operationStackName = "operation"
-                for (prop in protocolGenerator.customizations.getClientProperties()) {
-                    prop.addImportsAndDependencies(writer)
-                    prop.renderInstantiation(writer)
-                    prop.renderConfiguration(writer)
-                }
-
                 val generator = MiddlewareExecutionGenerator(
                     protocolGeneratorContext,
                     writer,
@@ -117,11 +110,7 @@ class PresignerGenerator : SwiftIntegration {
                 }
 
                 if (protocolGeneratorContext.settings.useInterceptors) {
-                    writer.write(
-                        """
-                        return try await op.presignRequest(input: input)
-                        """.trimIndent()
-                    )
+                    writer.write("return try await op.presignRequest(input: input)")
                 } else {
                     val requestBuilderName = "presignedRequestBuilder"
                     val builtRequestName = "builtRequest"

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/presignable/PresignableUrlIntegration.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/presignable/PresignableUrlIntegration.kt
@@ -126,12 +126,6 @@ class PresignableUrlIntegration(private val presignedOperations: Map<String, Set
                     )
                 }
                 val operationStackName = "operation"
-                for (prop in protocolGenerator.customizations.getClientProperties()) {
-                    prop.addImportsAndDependencies(writer)
-                    prop.renderInstantiation(writer)
-                    prop.renderConfiguration(writer)
-                }
-
                 val generator = MiddlewareExecutionGenerator(
                     protocolGeneratorContext,
                     writer,

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/ec2query/EC2QueryCustomizations.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/ec2query/EC2QueryCustomizations.kt
@@ -12,7 +12,6 @@ import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.protocoltests.traits.HttpRequestTestCase
 import software.amazon.smithy.swift.codegen.SwiftWriter
-import software.amazon.smithy.swift.codegen.integration.ClientProperty
 
 class EC2QueryCustomizations : AWSHTTPProtocolCustomizations() {
 

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/ec2query/EC2QueryCustomizations.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/ec2query/EC2QueryCustomizations.kt
@@ -16,10 +16,6 @@ import software.amazon.smithy.swift.codegen.integration.ClientProperty
 
 class EC2QueryCustomizations : AWSHTTPProtocolCustomizations() {
 
-    override fun getClientProperties(): List<ClientProperty> {
-        return listOf()
-    }
-
     override fun customRenderBodyComparison(test: HttpRequestTestCase): ((SwiftWriter, HttpRequestTestCase, Symbol, Shape, String, String) -> Unit)? {
         return this::renderFormURLBodyComparison
     }


### PR DESCRIPTION
## Description of changes
`ClientProperty` is being removed in https://github.com/smithy-lang/smithy-swift/pull/726.

This PR removes references to `ClientProperty` in AWS-specific types.

Also: some Kotlin code cleanup.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.