### PR TITLE
chore: Enabled swiftlint on modules, added import rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,5 @@
 included:
-  - Sources/Core/AWSClientRuntime
+  - Sources/Core
 
 analyzer_rules:
   - unused_import
@@ -22,6 +22,8 @@ disabled_rules:
 
 opt_in_rules:
   - empty_count
+  - sorted_imports
+  - unused_imports
 
 # configurable rules can be customized from this configuration file
 force_cast: warning

--- a/Sources/Core/AWSClientRuntime/AWSClientConfigDefaultsProvider.swift
+++ b/Sources/Core/AWSClientRuntime/AWSClientConfigDefaultsProvider.swift
@@ -6,9 +6,9 @@
 //
 
 @_spi(FileBasedConfig) import AWSSDKCommon
+@_spi(DefaultAWSCredentialIdentityResolverChain) import AWSSDKIdentity
 import SmithyIdentity
 import SmithyIdentityAPI
-@_spi(DefaultAWSCredentialIdentityResolverChain) import AWSSDKIdentity
 import struct ClientRuntime.DefaultSDKRuntimeConfiguration
 import enum ClientRuntime.DefaultRetryErrorInfoProvider
 import protocol SmithyHTTPAPI.HTTPClient

--- a/Sources/Core/AWSClientRuntime/Endpoints/AWSEndpoint.swift
+++ b/Sources/Core/AWSClientRuntime/Endpoints/AWSEndpoint.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import SmithyHTTPAPI
 import ClientRuntime
