### PR TITLE
fix: Correct query items in presigned URLs, add integration tests

### DIFF
--- a/IntegrationTests/Services/AWSS3IntegrationTests/S3PresignedURLTests.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/S3PresignedURLTests.swift
@@ -5,6 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import XCTest
 import AWSS3
 

--- a/IntegrationTests/Services/AWSS3IntegrationTests/S3PresignedURLTests.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/S3PresignedURLTests.swift
@@ -1,0 +1,33 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import XCTest
+import AWSS3
+
+class S3PresignedURLTests: S3XCTestCase {
+
+    func test_getObject_getsObjectWithPresignedURL() async throws {
+        let originalData = UUID().uuidString
+        let key = UUID().uuidString
+        try await putObject(body: originalData, key: key)
+        let input = GetObjectInput(bucket: bucketName, key: key)
+        let url = try await client.presignedURLForGetObject(input: input, expiration: 600.0)
+        let data = try await perform(urlRequest: URLRequest(url: url))
+        XCTAssertEqual(Data(originalData.utf8), data)
+    }
+
+    func test_getObject_urlEncodesInputMembers() async throws {
+        let key = UUID().uuidString
+        let originalIfMatch = UUID().uuidString
+        let originalIfNoneMatch = UUID().uuidString
+        let input = GetObjectInput(bucket: bucketName, ifMatch: originalIfMatch, ifNoneMatch: originalIfNoneMatch, key: key)
+        let url = try await client.presignedURLForGetObject(input: input, expiration: 600.0)
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        XCTAssertNotNil(components?.queryItems?.first(where: { $0.name == "IfMatch" && $0.value == originalIfMatch }))
+        XCTAssertNotNil(components?.queryItems?.first(where: { $0.name == "IfNoneMatch" && $0.value == originalIfNoneMatch }))
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -346,7 +346,7 @@ addDependencies(
 )
 
 // Uncomment this line to exclude runtime unit tests
-excludeRuntimeUnitTests()
+// excludeRuntimeUnitTests()
 
 let serviceTargets: [String] = [
     "AWSACM",
@@ -734,7 +734,7 @@ let serviceTargets: [String] = [
 ]
 
 // Uncomment this line to enable all services
-// addAllServices()
+addAllServices()
 
 let servicesWithIntegrationTests: [String] = [
     "AWSCloudFrontKeyValueStore",
@@ -751,7 +751,7 @@ let servicesWithIntegrationTests: [String] = [
 ]
 
 // Uncomment this line to enable integration tests
-addIntegrationTests()
+// addIntegrationTests()
 
 // Uncomment this line to enable protocol tests
 // addProtocolTests()

--- a/Package.swift
+++ b/Package.swift
@@ -346,7 +346,7 @@ addDependencies(
 )
 
 // Uncomment this line to exclude runtime unit tests
-// excludeRuntimeUnitTests()
+excludeRuntimeUnitTests()
 
 let serviceTargets: [String] = [
     "AWSACM",
@@ -734,7 +734,7 @@ let serviceTargets: [String] = [
 ]
 
 // Uncomment this line to enable all services
-addAllServices()
+// addAllServices()
 
 let servicesWithIntegrationTests: [String] = [
     "AWSCloudFrontKeyValueStore",
@@ -751,7 +751,7 @@ let servicesWithIntegrationTests: [String] = [
 ]
 
 // Uncomment this line to enable integration tests
-// addIntegrationTests()
+addIntegrationTests()
 
 // Uncomment this line to enable protocol tests
 // addProtocolTests()

--- a/Sources/Services/AWSPolly/Sources/AWSPolly/Models.swift
+++ b/Sources/Services/AWSPolly/Sources/AWSPolly/Models.swift
@@ -2602,43 +2602,43 @@ extension SynthesizeSpeechInputGETQueryItemMiddleware: Smithy.RequestMessageSeri
 
     public func apply(input: InputType, builder: SmithyHTTPAPI.SdkHttpRequestBuilder, attributes: Smithy.Context) throws {
         if let engine = input.engine {
-            let queryItem = Smithy.URIQueryItem(name: "engine.rawValue".urlPercentEncoding(), value: "Engine".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "Engine".urlPercentEncoding(), value: Swift.String(engine.rawValue).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
         if let languageCode = input.languageCode {
-            let queryItem = Smithy.URIQueryItem(name: "languageCode.rawValue".urlPercentEncoding(), value: "LanguageCode".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "LanguageCode".urlPercentEncoding(), value: Swift.String(languageCode.rawValue).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
         if let lexiconNames = input.lexiconNames {
             lexiconNames.forEach { item in
-                let queryItem = Smithy.URIQueryItem(name: "item".urlPercentEncoding(), value: "LexiconNames".urlPercentEncoding())
+                let queryItem = Smithy.URIQueryItem(name: "LexiconNames".urlPercentEncoding(), value: Swift.String(item).urlPercentEncoding())
                 builder.withQueryItem(queryItem)
             }
         }
         if let outputFormat = input.outputFormat {
-            let queryItem = Smithy.URIQueryItem(name: "outputFormat.rawValue".urlPercentEncoding(), value: "OutputFormat".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "OutputFormat".urlPercentEncoding(), value: Swift.String(outputFormat.rawValue).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
         if let sampleRate = input.sampleRate {
-            let queryItem = Smithy.URIQueryItem(name: "sampleRate".urlPercentEncoding(), value: "SampleRate".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "SampleRate".urlPercentEncoding(), value: Swift.String(sampleRate).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
         if let speechMarkTypes = input.speechMarkTypes {
             speechMarkTypes.forEach { item in
-                let queryItem = Smithy.URIQueryItem(name: "item.rawValue".urlPercentEncoding(), value: "SpeechMarkTypes".urlPercentEncoding())
+                let queryItem = Smithy.URIQueryItem(name: "SpeechMarkTypes".urlPercentEncoding(), value: Swift.String(item.rawValue).urlPercentEncoding())
                 builder.withQueryItem(queryItem)
             }
         }
         if let text = input.text {
-            let queryItem = Smithy.URIQueryItem(name: "text".urlPercentEncoding(), value: "Text".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "Text".urlPercentEncoding(), value: Swift.String(text).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
         if let textType = input.textType {
-            let queryItem = Smithy.URIQueryItem(name: "textType.rawValue".urlPercentEncoding(), value: "TextType".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "TextType".urlPercentEncoding(), value: Swift.String(textType.rawValue).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
         if let voiceId = input.voiceId {
-            let queryItem = Smithy.URIQueryItem(name: "voiceId.rawValue".urlPercentEncoding(), value: "VoiceId".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "VoiceId".urlPercentEncoding(), value: Swift.String(voiceId.rawValue).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
     }

--- a/Sources/Services/AWSS3/Sources/AWSS3/Models.swift
+++ b/Sources/Services/AWSS3/Sources/AWSS3/Models.swift
@@ -21649,71 +21649,71 @@ extension GetObjectInputGETQueryItemMiddleware: Smithy.RequestMessageSerializer 
 
     public func apply(input: InputType, builder: SmithyHTTPAPI.SdkHttpRequestBuilder, attributes: Smithy.Context) throws {
         if let bucket = input.bucket {
-            let queryItem = Smithy.URIQueryItem(name: "bucket".urlPercentEncoding(), value: "Bucket".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "Bucket".urlPercentEncoding(), value: Swift.String(bucket).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
         if let ifMatch = input.ifMatch {
-            let queryItem = Smithy.URIQueryItem(name: "ifMatch".urlPercentEncoding(), value: "IfMatch".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "IfMatch".urlPercentEncoding(), value: Swift.String(ifMatch).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
         if let ifNoneMatch = input.ifNoneMatch {
-            let queryItem = Smithy.URIQueryItem(name: "ifNoneMatch".urlPercentEncoding(), value: "IfNoneMatch".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "IfNoneMatch".urlPercentEncoding(), value: Swift.String(ifNoneMatch).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
         if let key = input.key {
-            let queryItem = Smithy.URIQueryItem(name: "key".urlPercentEncoding(), value: "Key".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "Key".urlPercentEncoding(), value: Swift.String(key).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
         if let range = input.range {
-            let queryItem = Smithy.URIQueryItem(name: "range".urlPercentEncoding(), value: "Range".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "Range".urlPercentEncoding(), value: Swift.String(range).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
         if let responseCacheControl = input.responseCacheControl {
-            let queryItem = Smithy.URIQueryItem(name: "responseCacheControl".urlPercentEncoding(), value: "ResponseCacheControl".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "ResponseCacheControl".urlPercentEncoding(), value: Swift.String(responseCacheControl).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
         if let responseContentDisposition = input.responseContentDisposition {
-            let queryItem = Smithy.URIQueryItem(name: "responseContentDisposition".urlPercentEncoding(), value: "ResponseContentDisposition".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "ResponseContentDisposition".urlPercentEncoding(), value: Swift.String(responseContentDisposition).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
         if let responseContentEncoding = input.responseContentEncoding {
-            let queryItem = Smithy.URIQueryItem(name: "responseContentEncoding".urlPercentEncoding(), value: "ResponseContentEncoding".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "ResponseContentEncoding".urlPercentEncoding(), value: Swift.String(responseContentEncoding).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
         if let responseContentLanguage = input.responseContentLanguage {
-            let queryItem = Smithy.URIQueryItem(name: "responseContentLanguage".urlPercentEncoding(), value: "ResponseContentLanguage".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "ResponseContentLanguage".urlPercentEncoding(), value: Swift.String(responseContentLanguage).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
         if let responseContentType = input.responseContentType {
-            let queryItem = Smithy.URIQueryItem(name: "responseContentType".urlPercentEncoding(), value: "ResponseContentType".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "ResponseContentType".urlPercentEncoding(), value: Swift.String(responseContentType).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
         if let versionId = input.versionId {
-            let queryItem = Smithy.URIQueryItem(name: "versionId".urlPercentEncoding(), value: "VersionId".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "VersionId".urlPercentEncoding(), value: Swift.String(versionId).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
         if let sseCustomerAlgorithm = input.sseCustomerAlgorithm {
-            let queryItem = Smithy.URIQueryItem(name: "sseCustomerAlgorithm".urlPercentEncoding(), value: "SSECustomerAlgorithm".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "SSECustomerAlgorithm".urlPercentEncoding(), value: Swift.String(sseCustomerAlgorithm).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
         if let sseCustomerKey = input.sseCustomerKey {
-            let queryItem = Smithy.URIQueryItem(name: "sseCustomerKey".urlPercentEncoding(), value: "SSECustomerKey".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "SSECustomerKey".urlPercentEncoding(), value: Swift.String(sseCustomerKey).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
         if let sseCustomerKeyMD5 = input.sseCustomerKeyMD5 {
-            let queryItem = Smithy.URIQueryItem(name: "sseCustomerKeyMD5".urlPercentEncoding(), value: "SSECustomerKeyMD5".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "SSECustomerKeyMD5".urlPercentEncoding(), value: Swift.String(sseCustomerKeyMD5).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
         if let requestPayer = input.requestPayer {
-            let queryItem = Smithy.URIQueryItem(name: "requestPayer.rawValue".urlPercentEncoding(), value: "RequestPayer".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "RequestPayer".urlPercentEncoding(), value: Swift.String(requestPayer.rawValue).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
         if let expectedBucketOwner = input.expectedBucketOwner {
-            let queryItem = Smithy.URIQueryItem(name: "expectedBucketOwner".urlPercentEncoding(), value: "ExpectedBucketOwner".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "ExpectedBucketOwner".urlPercentEncoding(), value: Swift.String(expectedBucketOwner).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
         if let checksumMode = input.checksumMode {
-            let queryItem = Smithy.URIQueryItem(name: "checksumMode.rawValue".urlPercentEncoding(), value: "ChecksumMode".urlPercentEncoding())
+            let queryItem = Smithy.URIQueryItem(name: "ChecksumMode".urlPercentEncoding(), value: Swift.String(checksumMode.rawValue).urlPercentEncoding())
             builder.withQueryItem(queryItem)
         }
     }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/InputTypeGETQueryItemMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/InputTypeGETQueryItemMiddleware.kt
@@ -13,6 +13,7 @@ import software.amazon.smithy.swift.codegen.integration.steps.OperationSerialize
 import software.amazon.smithy.swift.codegen.model.isEnum
 import software.amazon.smithy.swift.codegen.swiftmodules.SmithyHTTPAPITypes
 import software.amazon.smithy.swift.codegen.swiftmodules.SmithyTypes
+import software.amazon.smithy.swift.codegen.swiftmodules.SwiftTypes
 
 class InputTypeGETQueryItemMiddleware(
     private val ctx: ProtocolGenerator.GenerationContext,
@@ -83,10 +84,11 @@ class InputTypeGETQueryItemMiddleware(
 
     private fun writeRenderItem(queryKey: String, queryValue: String) {
         writer.write(
-            "let queryItem = \$N(name: \$S.urlPercentEncoding(), value: \$S.urlPercentEncoding())",
+            "let queryItem = \$N(name: \$S.urlPercentEncoding(), value: \$N(\$L).urlPercentEncoding())",
             SmithyTypes.URIQueryItem,
-            queryValue,
             queryKey,
+            SwiftTypes.String,
+            queryValue,
         )
         writer.write("builder.withQueryItem(queryItem)")
     }


### PR DESCRIPTION
## Issue \#
#1222

## Description of changes
In completing #1566, it appears that query items in presigned URLs are rendered incorrectly.
This PR corrects the rendering, regenerates the affected operations, and adds presigned URL integration tests to test for future regression.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.