### PR TITLE
feat: Add simulator as additional metadata of OS metadata in user agent

### DIFF
--- a/Sources/Core/AWSClientRuntime/UserAgent/AdditionalMetadata.swift
+++ b/Sources/Core/AWSClientRuntime/UserAgent/AdditionalMetadata.swift
@@ -9,12 +9,21 @@ import Foundation
 
 struct AdditionalMetadata {
     let name: String
-    let value: String
+    let value: String?
+
+    init(name: String, value: String? = nil) {
+        self.name = name
+        self.value = value
+    }
 }
 
 extension AdditionalMetadata: CustomStringConvertible {
 
     var description: String {
-        "md/\(name.userAgentTokenNoHash)#\(value.userAgentToken)"
+        if let value {
+            "md/\(name.userAgentTokenNoHash)#\(value.userAgentToken)"
+        } else {
+            "md/\(name.userAgentTokenNoHash)"
+        }
     }
 }

--- a/Sources/Core/AWSClientRuntime/UserAgent/AdditionalMetadata.swift
+++ b/Sources/Core/AWSClientRuntime/UserAgent/AdditionalMetadata.swift
@@ -21,9 +21,9 @@ extension AdditionalMetadata: CustomStringConvertible {
 
     var description: String {
         if let value {
-            "md/\(name.userAgentTokenNoHash)#\(value.userAgentToken)"
+            return "md/\(name.userAgentTokenNoHash)#\(value.userAgentToken)"
         } else {
-            "md/\(name.userAgentTokenNoHash)"
+            return "md/\(name.userAgentTokenNoHash)"
         }
     }
 }

