### PR TITLE
chore: Use TestInitializer to initialize CRT

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.swift
@@ -223,7 +223,7 @@ func addServiceUnitTestTarget(_ name: String) {
     package.targets += [
         .testTarget(
             name: "\(testName)",
-            dependencies: [.crt, .clientRuntime, .awsClientRuntime, .byName(name: name), .smithyTestUtils],
+            dependencies: [.clientRuntime, .awsClientRuntime, .byName(name: name), .smithyTestUtils],
             path: "Sources/Services/\(name)/Tests/\(testName)"
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -223,7 +223,7 @@ func addServiceUnitTestTarget(_ name: String) {
     package.targets += [
         .testTarget(
             name: "\(testName)",
-            dependencies: [.crt, .clientRuntime, .awsClientRuntime, .byName(name: name), .smithyTestUtils],
+            dependencies: [.clientRuntime, .awsClientRuntime, .byName(name: name), .smithyTestUtils],
             path: "Sources/Services/\(name)/Tests/\(testName)"
         )
     ]

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/EndpointTestGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/EndpointTestGenerator.kt
@@ -20,9 +20,9 @@ import software.amazon.smithy.swift.codegen.SwiftDependency
 import software.amazon.smithy.swift.codegen.SwiftWriter
 import software.amazon.smithy.swift.codegen.endpoints.EndpointTypes
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
-import software.amazon.smithy.swift.codegen.swiftmodules.CRT
 import software.amazon.smithy.swift.codegen.swiftmodules.ClientRuntimeTypes
 import software.amazon.smithy.swift.codegen.swiftmodules.SmithyHTTPAPITypes
+import software.amazon.smithy.swift.codegen.swiftmodules.SmithyTestUtilTypes
 import software.amazon.smithy.swift.codegen.swiftmodules.XCTestTypes
 import software.amazon.smithy.swift.codegen.utils.toLowerCamelCase
 
@@ -47,7 +47,7 @@ class EndpointTestGenerator(
         writer.openBlock("class EndpointResolverTest: \$N {", "}", XCTestTypes.XCTestCase) {
             writer.write("")
             writer.openBlock("override class func setUp() {", "}") {
-                writer.write("\$N.initialize()", CRT.CommonRuntimeKit)
+                writer.write("\$N.initialize()", SmithyTestUtilTypes.TestInitializer)
             }
             writer.write("")
 


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1627

## Description of changes
- Use the TestInitializer in SmithyTestUtils to initialize CRT
- Remove CRT as a service client test dependency

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.