### PR TITLE
chore!: Bump Swift minimum version & bump simulators in CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,12 +20,12 @@ jobs:
           - macos-13-xlarge
           - macos-14-xlarge
         xcode:
-          - Xcode_14.1
+          - Xcode_15.1
           - Xcode_15.4
         destination:
-          - 'platform=iOS Simulator,OS=16.1,name=iPhone 14'
+          - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
           - 'platform=iOS Simulator,OS=17.5,name=iPhone 15'
-          - 'platform=tvOS Simulator,OS=16.1,name=Apple TV 4K (3rd generation) (at 1080p)'
+          - 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=tvOS Simulator,OS=17.5,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro'
           - 'platform=visionOS Simulator,OS=1.2,name=Apple Vision Pro'
@@ -36,21 +36,21 @@ jobs:
             xcode: Xcode_15.4
           # Don't run new macOS with old Xcode
           - runner: macos-14-xlarge
-            xcode: Xcode_14.1
+            xcode: Xcode_15.1
           # Don't run old simulators with new Xcode
-          - destination: 'platform=tvOS Simulator,OS=16.1,name=Apple TV 4K (3rd generation) (at 1080p)'
+          - destination: 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_15.4
-          - destination: 'platform=iOS Simulator,OS=16.1,name=iPhone 14'
+          - destination: 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
             xcode: Xcode_15.4
           # Don't run new simulators with old Xcode
           - destination: 'platform=tvOS Simulator,OS=17.5,name=Apple TV 4K (3rd generation) (at 1080p)'
-            xcode: Xcode_14.1
+            xcode: Xcode_15.1
           - destination: 'platform=iOS Simulator,OS=17.5,name=iPhone 15'
-            xcode: Xcode_14.1
+            xcode: Xcode_15.1
           - destination: 'platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro'
-            xcode: Xcode_14.1
+            xcode: Xcode_15.1
           - destination: 'platform=visionOS Simulator,OS=1.2,name=Apple Vision Pro'
-            xcode: Xcode_14.1
+            xcode: Xcode_15.1
     steps:
       - name: Checkout aws-sdk-swift
         uses: actions/checkout@v4
@@ -116,7 +116,7 @@ jobs:
           - jammy
           - amazonlinux2
         version:
-          - "5.7"
+          - "5.9"
           - "5.10"
     steps:
       - name: Checkout aws-sdk-swift

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,7 +20,7 @@ jobs:
           - macos-13-xlarge
           - macos-14-xlarge
         xcode:
-          - Xcode_15.1
+          - Xcode_15.2
           - Xcode_15.4
         destination:
           - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
@@ -36,7 +36,7 @@ jobs:
             xcode: Xcode_15.4
           # Don't run new macOS with old Xcode
           - runner: macos-14-xlarge
-            xcode: Xcode_15.1
+            xcode: Xcode_15.2
           # Don't run old simulators with new Xcode
           - destination: 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_15.4
@@ -44,13 +44,13 @@ jobs:
             xcode: Xcode_15.4
           # Don't run new simulators with old Xcode
           - destination: 'platform=tvOS Simulator,OS=17.5,name=Apple TV 4K (3rd generation) (at 1080p)'
-            xcode: Xcode_15.1
+            xcode: Xcode_15.2
           - destination: 'platform=iOS Simulator,OS=17.5,name=iPhone 15'
-            xcode: Xcode_15.1
+            xcode: Xcode_15.2
           - destination: 'platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro'
-            xcode: Xcode_15.1
+            xcode: Xcode_15.2
           - destination: 'platform=visionOS Simulator,OS=1.2,name=Apple Vision Pro'
-            xcode: Xcode_15.1
+            xcode: Xcode_15.2
     steps:
       - name: Checkout aws-sdk-swift
         uses: actions/checkout@v4

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -23,12 +23,12 @@ jobs:
           - macos-13-xlarge
           - macos-14-xlarge
         xcode:
-          - Xcode_14.1
+          - Xcode_15.1
           - Xcode_15.4
         destination:
-          - 'platform=iOS Simulator,OS=16.1,name=iPhone 14'
+          - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
           - 'platform=iOS Simulator,OS=17.5,name=iPhone 15'
-          - 'platform=tvOS Simulator,OS=16.1,name=Apple TV 4K (3rd generation) (at 1080p)'
+          - 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=tvOS Simulator,OS=17.5,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro'
           - 'platform=visionOS Simulator,OS=1.2,name=Apple Vision Pro'
@@ -39,21 +39,21 @@ jobs:
             xcode: Xcode_15.4
           # Don't run new macOS with old Xcode
           - runner: macos-14-xlarge
-            xcode: Xcode_14.1
+            xcode: Xcode_15.1
           # Don't run old simulators with new Xcode
