### PR TITLE
chore: Refactor protocol tests

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHTTPBindingProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHTTPBindingProtocolGenerator.kt
@@ -47,7 +47,6 @@ abstract class AWSHTTPBindingProtocolGenerator(
             responseTestBuilder,
             errorTestBuilder,
             customizations,
-            operationMiddleware,
             getProtocolHttpBindingResolver(ctx, defaultContentType),
             testsToIgnore,
             tagsToIgnore,


### PR DESCRIPTION
## Description of changes
Adapts constructor call to remove the operationMiddleware param from HttpProtocolTestGenerator.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.