### PR TITLE
feat!: Standalone protocol test package

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Prepare Protocol & Unit Tests
         run: |
           ./scripts/ci_steps/prepare_protocol_and_unit_tests.sh
-      - name: Build and Run Protocol & Unit Tests
+      - name: Build and Run Unit Tests
         run: |
           set -o pipefail && \
           NSUnbufferedIO=YES xcodebuild \
@@ -105,6 +105,16 @@ jobs:
             -destination '${{ matrix.destination }}' \
             test 2>&1 \
             | xcbeautify
+      - name: Build and Run Protocol Tests
+        run: |
+          cd codegen/
+          set -o pipefail && \
+          NSUnbufferedIO=YES xcodebuild \
+            -scheme aws-sdk-swift-protocol-tests-Package \
+            -destination '${{ matrix.destination }}' \
+            test 2>&1 \
+            | xcbeautify
+          cd ..
 
   linux:
     runs-on: ubuntu-latest
@@ -166,5 +176,10 @@ jobs:
       - name: Prepare Protocol & Unit Tests
         run: |
           ./scripts/ci_steps/prepare_protocol_and_unit_tests.sh
-      - name: Build and Run Protocol & Unit Tests on Linux
+      - name: Build and Run Unit Tests on Linux
         run: swift test
+      - name: Build and Run Protocol Tests on Linux
+        run: |
+          cd codegen/
+          swift test
+          cd ..

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/GeneratePackageManifest.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/GeneratePackageManifest.swift
@@ -35,9 +35,6 @@ struct GeneratePackageManifestCommand: ParsableCommand {
     @Flag(help: "If the package manifest should include the integration tests.")
     var includeIntegrationTests: Bool = false
     
-    @Flag(help: "If the package manifest should include the protocol tests.")
-    var includeProtocolTests: Bool = false
-
     @Flag(help: "If the package manifest should exclude AWS services.")
     var excludeAWSServices = false
 
@@ -52,7 +49,6 @@ struct GeneratePackageManifestCommand: ParsableCommand {
             crtVersion: crtVersion,
             services: services.isEmpty ? nil : services,
             includeIntegrationTests: includeIntegrationTests,
-            includeProtocolTests: includeProtocolTests,
             excludeAWSServices: excludeAWSServices,
             excludeRuntimeTests: excludeRuntimeTests
         )
@@ -79,8 +75,6 @@ struct GeneratePackageManifest {
     let services: [String]?
     /// If the package manifest should include the integration tests.
     let includeIntegrationTests: Bool
-    /// If the package manifest should include the protocol tests.
-    let includeProtocolTests: Bool
     /// If the package manifest should exclude the AWS services.
     let excludeAWSServices: Bool
     /// If the package manifest should exclude runtime unit tests.
@@ -238,7 +232,6 @@ extension GeneratePackageManifest {
         crtVersion: Version? = nil,
         services: [String]? = nil,
         includeIntegrationTests: Bool = false,
-        includeProtocolTests: Bool = false,
         excludeAWSServices: Bool = false,
         excludeRuntimeTests: Bool = false
     ) -> Self {
@@ -249,7 +242,6 @@ extension GeneratePackageManifest {
             crtVersion: crtVersion,
             services: services,
             includeIntegrationTests: includeIntegrationTests,
-            includeProtocolTests: includeProtocolTests,
             excludeAWSServices: excludeAWSServices,
             excludeRuntimeTests: excludeRuntimeTests
         ) { _clientRuntimeVersion, _crtVersion, _services in
@@ -257,7 +249,6 @@ extension GeneratePackageManifest {
                 clientRuntimeVersion: _clientRuntimeVersion,
                 crtVersion: _crtVersion,
                 services: _services,
-                includeProtocolTests: includeProtocolTests,
                 includeIntegrationTests: includeIntegrationTests,
                 excludeAWSServices: excludeAWSServices,
                 excludeRuntimeTests: excludeRuntimeTests

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Models/PackageManifestBuilder.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Models/PackageManifestBuilder.swift
@@ -18,7 +18,6 @@ struct PackageManifestBuilder {
     let clientRuntimeVersion: Version
     let crtVersion: Version
     let services: [Service]
-    let includeProtocolTests: Bool
     let includeIntegrationTests: Bool
     let excludeAWSServices: Bool
     let excludeRuntimeTests: Bool
@@ -28,7 +27,6 @@ struct PackageManifestBuilder {
         clientRuntimeVersion: Version,
         crtVersion: Version,
         services: [Service],
-        includeProtocolTests: Bool,
         includeIntegrationTests: Bool,
         excludeAWSServices: Bool,
         excludeRuntimeTests: Bool,
@@ -37,7 +35,6 @@ struct PackageManifestBuilder {
         self.clientRuntimeVersion = clientRuntimeVersion
         self.crtVersion = crtVersion
         self.services = services
-        self.includeProtocolTests = includeProtocolTests
         self.includeIntegrationTests = includeIntegrationTests
         self.excludeAWSServices = excludeAWSServices
         self.basePackageContents = basePackageContents
@@ -48,12 +45,11 @@ struct PackageManifestBuilder {
         clientRuntimeVersion: Version,
         crtVersion: Version,
         services: [Service],
-        includeProtocolTests: Bool,
         includeIntegrationTests: Bool,
         excludeAWSServices: Bool,
         excludeRuntimeTests: Bool
     ) {
-        self.init(clientRuntimeVersion: clientRuntimeVersion, crtVersion: crtVersion, services: services, includeProtocolTests: includeProtocolTests, includeIntegrationTests: includeIntegrationTests, excludeAWSServices: excludeAWSServices, excludeRuntimeTests: excludeRuntimeTests) {
+        self.init(clientRuntimeVersion: clientRuntimeVersion, crtVersion: crtVersion, services: services, includeIntegrationTests: includeIntegrationTests, excludeAWSServices: excludeAWSServices, excludeRuntimeTests: excludeRuntimeTests) {
             // Returns the contents of the base package manifest stored in the bundle at `Resources/Package.Base.swift`
             let basePackageName = "Package.Base"
             
@@ -103,8 +99,6 @@ struct PackageManifestBuilder {
             "",
             // Add the generated content that defines the list of services with integration tests to include
             buildIntegrationTestsTargets(),
-            "",
-            buildProtocolTests(),
             "",
             buildResolvedServices(),
             "\n"
@@ -165,14 +159,6 @@ struct PackageManifestBuilder {
         lines += ["\(includeIntegrationTests ? "" : "// ")addIntegrationTests()"]
 
         return lines.joined(separator: .newline)
-    }
-
-    /// Calls the method to include protocol tests in the manifest.
-    private func buildProtocolTests() -> String {
-        return [
-            "// Uncomment this line to enable protocol tests",
-            (includeProtocolTests ? "" : "// ") + "addProtocolTests()"
-        ].joined(separator: .newline)
     }
 
     private func buildResolvedServices() -> String {

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
@@ -291,58 +291,6 @@ func excludeRuntimeUnitTests() {
     }
 }
 
-func addProtocolTests() {
-    struct ProtocolTest {
-        let name: String
-        let sourcePath: String
-        let testPath: String?
-        let buildOnly: Bool
-
-        init(name: String, sourcePath: String, testPath: String? = nil, buildOnly: Bool = false) {
-            self.name = name
-            self.sourcePath = sourcePath
-            self.testPath = testPath
-            self.buildOnly = buildOnly
-        }
-    }
-
-    let baseDir = "codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen"
-    let baseDirLocal = "codegen/protocol-test-codegen-local/build/smithyprojections/protocol-test-codegen-local"
-
-    let protocolTests: [ProtocolTest] = [
-        .init(name: "AWSRestJsonTestSDK", sourcePath: "\(baseDir)/aws-restjson"),
-        .init(name: "AWSRestJsonValidationTestSDK", sourcePath: "\(baseDir)/aws-restjson-validation"),
-        .init(name: "AWSJson1_0TestSDK", sourcePath: "\(baseDir)/aws-json-10"),
-        .init(name: "AWSJson1_1TestSDK", sourcePath: "\(baseDir)/aws-json-11"),
-        .init(name: "RestXmlTestSDK", sourcePath: "\(baseDir)/rest-xml"),
-        .init(name: "RestXmlWithNamespaceTestSDK", sourcePath: "\(baseDir)/rest-xml-xmlns"),
-        .init(name: "Ec2QueryTestSDK", sourcePath: "\(baseDir)/ec2-query"),
-        .init(name: "AWSQueryTestSDK", sourcePath: "\(baseDir)/aws-query"),
-        .init(name: "APIGatewayTestSDK", sourcePath: "\(baseDir)/apigateway"),
-        .init(name: "GlacierTestSDK", sourcePath: "\(baseDir)/glacier"),
-        .init(name: "MachineLearningTestSDK", sourcePath: "\(baseDir)/machinelearning"),
-        .init(name: "S3TestSDK", sourcePath: "\(baseDir)/s3"),
-        .init(name: "rest_json_extras", sourcePath: "\(baseDirLocal)/rest_json_extras"),
-        .init(name: "AwsQueryExtras", sourcePath: "\(baseDirLocal)/AwsQueryExtras"),
-        .init(name: "EventStream", sourcePath: "\(baseDirLocal)/EventStream", buildOnly: true),
-        .init(name: "RPCEventStream", sourcePath: "\(baseDirLocal)/RPCEventStream", buildOnly: true),
-        .init(name: "Waiters", sourcePath: "\(baseDirLocal)/Waiters", testPath: "codegen/protocol-test-codegen-local/Tests"),
-    ]
-    for protocolTest in protocolTests {
-        let target = Target.target(
-            name: protocolTest.name,
-            dependencies: serviceTargetDependencies,
-            path: "\(protocolTest.sourcePath)/swift-codegen/Sources/\(protocolTest.name)"
-        )
-        let testTarget = protocolTest.buildOnly ? nil : Target.testTarget(
-            name: "\(protocolTest.name)Tests",
-            dependencies: [.smithyTestUtils, .smithyStreams, .smithyWaitersAPI, .byNameItem(name: protocolTest.name, condition: nil)],
-            path: "\(protocolTest.testPath ?? protocolTest.sourcePath)/swift-codegen/Tests/\(protocolTest.name)Tests"
-        )
-        package.targets += [target, testTarget].compactMap { $0 }
-    }
-}
-
 func addResolvedTargets() {
     enabledServices.union(integrationTestServices).forEach(addServiceTarget)
     enabledServiceUnitTests.forEach(addServiceUnitTestTarget)

--- a/codegen/Package.swift
+++ b/codegen/Package.swift
@@ -1,0 +1,174 @@
+// swift-tools-version:5.9
+
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import PackageDescription
+
+// MARK: - Target dependencies
+
+extension Target.Dependency {
+    // AWS modules
+    static var awsClientRuntime: Self { .product(name: "AWSClientRuntime", package: "aws-sdk-swift") }
+    static var awsSDKCommon: Self { .product(name: "AWSSDKCommon", package: "aws-sdk-swift") }
+    static var awsSDKEventStreamsAuth: Self { .product(name: "AWSSDKEventStreamsAuth", package: "aws-sdk-swift") }
+    static var awsSDKHTTPAuth: Self { .product(name: "AWSSDKHTTPAuth", package: "aws-sdk-swift") }
+    static var awsSDKIdentity: Self { .product(name: "AWSSDKIdentity", package: "aws-sdk-swift") }
+    static var awsSDKChecksums: Self { .product(name: "AWSSDKChecksums", package: "aws-sdk-swift") }
+
+    // CRT module
+    static var crt: Self { .product(name: "AwsCommonRuntimeKit", package: "aws-crt-swift") }
+
+    // Smithy modules
+    static var clientRuntime: Self { .product(name: "ClientRuntime", package: "smithy-swift") }
+    static var smithy: Self { .product(name: "Smithy", package: "smithy-swift") }
+    static var smithyChecksumsAPI: Self { .product(name: "SmithyChecksumsAPI", package: "smithy-swift") }
+    static var smithyChecksums: Self { .product(name: "SmithyChecksums", package: "smithy-swift") }
+    static var smithyEventStreams: Self { .product(name: "SmithyEventStreams", package: "smithy-swift") }
+    static var smithyEventStreamsAPI: Self { .product(name: "SmithyEventStreamsAPI", package: "smithy-swift") }
+    static var smithyEventStreamsAuthAPI: Self { .product(name: "SmithyEventStreamsAuthAPI", package: "smithy-swift") }
+    static var smithyHTTPAPI: Self { .product(name: "SmithyHTTPAPI", package: "smithy-swift") }
+    static var smithyHTTPAuth: Self { .product(name: "SmithyHTTPAuth", package: "smithy-swift") }
+    static var smithyIdentity: Self { .product(name: "SmithyIdentity", package: "smithy-swift") }
+    static var smithyIdentityAPI: Self { .product(name: "SmithyIdentityAPI", package: "smithy-swift") }
+    static var smithyRetries: Self { .product(name: "SmithyRetries", package: "smithy-swift") }
+    static var smithyRetriesAPI: Self { .product(name: "SmithyRetriesAPI", package: "smithy-swift") }
+    static var smithyWaitersAPI: Self { .product(name: "SmithyWaitersAPI", package: "smithy-swift") }
+    static var smithyTestUtils: Self { .product(name: "SmithyTestUtil", package: "smithy-swift") }
+    static var smithyStreams: Self { .product(name: "SmithyStreams", package: "smithy-swift") }
+}
+
+// MARK: - Base Package
+
+let package = Package(
+    name: "aws-sdk-swift-protocol-tests",
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .tvOS(.v13),
+        .watchOS(.v6)
+    ]
+)
+
+// MARK: - CRT, Smithy ClientRuntime, AWS ClientRuntime Dependencies
+
+func addDependencies() {
+    addClientRuntimeDependency()
+    addAWSClientRuntimeDependency()
+    addCRTDependency()
+}
+
+func addClientRuntimeDependency() {
+    let smithySwiftURL = "https://github.com/smithy-lang/smithy-swift"
+    let useLocalDeps = ProcessInfo.processInfo.environment["AWS_SWIFT_SDK_USE_LOCAL_DEPS"] != nil
+    let useMainDeps = ProcessInfo.processInfo.environment["AWS_SWIFT_SDK_USE_MAIN_DEPS"] != nil
+    switch (useLocalDeps, useMainDeps) {
+    case (true, true):
+        fatalError("Unable to determine which dependencies to use. Please only specify one of AWS_SWIFT_SDK_USE_LOCAL_DEPS or AWS_SWIFT_SDK_USE_MAIN_DEPS.")
+    case (true, false):
+        package.dependencies += [
+            .package(path: "../../smithy-swift")
+        ]
+    case (false, true):
+        package.dependencies += [
+            .package(url: smithySwiftURL, branch: "main")
+        ]
+    case (false, false):
+        package.dependencies += [
+            .package(url: smithySwiftURL, .upToNextMajor(from: "0.0.0"))
+        ]
+    }
+}
+
+func addAWSClientRuntimeDependency() {
+    package.dependencies += [
+        .package(path: "../../aws-sdk-swift")
+    ]
+}
+
+func addCRTDependency() {
+    package.dependencies += [
+        .package(url: "https://github.com/awslabs/aws-crt-swift", .upToNextMajor(from: "0.0.0"))
+    ]
+}
+
+let serviceTargetDependencies: [Target.Dependency] = [
+    .clientRuntime,
+    .awsClientRuntime,
+    .smithyRetriesAPI,
+    .smithyRetries,
+    .smithy,
+    .smithyIdentity,
+    .smithyIdentityAPI,
+    .smithyEventStreamsAPI,
+    .smithyEventStreamsAuthAPI,
+    .smithyEventStreams,
+    .smithyChecksumsAPI,
+    .smithyChecksums,
+    .smithyWaitersAPI,
+    .awsSDKCommon,
+    .awsSDKIdentity,
+    .awsSDKHTTPAuth,
+    .awsSDKEventStreamsAuth,
+    .awsSDKChecksums,
+]
+
+func addProtocolTests() {
+    struct ProtocolTest {
+        let name: String
+        let sourcePath: String
+        let testPath: String?
+        let buildOnly: Bool
+
+        init(name: String, sourcePath: String, testPath: String? = nil, buildOnly: Bool = false) {
+            self.name = name
+            self.sourcePath = sourcePath
+            self.testPath = testPath
+            self.buildOnly = buildOnly
+        }
+    }
+
+    let baseDir = "../codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen"
+    let baseDirLocal = "../codegen/protocol-test-codegen-local/build/smithyprojections/protocol-test-codegen-local"
+
+    let protocolTests: [ProtocolTest] = [
+        .init(name: "AWSRestJsonTestSDK", sourcePath: "\(baseDir)/aws-restjson"),
+        .init(name: "AWSRestJsonValidationTestSDK", sourcePath: "\(baseDir)/aws-restjson-validation"),
+        .init(name: "AWSJson1_0TestSDK", sourcePath: "\(baseDir)/aws-json-10"),
+        .init(name: "AWSJson1_1TestSDK", sourcePath: "\(baseDir)/aws-json-11"),
+        .init(name: "RestXmlTestSDK", sourcePath: "\(baseDir)/rest-xml"),
+        .init(name: "RestXmlWithNamespaceTestSDK", sourcePath: "\(baseDir)/rest-xml-xmlns"),
+        .init(name: "Ec2QueryTestSDK", sourcePath: "\(baseDir)/ec2-query"),
+        .init(name: "AWSQueryTestSDK", sourcePath: "\(baseDir)/aws-query"),
+        .init(name: "APIGatewayTestSDK", sourcePath: "\(baseDir)/apigateway"),
+        .init(name: "GlacierTestSDK", sourcePath: "\(baseDir)/glacier"),
+        .init(name: "MachineLearningTestSDK", sourcePath: "\(baseDir)/machinelearning"),
+        .init(name: "S3TestSDK", sourcePath: "\(baseDir)/s3"),
+        .init(name: "rest_json_extras", sourcePath: "\(baseDirLocal)/rest_json_extras"),
+        .init(name: "AwsQueryExtras", sourcePath: "\(baseDirLocal)/AwsQueryExtras"),
+        .init(name: "EventStream", sourcePath: "\(baseDirLocal)/EventStream", buildOnly: true),
+        .init(name: "RPCEventStream", sourcePath: "\(baseDirLocal)/RPCEventStream", buildOnly: true),
+        .init(name: "Waiters", sourcePath: "\(baseDirLocal)/Waiters", testPath: "../codegen/protocol-test-codegen-local/Tests"),
+    ]
+    for protocolTest in protocolTests {
+        let target = Target.target(
+            name: protocolTest.name,
+            dependencies: serviceTargetDependencies,
+            path: "\(protocolTest.sourcePath)/swift-codegen/Sources/\(protocolTest.name)"
+        )
+        let testTarget = protocolTest.buildOnly ? nil : Target.testTarget(
+            name: "\(protocolTest.name)Tests",
+            dependencies: [.smithyTestUtils, .smithyStreams, .smithyWaitersAPI, .byNameItem(name: protocolTest.name, condition: nil)],
+            path: "\(protocolTest.testPath ?? protocolTest.sourcePath)/swift-codegen/Tests/\(protocolTest.name)Tests"
+        )
+        package.targets += [target, testTarget].compactMap { $0 }
+    }
+}
+
+addDependencies()
+addProtocolTests()

--- a/scripts/ci_steps/prepare_protocol_and_unit_tests.sh
+++ b/scripts/ci_steps/prepare_protocol_and_unit_tests.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-# Regenerate the SDK Package.swift to run only protocol tests and runtime unit tests
 cd AWSSDKSwiftCLI
 swift run AWSSDKSwiftCLI generate-package-manifest --exclude-aws-services ..
 cd ..

--- a/scripts/ci_steps/prepare_protocol_and_unit_tests.sh
+++ b/scripts/ci_steps/prepare_protocol_and_unit_tests.sh
@@ -4,7 +4,7 @@ set -e
 
 # Regenerate the SDK Package.swift to run only protocol tests and runtime unit tests
 cd AWSSDKSwiftCLI
-swift run AWSSDKSwiftCLI generate-package-manifest --include-protocol-tests --exclude-aws-services ..
+swift run AWSSDKSwiftCLI generate-package-manifest --exclude-aws-services ..
 cd ..
 
 # Dump the Package.swift contents to the logs

--- a/scripts/protogen.sh
+++ b/scripts/protogen.sh
@@ -44,12 +44,7 @@ rm codegen/protocol-test-codegen-local/build/smithyprojections/protocol-test-cod
 rm codegen/protocol-test-codegen-local/build/smithyprojections/protocol-test-codegen-local/RPCEventStream/swift-codegen/Package.swift
 rm codegen/protocol-test-codegen-local/build/smithyprojections/protocol-test-codegen-local/Waiters/swift-codegen/Package.swift
 
-# Regenerate the Package.swift with services & runtime tests excluded
-cd AWSSDKSwiftCLI
-swift run AWSSDKSwiftCLI generate-package-manifest --exclude-aws-services --exclude-runtime-tests ..
-cd ..
-
 # If on Mac, reopen Xcode to the refreshed tests
 if [ -x "$(command -v osascript)" ]; then
-  open -a Xcode
+  open -a Xcode codegen/
 fi

--- a/scripts/protogen.sh
+++ b/scripts/protogen.sh
@@ -44,9 +44,9 @@ rm codegen/protocol-test-codegen-local/build/smithyprojections/protocol-test-cod
 rm codegen/protocol-test-codegen-local/build/smithyprojections/protocol-test-codegen-local/RPCEventStream/swift-codegen/Package.swift
 rm codegen/protocol-test-codegen-local/build/smithyprojections/protocol-test-codegen-local/Waiters/swift-codegen/Package.swift
 
-# Regenerate the Package.swift with protocol tests included and services excluded
+# Regenerate the Package.swift with services & runtime tests excluded
 cd AWSSDKSwiftCLI
-swift run AWSSDKSwiftCLI generate-package-manifest --include-protocol-tests --exclude-aws-services --exclude-runtime-tests ..
+swift run AWSSDKSwiftCLI generate-package-manifest --exclude-aws-services --exclude-runtime-tests ..
 cd ..
 
 # If on Mac, reopen Xcode to the refreshed tests


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-swift/issues/1551

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
In logical order, from top to bottom:
- Add a new `Package.swift` for protocol tests, under codegen/.
- Remove `addProtocolTests()` function from the `Package.Base.swift`.
- Remove `includeProtocolTests` flag and `addProtocolTests()` function call codegen from AWSSDKSwiftCLI package codegen.
- Remove `includeProtocolTests` flag from where they're used in scripts.
- Update GH CI to run protocol tests with the new `Package.swift` under codegen/.

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.