--- a/Sources/Core/AWSClientRuntime/UserAgent/ExecutionEnvMetadata.swift
+++ b/Sources/Core/AWSClientRuntime/UserAgent/ExecutionEnvMetadata.swift
@@ -18,9 +18,6 @@ extension ExecutionEnvMetadata: CustomStringConvertible {
     }
 
     static func detectExecEnv() -> ExecutionEnvMetadata? {
-        #if targetEnvironment(simulator)
-        return ExecutionEnvMetadata(name: "simulator")
-        #endif
         guard let execEnv = ProcessInfo.processInfo.environment["AWS_EXECUTION_ENV"], !execEnv.isEmpty else {
             return nil
         }

--- a/Sources/Core/AWSClientRuntime/UserAgent/ExecutionEnvMetadata.swift
+++ b/Sources/Core/AWSClientRuntime/UserAgent/ExecutionEnvMetadata.swift
@@ -18,6 +18,9 @@ extension ExecutionEnvMetadata: CustomStringConvertible {
     }
 
     static func detectExecEnv() -> ExecutionEnvMetadata? {
+        #if targetEnvironment(simulator)
+        return ExecutionEnvMetadata(name: "simulator")
+        #endif
         guard let execEnv = ProcessInfo.processInfo.environment["AWS_EXECUTION_ENV"], !execEnv.isEmpty else {
             return nil
         }

--- a/Sources/Core/AWSClientRuntime/UserAgent/OSMetadata.swift
+++ b/Sources/Core/AWSClientRuntime/UserAgent/OSMetadata.swift
@@ -11,11 +11,18 @@ struct OSMetadata {
     let family: PlatformOperatingSystem
     let version: String?
     let additionalMetadata: [AdditionalMetadata]
+    #if targetEnvironment(simulator)
+    let simulatorMetadata = [AdditionalMetadata(name: "simulator")]
+    #endif
 
     init(family: PlatformOperatingSystem, version: String? = nil, additionalMetadata: [AdditionalMetadata] = []) {
         self.family = family
         self.version = version
+        #if targetEnvironment(simulator)
+        self.additionalMetadata = additionalMetadata + simulatorMetadata
+        #else
         self.additionalMetadata = additionalMetadata
+        #endif
     }
 }
 

--- a/Tests/Core/AWSClientRuntimeTests/UserAgent/AWSUserAgentMetadataTests.swift
+++ b/Tests/Core/AWSClientRuntimeTests/UserAgent/AWSUserAgentMetadataTests.swift
@@ -17,6 +17,15 @@ class AWSUseragentMetadataTests: XCTestCase {
     let executionEnvMetadata = ExecutionEnvMetadata(name: "e123")
     let frameworkMetadata = [FrameworkMetadata(name: "aws-amplify", version: "2.0.1")]
 
+    #if targetEnvironment(simulator)
+    func testSimulatorMetadata() {
+        let sut = AWSUserAgentMetadata(sdkMetadata: sdkMetadata,
+                                       apiMetadata: apiMetadata,
+                                       osMetadata: osMetadata,
+                                       languageMetadata: languageMetadata)
+        XCTAssertEqual("aws-sdk-swift/0.0.1 ua/2.0 api/meow#1.1 os/ios#13.1 md/simulator lang/swift#5.0", sut.userAgent)
+    }
+    #else
     func testHappyPathMinimum() {
         let sut = AWSUserAgentMetadata(sdkMetadata: sdkMetadata,
                                        apiMetadata: apiMetadata,
@@ -118,4 +127,5 @@ class AWSUseragentMetadataTests: XCTestCase {
         }
         XCTAssertEqual(awsUserAgent.userAgent, expected)
     }
+    #endif
 }

--- a/Tests/Core/AWSClientRuntimeTests/UserAgent/ExecutionEnvMetadataTests.swift
+++ b/Tests/Core/AWSClientRuntimeTests/UserAgent/ExecutionEnvMetadataTests.swift
@@ -11,7 +11,7 @@ import XCTest
 class ExecutionEnvMetadataTests: XCTestCase {
     #if targetEnvironment(simulator)
     func test_simulatorExecEnv() {
-        XCTAssertEqual(ExecutionEnvMetadata.detectExecEnv(), "exec-env/simulator")
+        XCTAssertEqual(ExecutionEnvMetadata.detectExecEnv()?.description, "exec-env/simulator")
     }
     #else
     func test_detectExecEnv_returnsNilWhenExecutionEnvIsUnset() {

--- a/Tests/Core/AWSClientRuntimeTests/UserAgent/ExecutionEnvMetadataTests.swift
+++ b/Tests/Core/AWSClientRuntimeTests/UserAgent/ExecutionEnvMetadataTests.swift
@@ -9,11 +9,6 @@
 import XCTest
 
 class ExecutionEnvMetadataTests: XCTestCase {
-    #if targetEnvironment(simulator)
-    func test_simulatorExecEnv() {
-        XCTAssertEqual(ExecutionEnvMetadata.detectExecEnv()?.description, "exec-env/simulator")
-    }
-    #else
     func test_detectExecEnv_returnsNilWhenExecutionEnvIsUnset() {
         unsetenv("AWS_EXECUTION_ENV")
         XCTAssertNil(ExecutionEnvMetadata.detectExecEnv())
@@ -29,5 +24,4 @@ class ExecutionEnvMetadataTests: XCTestCase {
         let subject = try XCTUnwrap(ExecutionEnvMetadata.detectExecEnv())
         XCTAssertEqual(subject.description, "exec-env/Elastic---Service")
     }
-    #endif
 }

--- a/Tests/Core/AWSClientRuntimeTests/UserAgent/ExecutionEnvMetadataTests.swift
+++ b/Tests/Core/AWSClientRuntimeTests/UserAgent/ExecutionEnvMetadataTests.swift
@@ -9,7 +9,11 @@
 import XCTest
 
 class ExecutionEnvMetadataTests: XCTestCase {
-
+    #if targetEnvironment(simulator)
+    func test_simulatorExecEnv() {
+        XCTAssertEqual(ExecutionEnvMetadata.detectExecEnv(), "exec-env/simulator")
+    }
+    #else
     func test_detectExecEnv_returnsNilWhenExecutionEnvIsUnset() {
         unsetenv("AWS_EXECUTION_ENV")
         XCTAssertNil(ExecutionEnvMetadata.detectExecEnv())
@@ -25,4 +29,5 @@ class ExecutionEnvMetadataTests: XCTestCase {
         let subject = try XCTUnwrap(ExecutionEnvMetadata.detectExecEnv())
         XCTAssertEqual(subject.description, "exec-env/Elastic---Service")
     }
+    #endif
 }

--- a/Tests/Core/AWSClientRuntimeTests/UserAgent/OSMetadataTests.swift
+++ b/Tests/Core/AWSClientRuntimeTests/UserAgent/OSMetadataTests.swift
@@ -10,6 +10,7 @@ import XCTest
 
 class OSMetadataTests: XCTestCase {
 
+    #if !targetEnvironment(simulator)
     func test_description_itIncludesSanitizedFamilyAndVersion() {
         let subject = OSMetadata(family: .iOS, version: "1.2.3🤡")
         XCTAssertEqual(subject.description, "os/ios#1.2.3-")
@@ -35,4 +36,5 @@ class OSMetadataTests: XCTestCase {
         XCTAssertEqual(OSMetadata(family: .visionOS).description, "os/visionos")
         XCTAssertEqual(OSMetadata(family: .unknown).description, "os/other")
     }
+    #endif
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-swift/issues/874

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
Using compiler directive, add "simulator" as additional metadata to OS metadata in user agent header if SDK is being used within simulators.

Also, make the `value` of additional metadata optional to follow the SEP.

The change was tested using a simple iOS application & confirming that user agent header header is changed as expected:
```
User-Agent: aws-sdk-swift/1.0 ua/2.0 api/s3#1.0 os/ios#17.4.0 md/simulator lang/swift#5.10 cfg/retry-mode#legacy
```

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.