-          - destination: 'platform=tvOS Simulator,OS=16.1,name=Apple TV 4K (3rd generation) (at 1080p)'
+          - destination: 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_15.4
-          - destination: 'platform=iOS Simulator,OS=16.1,name=iPhone 14'
+          - destination: 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
             xcode: Xcode_15.4
           # Don't run new simulators with old Xcode
           - destination: 'platform=tvOS Simulator,OS=17.5,name=Apple TV 4K (3rd generation) (at 1080p)'
-            xcode: Xcode_14.1
+            xcode: Xcode_15.1
           - destination: 'platform=iOS Simulator,OS=17.5,name=iPhone 15'
-            xcode: Xcode_14.1
+            xcode: Xcode_15.1
           - destination: 'platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro'
-            xcode: Xcode_14.1
+            xcode: Xcode_15.1
           - destination: 'platform=visionOS Simulator,OS=1.2,name=Apple Vision Pro'
-            xcode: Xcode_14.1
+            xcode: Xcode_15.1
     steps:
       - name: Configure AWS Credentials for Integration Tests
         uses: aws-actions/configure-aws-credentials@v4
@@ -135,7 +135,7 @@ jobs:
           - jammy
           - amazonlinux2
         version:
-          - "5.7"
+          - "5.9"
           - "5.10"
     steps:
       - name: Configure AWS Credentials for Integration Tests

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -23,7 +23,7 @@ jobs:
           - macos-13-xlarge
           - macos-14-xlarge
         xcode:
-          - Xcode_15.1
+          - Xcode_15.2
           - Xcode_15.4
         destination:
           - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
@@ -39,7 +39,7 @@ jobs:
             xcode: Xcode_15.4
           # Don't run new macOS with old Xcode
           - runner: macos-14-xlarge
-            xcode: Xcode_15.1
+            xcode: Xcode_15.2
           # Don't run old simulators with new Xcode
           - destination: 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_15.4
@@ -47,13 +47,13 @@ jobs:
             xcode: Xcode_15.4
           # Don't run new simulators with old Xcode
           - destination: 'platform=tvOS Simulator,OS=17.5,name=Apple TV 4K (3rd generation) (at 1080p)'
-            xcode: Xcode_15.1
+            xcode: Xcode_15.2
           - destination: 'platform=iOS Simulator,OS=17.5,name=iPhone 15'
-            xcode: Xcode_15.1
+            xcode: Xcode_15.2
           - destination: 'platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro'
-            xcode: Xcode_15.1
+            xcode: Xcode_15.2
           - destination: 'platform=visionOS Simulator,OS=1.2,name=Apple Vision Pro'
-            xcode: Xcode_15.1
+            xcode: Xcode_15.2
     steps:
       - name: Configure AWS Credentials for Integration Tests
         uses: aws-actions/configure-aws-credentials@v4

--- a/AWSSDKSwiftCLI/Package.swift
+++ b/AWSSDKSwiftCLI/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 
 import PackageDescription
 

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.9
 
 //
 // Copyright Amazon.com Inc. or its affiliates.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This library is licensed under the Apache 2.0 License.
 ## Requirements
 
 The AWS SDK for Swift supports the following:
-- Swift 5.7 or higher
+- Swift 5.9 or higher
 - iOS & iPadOS 13.0 or higher
 - macOS 10.15 or higher
 - Ubuntu Linux 16.04 LTS or higher
@@ -56,7 +56,7 @@ $ swift package init --type executable
 
 2. Edit your new package's `Package.swift` file to read:
 ```
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 
 import PackageDescription
 

--- a/codegen/protocol-test-codegen-local/build.gradle.kts
+++ b/codegen/protocol-test-codegen-local/build.gradle.kts
@@ -62,7 +62,7 @@ fun generateSmithyBuild(tests: List<CodegenTest>): String {
                       "gitRepo": "https://github.com/aws-amplify/smithy-swift.git",
                       "author": "Amazon Web Services",
                       "homepage": "https://docs.amplify.aws/",
-                      "swiftVersion": "5.7.0",
+                      "swiftVersion": "5.9.0",
                       "build": {
                         "rootProject": true
                       },

--- a/codegen/sdk-codegen/build.gradle.kts
+++ b/codegen/sdk-codegen/build.gradle.kts
@@ -113,7 +113,7 @@ fun generateSmithyBuild(services: List<AwsService>): String {
                       "sdkId": "${service.sdkId}",
                       "author": "Amazon Web Services",
                       "gitRepo": "${service.gitRepo}",
-                      "swiftVersion": "5.7.0",
+                      "swiftVersion": "5.9.0",
                       "build": {
                           "rootProject": $buildStandaloneSdk
                       },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-swift/issues/1518

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Bump minimum Swift version from 5.7 to 5.9
- Update simulator versions

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.