### PR TITLE
fix: Don't git add Tests/Services folder since it no longer exists

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/PrepareRelease.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/PrepareRelease.swift
@@ -164,7 +164,6 @@ struct PrepareRelease {
                 "Package.version",
                 "packageDependencies.plist",
                 "Sources/Services",
-                "Tests/Services",
                 "Sources/Core/AWSSDKForSwift/Documentation.docc/AWSSDKForSwift.md"
             ]
         case .smithySwift:

--- a/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Commands/PrepareReleaseTests.swift
+++ b/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Commands/PrepareReleaseTests.swift
@@ -104,7 +104,7 @@ class PrepareReleaseTests: CLITestCase {
         ProcessRunner.testRunner = runner
         let subject = PrepareRelease.mock(repoType: .awsSdkSwift)
         try! subject.stageFiles()
-        XCTAssertTrue(command.hasSuffix("git add Package.swift Package.version packageDependencies.plist Sources/Services Tests/Services Sources/Core/AWSSDKForSwift/Documentation.docc/AWSSDKForSwift.md"))
+        XCTAssertTrue(command.hasSuffix("git add Package.swift Package.version packageDependencies.plist Sources/Services Sources/Core/AWSSDKForSwift/Documentation.docc/AWSSDKForSwift.md"))
     }
     
     func testStageFilesForSmithySwift() {


### PR DESCRIPTION
## Description of changes
When preparing a release with SDK CLI tools, don't add the folder `Tests/Services` to Git staged files since it no longer exists.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.