+import SmithyHTTPAPI
 
 /**
   A structure used by the service client to determine the endpoint.

--- a/Sources/Core/AWSClientRuntime/Endpoints/ServiceEndpointMetadata+Extension.swift
+++ b/Sources/Core/AWSClientRuntime/Endpoints/ServiceEndpointMetadata+Extension.swift
@@ -6,8 +6,8 @@
 //
 
 import enum Smithy.URIScheme
-import SmithyHTTPAPI
 import ClientRuntime
+import SmithyHTTPAPI
 
 extension ServiceEndpointMetadata {
     func resolve(region: String, defaults: ServiceEndpointMetadata) throws -> AWSEndpoint {

--- a/Sources/Core/AWSClientRuntime/Middlewares/AWSS3ErrorWith200StatusXMLMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Middlewares/AWSS3ErrorWith200StatusXMLMiddleware.swift
@@ -6,8 +6,8 @@
 //
 
 import class Smithy.Context
-import SmithyHTTPAPI
 import ClientRuntime
+import SmithyHTTPAPI
 
 public struct AWSS3ErrorWith200StatusXMLMiddleware<OperationStackInput, OperationStackOutput>: Middleware {
     public let id: String = "AWSS3ErrorWith200StatusXMLMiddleware"

--- a/Sources/Core/AWSClientRuntime/Middlewares/Sha256TreeHashMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Middlewares/Sha256TreeHashMiddleware.swift
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0.
 
 import class Smithy.Context
-import SmithyHTTPAPI
+import AwsCCal
 import AwsCommonRuntimeKit
 import ClientRuntime
-import AwsCCal
+import SmithyHTTPAPI
 import struct Foundation.Data
 
 public struct Sha256TreeHashMiddleware<OperationStackInput, OperationStackOutput>: Middleware {

--- a/Sources/Core/AWSClientRuntime/Middlewares/UserAgentMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Middlewares/UserAgentMiddleware.swift
@@ -6,8 +6,8 @@
 //
 
 import class Smithy.Context
-import SmithyHTTPAPI
 import ClientRuntime
+import SmithyHTTPAPI
 
 public struct UserAgentMiddleware<OperationStackInput, OperationStackOutput>: Middleware {
     public let id: String = "UserAgentHeader"

--- a/Sources/Core/AWSClientRuntime/Middlewares/XAmzTargetMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Middlewares/XAmzTargetMiddleware.swift
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0.
 
 import class Smithy.Context
-import SmithyHTTPAPI
 import ClientRuntime
+import SmithyHTTPAPI
 
 public struct XAmzTargetMiddleware<OperationStackInput, OperationStackOutput>: Middleware {
     public let id: String = "XAmzTargetHeader"

--- a/Sources/Core/AWSClientRuntime/Regions/DefaultRegionResolver.swift
+++ b/Sources/Core/AWSClientRuntime/Regions/DefaultRegionResolver.swift
@@ -6,8 +6,8 @@
 //
 
 import struct Smithy.SwiftLogger
-import ClientRuntime
 @_spi(FileBasedConfig) import AWSSDKCommon
+import ClientRuntime
 
 @_spi(DefaultRegionResolver)
 public struct DefaultRegionResolver: RegionResolver {

--- a/Sources/Core/AWSSDKEventStreamsAuth/AWSSigV4Signer+EventStreams.swift
+++ b/Sources/Core/AWSSDKEventStreamsAuth/AWSSigV4Signer+EventStreams.swift
@@ -5,11 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import AWSSDKHTTPAuth
 import Smithy
-import SmithyHTTPAuthAPI
 import SmithyEventStreamsAPI
 import SmithyEventStreamsAuthAPI
-import AWSSDKHTTPAuth
+import SmithyHTTPAuthAPI
 import struct Foundation.Data
 import AwsCommonRuntimeKit
 import SmithyHTTPAuth
@@ -51,6 +51,5 @@ extension AWSSigV4Signer: MessageDataSigner {
 
         return SigningResult(output: message, signature: signature)
     }
-
 
 }

--- a/Sources/Core/AWSSDKEventStreamsAuth/Context+AWSEventStreamsAuth.swift
+++ b/Sources/Core/AWSSDKEventStreamsAuth/Context+AWSEventStreamsAuth.swift
@@ -6,10 +6,10 @@
 //
 
 import Smithy
-import SmithyHTTPAPI
-import SmithyEventStreamsAPI
 import SmithyEventStreams
+import SmithyEventStreamsAPI
 import SmithyEventStreamsAuthAPI
+import SmithyHTTPAPI
 
 /// Setups context with encoder, decoder and signer for bidirectional streaming
 /// and sets the bidirectional streaming flag

--- a/Sources/Core/AWSSDKEventStreamsAuth/Context+Signing.swift
+++ b/Sources/Core/AWSSDKEventStreamsAuth/Context+Signing.swift
@@ -5,14 +5,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import AWSSDKHTTPAuth
+import ClientRuntime
 import Smithy
-import SmithyIdentity
-import SmithyIdentityAPI
+import SmithyEventStreamsAPI
 import SmithyHTTPAPI
 import SmithyHTTPAuthAPI
-import SmithyEventStreamsAPI
-import ClientRuntime
-import AWSSDKHTTPAuth
+import SmithyIdentity
+import SmithyIdentityAPI
 import struct Foundation.Date
 import struct Foundation.TimeInterval
 import SmithyHTTPAuth

--- a/Sources/Core/AWSSDKHTTPAuth/AWSSigV4Signer.swift
+++ b/Sources/Core/AWSSDKHTTPAuth/AWSSigV4Signer.swift
@@ -119,7 +119,8 @@ public class AWSSigV4Signer: SmithyHTTPAuthAPI.Signer {
         }
 
         let expiration: TimeInterval = signingProperties.get(key: SigningPropertyKeys.expiration) ?? 0
-        let signedBodyHeader: AWSSignedBodyHeader = signingProperties.get(key: SigningPropertyKeys.signedBodyHeader) ?? .none
+        let signedBodyHeader: AWSSignedBodyHeader =
+            signingProperties.get(key: SigningPropertyKeys.signedBodyHeader) ?? .none
 
         // Determine signed body value
         let checksumIsPresent = signingProperties.get(key: SigningPropertyKeys.checksum) != nil
@@ -136,7 +137,8 @@ public class AWSSigV4Signer: SmithyHTTPAuthAPI.Signer {
             shouldNormalizeURIPath: signingProperties.get(key: SigningPropertyKeys.shouldNormalizeURIPath) ?? true,
             omitSessionToken: signingProperties.get(key: SigningPropertyKeys.omitSessionToken) ?? false
         )
-        let signatureType: AWSSignatureType = signingProperties.get(key: SigningPropertyKeys.signatureType) ?? .requestHeaders
+        let signatureType: AWSSignatureType =
+            signingProperties.get(key: SigningPropertyKeys.signatureType) ?? .requestHeaders
 
         return AWSSigningConfig(
             credentials: identity,

--- a/Sources/Core/AWSSDKHTTPAuth/CustomSigningPropertiesSetter.swift
+++ b/Sources/Core/AWSSDKHTTPAuth/CustomSigningPropertiesSetter.swift
@@ -24,7 +24,7 @@ public class CustomSigningPropertiesSetter {
     ]
 
     public init() {}
-    
+
     public func setServiceSpecificSigningProperties(
         signingProperties: inout Attributes,
         context: Context
@@ -42,7 +42,8 @@ public class CustomSigningPropertiesSetter {
             serviceName: serviceName,
             opName: operationName
         )
-        let unsignedBody = (signingProperties.get(key: SigningPropertyKeys.unsignedBody) ?? false) || shouldForceUnsignedBody
+        let unsignedBody =
+            (signingProperties.get(key: SigningPropertyKeys.unsignedBody) ?? false) || shouldForceUnsignedBody
         signingProperties.set(key: SigningPropertyKeys.unsignedBody, value: unsignedBody)
 
         // Set signedBodyHeader flag

--- a/Sources/Core/AWSSDKHTTPAuth/SigV4AAuthScheme.swift
+++ b/Sources/Core/AWSSDKHTTPAuth/SigV4AAuthScheme.swift
@@ -17,7 +17,7 @@ public struct SigV4AAuthScheme: AuthScheme {
     public let signer: Signer = AWSSigV4Signer()
 
     public init() {}
-    
+
     public func customizeSigningProperties(signingProperties: Attributes, context: Context) throws -> Attributes {
         var updatedSigningProperties = signingProperties
 


### PR DESCRIPTION
## Description of changes
- Swiftlint was not running on any of the new AWS modules.  This is fixed, along with a few lint violations in those files
- New rules are added for sorted & unused imports (duplicate imports is enabled by default.)

Note that Swiftlint will fix the new import rules automatically by running `swiftlint --fix`.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.