### PR TITLE
chore: Prevent node 20 from running on AL2, fix transcribe expectation

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -129,7 +129,7 @@ jobs:
           - "5.9"
           - "5.10"
     env:
-      - ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Checkout aws-sdk-swift
         uses: actions/checkout@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -128,6 +128,8 @@ jobs:
         version:
           - "5.9"
           - "5.10"
+    env:
+      - ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Checkout aws-sdk-swift
         uses: actions/checkout@v3

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -138,6 +138,8 @@ jobs:
         version:
           - "5.9"
           - "5.10"
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - name: Configure AWS Credentials for Integration Tests
         # configure-aws-credentials@v4 does not work with AL2 images, so @v3 is used instead.  See:

--- a/IntegrationTests/Services/AWSTranscribeStreamingIntegrationTests/TranscribeStreamingTests.swift
+++ b/IntegrationTests/Services/AWSTranscribeStreamingIntegrationTests/TranscribeStreamingTests.swift
@@ -19,7 +19,7 @@ final class TranscribeStreamingTests: XCTestCase {
         let audioURL = Bundle.module.url(forResource: "hello-swift", withExtension: "wav")!
         let audioData = try Data(contentsOf: audioURL)
 
-        // A delay will be imposed between chunks to keep the audio streaming to the Teranscribe
+        // A delay will be imposed between chunks to keep the audio streaming to the Transcribe
         // service at approximately real-time.
         let duration = 2.976
         let chunkSize = 4096
@@ -70,6 +70,16 @@ final class TranscribeStreamingTests: XCTestCase {
             }
         }
 
-        XCTAssertEqual("Hello transcribed streaming from swift sdk.", fullMessage)
+        // All of the following are acceptable results for the transcription, without
+        // regard to capitalization.
+        //
+        // Due to changes to the transcription logic, all of these have been returned
+        // as the transcription at some point.
+        let candidates = [
+            "Hello transcribed streaming from Swift S. D. K.",
+            "Hello transcribed streaming from swift sdk.",
+            "Hello transcribes streaming from Swift SDK.",
+        ]
+        XCTAssertTrue(candidates.contains(where: { $0.lowercased() == fullMessage.lowercased() }))
     }
 }


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1608

## Description of changes
- Disable the forcing of Github Actions onto Node 20 since AL2 is incompatible with that version of Node.
- The Transcribe Streaming integration test transcription has been changed slightly by the service.  Verification of the transcription is now case-insensitive, and allows for any of the previous variations that the service has returned.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.