### PR TITLE
chore: Remove the AWS Backup Storage service from next release

### DIFF
--- a/sdk.properties
+++ b/sdk.properties
@@ -1,4 +1,4 @@
-excludeModels=alexa-for-business.2017-11-09,honeycode.2020-03-01
+excludeModels=alexa-for-business.2017-11-09,honeycode.2020-03-01,backupstorage.2018-04-10
 
 # One service from each AWS protocol:
 # - S3 is RestXML


### PR DESCRIPTION
## Issue \#
#1574

## Description of changes
Removes the AWS Backup Service client from the next release, by excluding its id in `sdk.properties`.

It appears that the service has already been removed from aws-models but this will ensure that it is not built even if present.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.