### PR TITLE
feat!: Renamed several HTTP-related types

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -24,6 +24,7 @@ disabled_rules:
   - operator_whitespace
   - large_tuple
   - trailing_comma
+  - non_optional_string_data_conversion
 
 opt_in_rules:
   - empty_count

--- a/IntegrationTests/Services/AWSS3IntegrationTests/S3ErrorIn200Test.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/S3ErrorIn200Test.swift
@@ -20,7 +20,7 @@ public class MockHttpClientEngine: HTTPClient {
     // Public initializer
     public init() {}
 
-    func successHttpResponse(request: SdkHttpRequest) -> HttpResponse {
+    func successHttpResponse(request: SmithyHTTPAPI.HTTPRequest) -> HTTPResponse {
         let errorResponsePayload = """
             <Error>
                 <Code>SlowDown</Code>
@@ -30,14 +30,14 @@ public class MockHttpClientEngine: HTTPClient {
             </Error>
         """
         request.withHeader(name: "Date", value: "Wed, 21 Oct 2015 07:28:00 GMT")
-        return HttpResponse(
+        return HTTPResponse(
             headers: request.headers,
             body: ByteStream.data(errorResponsePayload.data(using: .utf8)),
-            statusCode: HttpStatusCode.ok
+            statusCode: .ok
         )
     }
 
-    public func send(request: SdkHttpRequest) async throws -> HttpResponse {
+    public func send(request: SmithyHTTPAPI.HTTPRequest) async throws -> HTTPResponse {
         return successHttpResponse(request: request)
     }
 }

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Endpoints/EndpointResolverMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Endpoints/EndpointResolverMiddleware.swift
@@ -7,8 +7,8 @@
 
 import class Smithy.Context
 import struct SmithyHTTPAPI.Endpoint
-import class SmithyHTTPAPI.SdkHttpRequest
-import class SmithyHTTPAPI.SdkHttpRequestBuilder
+import class SmithyHTTPAPI.HTTPRequest
+import class SmithyHTTPAPI.HTTPRequestBuilder
 import struct SmithyHTTPAuthAPI.SelectedAuthScheme
 import enum SmithyHTTPAuthAPI.SigningAlgorithm
 import enum SmithyHTTPAuthAPI.SigningPropertyKeys
@@ -22,7 +22,7 @@ import protocol ClientRuntime.Middleware
 import struct ClientRuntime.OperationOutput
 
 public struct EndpointResolverMiddleware<OperationStackOutput, Params: EndpointsRequestContextProviding>: Middleware {
-    public typealias MInput = SmithyHTTPAPI.SdkHttpRequestBuilder
+    public typealias MInput = HTTPRequestBuilder
     public typealias MOutput = ClientRuntime.OperationOutput<OperationStackOutput>
 
     public let id: Swift.String = "EndpointResolverMiddleware"
@@ -45,7 +45,7 @@ public struct EndpointResolverMiddleware<OperationStackOutput, Params: Endpoints
 
     public func handle<H>(
         context: Smithy.Context,
-        input: SmithyHTTPAPI.SdkHttpRequestBuilder,
+        input: HTTPRequestBuilder,
         next: H
     ) async throws -> ClientRuntime.OperationOutput<OperationStackOutput>
         where H: Handler,
@@ -62,10 +62,10 @@ public struct EndpointResolverMiddleware<OperationStackOutput, Params: Endpoints
 extension EndpointResolverMiddleware: ApplyEndpoint {
 
     public func apply(
-        request: SdkHttpRequest,
+        request: HTTPRequest,
         selectedAuthScheme: SelectedAuthScheme?,
         attributes: Smithy.Context
-    ) async throws -> SdkHttpRequest {
+    ) async throws -> HTTPRequest {
         let builder = request.toBuilder()
 
         let endpoint = try endpointResolverBlock(endpointParams)

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Errors/Candidates/InvalidAccessKeyId.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Errors/Candidates/InvalidAccessKeyId.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class SmithyHTTPAPI.HttpResponse
+import class SmithyHTTPAPI.HTTPResponse
 import protocol ClientRuntime.HTTPError
 
 /// An error that may be returned by AWS when the access key used cannot be found by the server.
@@ -14,12 +14,12 @@ import protocol ClientRuntime.HTTPError
 public struct InvalidAccessKeyId: AWSServiceError, HTTPError, Error {
 
     static var errorCode: String { "InvalidAccessKeyId" }
-    public var httpResponse: HttpResponse
+    public var httpResponse: HTTPResponse
     public var requestID: String?
     public var requestID2: String?
     public var message: String?
 
-    init(httpResponse: HttpResponse, message: String?, requestID: String?, requestID2: String?) {
+    init(httpResponse: HTTPResponse, message: String?, requestID: String?, requestID2: String?) {
         self.httpResponse = httpResponse
         self.message = message
         self.requestID = requestID

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Errors/Candidates/UnknownAWSHTTPErrorCandidate.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Errors/Candidates/UnknownAWSHTTPErrorCandidate.swift
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class SmithyHTTPAPI.HttpResponse
+import class SmithyHTTPAPI.HTTPResponse
 import protocol ClientRuntime.ServiceError
 import protocol ClientRuntime.HTTPError
 
@@ -21,7 +21,7 @@ protocol UnknownAWSHTTPErrorCandidate: ServiceError, HTTPError, Error {
     /// If a HTTP response matches this error type, then an instance of this error should be created.
     static var errorCode: String { get }
 
-    init(httpResponse: HttpResponse, message: String?, requestID: String?, requestID2: String?)
+    init(httpResponse: HTTPResponse, message: String?, requestID: String?, requestID2: String?)
 }
 
 // These extensions provide for conformance with the `ServiceError` and

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Errors/UnknownAWSHTTPServiceError.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Errors/UnknownAWSHTTPServiceError.swift
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-import class SmithyHTTPAPI.HttpResponse
+import class SmithyHTTPAPI.HTTPResponse
 import ClientRuntime
 
 /// AWS specific Service Error structure used when exact error could not be deduced from the `HttpResponse`
@@ -21,7 +21,7 @@ import ClientRuntime
 
     public var requestID2: String?
 
-    public var httpResponse: HttpResponse
+    public var httpResponse: HTTPResponse
 }
 
 extension UnknownAWSHTTPServiceError {
@@ -34,7 +34,7 @@ extension UnknownAWSHTTPServiceError {
     ///   - requestID2: The request ID2 associated with this error (defined on S3 only.)  Defaults to `nil`.
     ///   - typeName: The non-namespaced name of the error type for this error.
     public init(
-        httpResponse: HttpResponse,
+        httpResponse: HTTPResponse,
         message: String?,
         requestID: String?,
         requestID2: String? = nil,
@@ -42,7 +42,7 @@ extension UnknownAWSHTTPServiceError {
     ) {
         self.typeName = typeName
         self.message = message
-        self.requestID = requestID ?? httpResponse.requestId
+        self.requestID = requestID ?? httpResponse.requestID
         self.requestID2 = requestID2
         self.httpResponse = httpResponse
     }

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/HTTP/HttpResponse+AWS.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/HTTP/HttpResponse+AWS.swift
@@ -3,18 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-import class SmithyHTTPAPI.HttpResponse
+import class SmithyHTTPAPI.HTTPResponse
 import ClientRuntime
 
-public extension HttpResponse {
+public extension HTTPResponse {
 
     /// The value of the x-amz-request-id header.
-    var requestId: String? {
+    var requestID: String? {
         return headers.value(for: "x-amz-request-id")
     }
 
     /// The value of the x-amz-id-2 header.
-    var requestId2: String? {
+    var requestID2: String? {
         return headers.value(for: "x-amz-id-2")
     }
 }

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/AWSS3ErrorWith200StatusXMLMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/AWSS3ErrorWith200StatusXMLMiddleware.swift
@@ -11,12 +11,12 @@ import SmithyHTTPAPI
 
 public struct AWSS3ErrorWith200StatusXMLMiddleware<OperationStackInput, OperationStackOutput>: Middleware {
     public let id: String = "AWSS3ErrorWith200StatusXMLMiddleware"
-    private let errorStatusCode: HttpStatusCode = .internalServerError
+    private let errorStatusCode: HTTPStatusCode = .internalServerError
 
     public init() {}
 
     public func handle<H>(context: Context,
-                          input: SdkHttpRequest,
+                          input: HTTPRequest,
                           next: H) async throws -> OperationOutput<OperationStackOutput>
     where H: Handler,
           Self.MInput == H.Input,
@@ -35,7 +35,7 @@ public struct AWSS3ErrorWith200StatusXMLMiddleware<OperationStackInput, Operatio
         return response
     }
 
-    private func isErrorWith200Status(response: HttpResponse) async throws -> Bool {
+    private func isErrorWith200Status(response: HTTPResponse) async throws -> Bool {
         // Check if the status code is OK (200)
         guard response.statusCode == .ok else {
             return false
@@ -51,7 +51,7 @@ public struct AWSS3ErrorWith200StatusXMLMiddleware<OperationStackInput, Operatio
         return xmlString.contains("<Error>")
     }
 
-    public typealias MInput = SdkHttpRequest
+    public typealias MInput = HTTPRequest
     public typealias MOutput = OperationOutput<OperationStackOutput>
 }
 

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/FlexibleChecksumsRequestMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/FlexibleChecksumsRequestMiddleware.swift
@@ -34,7 +34,7 @@ public struct FlexibleChecksumsRequestMiddleware<OperationStackInput, OperationS
         return try await next.handle(context: context, input: input)
     }
 
-    private func addHeaders(builder: SdkHttpRequestBuilder, attributes: Context) async throws {
+    private func addHeaders(builder: HTTPRequestBuilder, attributes: Context) async throws {
         if case(.stream(let stream)) = builder.body {
             attributes.isChunkedEligibleStream = stream.isEligibleForChunkedStreaming
             if stream.isEligibleForChunkedStreaming {

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/FlexibleChecksumsResponseMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/FlexibleChecksumsResponseMiddleware.swift
@@ -30,7 +30,7 @@ public struct FlexibleChecksumsResponseMiddleware<OperationStackInput, Operation
     }
 
     public func handle<H>(context: Context,
-                          input: SdkHttpRequest,
+                          input: HTTPRequest,
                           next: H) async throws -> OperationOutput<OperationStackOutput>
     where H: Handler,
     Self.MInput == H.Input,
@@ -50,7 +50,7 @@ public struct FlexibleChecksumsResponseMiddleware<OperationStackInput, Operation
         return output
     }
 
-    private func validateChecksum(response: HttpResponse, logger: any LogAgent, attributes: Context) async throws {
+    private func validateChecksum(response: HTTPResponse, logger: any LogAgent, attributes: Context) async throws {
         // Exit if validation should not be performed
         if !validationMode {
             logger.info("Checksum validation should not be performed! Skipping workflow...")
@@ -112,7 +112,7 @@ public struct FlexibleChecksumsResponseMiddleware<OperationStackInput, Operation
         }
     }
 
-    public typealias MInput = SdkHttpRequest
+    public typealias MInput = HTTPRequest
     public typealias MOutput = OperationOutput<OperationStackOutput>
 }
 

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/Sha256TreeHashMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/Sha256TreeHashMiddleware.swift
@@ -29,7 +29,7 @@ public struct Sha256TreeHashMiddleware<OperationStackInput, OperationStackOutput
               return try await next.handle(context: context, input: input)
           }
 
-    private func addHashes(request: SdkHttpRequest, builder: SdkHttpRequestBuilder, context: Context) async throws {
+    private func addHashes(request: SmithyHTTPAPI.HTTPRequest, builder: HTTPRequestBuilder, context: Context) async throws {
         switch request.body {
         case .data(let data):
             guard let data = data else {
@@ -104,7 +104,7 @@ public struct Sha256TreeHashMiddleware<OperationStackInput, OperationStackOutput
         return data.encodeToHexString()
     }
 
-    public typealias MInput = SdkHttpRequestBuilder
+    public typealias MInput = HTTPRequestBuilder
     public typealias MOutput = OperationOutput<OperationStackOutput>
 }
 

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/Sha256TreeHashMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/Sha256TreeHashMiddleware.swift
@@ -29,7 +29,11 @@ public struct Sha256TreeHashMiddleware<OperationStackInput, OperationStackOutput
               return try await next.handle(context: context, input: input)
           }
 
-    private func addHashes(request: SmithyHTTPAPI.HTTPRequest, builder: HTTPRequestBuilder, context: Context) async throws {
+    private func addHashes(
+        request: SmithyHTTPAPI.HTTPRequest,
+        builder: HTTPRequestBuilder,
+        context: Context
+    ) async throws {
         switch request.body {
         case .data(let data):
             guard let data = data else {

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/UserAgentMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/UserAgentMiddleware.swift
@@ -22,7 +22,7 @@ public struct UserAgentMiddleware<OperationStackInput, OperationStackOutput>: Mi
     }
 
     public func handle<H>(context: Context,
-                          input: SdkHttpRequestBuilder,
+                          input: HTTPRequestBuilder,
                           next: H) async throws -> OperationOutput<OperationStackOutput>
     where H: Handler,
           Self.MInput == H.Input,
@@ -31,11 +31,11 @@ public struct UserAgentMiddleware<OperationStackInput, OperationStackOutput>: Mi
         return try await next.handle(context: context, input: input)
     }
 
-    private func addHeader(builder: SdkHttpRequestBuilder) {
+    private func addHeader(builder: HTTPRequestBuilder) {
         builder.withHeader(name: USER_AGENT, value: metadata.userAgent)
     }
 
-    public typealias MInput = SdkHttpRequestBuilder
+    public typealias MInput = HTTPRequestBuilder
     public typealias MOutput = OperationOutput<OperationStackOutput>
 }
 
@@ -43,7 +43,7 @@ extension UserAgentMiddleware: HttpInterceptor {
     public typealias InputType = OperationStackInput
     public typealias OutputType = OperationStackOutput
 
-    public func modifyBeforeRetryLoop(context: some MutableRequest<Self.InputType, SdkHttpRequest>) async throws {
+    public func modifyBeforeRetryLoop(context: some MutableRequest<Self.InputType, HTTPRequest>) async throws {
         let builder = context.getRequest().toBuilder()
         addHeader(builder: builder)
         context.updateRequest(updated: builder.build())

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/XAmzTargetMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/XAmzTargetMiddleware.swift
@@ -25,7 +25,7 @@ public struct XAmzTargetMiddleware<OperationStackInput, OperationStackOutput>: M
         return try await next.handle(context: context, input: input)
     }
 
-    private func addHeader(builder: SdkHttpRequestBuilder) {
+    private func addHeader(builder: HTTPRequestBuilder) {
         builder.withHeader(name: "X-Amz-Target", value: xAmzTarget)
     }
 

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Protocols/AWSJSON/AWSJSONError.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Protocols/AWSJSON/AWSJSONError.swift
@@ -7,7 +7,7 @@
 
 import protocol ClientRuntime.BaseError
 import enum ClientRuntime.BaseErrorDecodeError
-import class SmithyHTTPAPI.HttpResponse
+import class SmithyHTTPAPI.HTTPResponse
 import class SmithyJSON.Reader
 
 public struct AWSJSONError: BaseError {
@@ -16,10 +16,10 @@ public struct AWSJSONError: BaseError {
     public let requestID: String?
     public var errorBodyReader: Reader { responseReader }
 
-    public let httpResponse: HttpResponse
+    public let httpResponse: HTTPResponse
     private let responseReader: Reader
 
-    public init(httpResponse: HttpResponse, responseReader: Reader, noErrorWrapping: Bool) throws {
+    public init(httpResponse: HTTPResponse, responseReader: Reader, noErrorWrapping: Bool) throws {
         let code: String? = try httpResponse.headers.value(for: "X-Amzn-Errortype")
                             ?? responseReader["code"].readIfPresent()
                             ?? responseReader["__type"].readIfPresent()

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Protocols/AWSQuery/AWSQueryError.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Protocols/AWSQuery/AWSQueryError.swift
@@ -7,18 +7,18 @@
 
 import protocol ClientRuntime.BaseError
 import enum ClientRuntime.BaseErrorDecodeError
-import class SmithyHTTPAPI.HttpResponse
+import class SmithyHTTPAPI.HTTPResponse
 import class SmithyXML.Reader
 
 public struct AWSQueryError: BaseError {
     public let code: String
     public let message: String?
     public let requestID: String?
-    public let httpResponse: HttpResponse
+    public let httpResponse: HTTPResponse
     public let responseReader: Reader
     public let errorBodyReader: Reader
 
-    public init(httpResponse: HttpResponse, responseReader: Reader, noErrorWrapping: Bool) throws {
+    public init(httpResponse: HTTPResponse, responseReader: Reader, noErrorWrapping: Bool) throws {
         self.errorBodyReader = noErrorWrapping ? responseReader : responseReader["Error"]
         let code: String? = try errorBodyReader["Code"].readIfPresent()
         let message: String? = try errorBodyReader["Message"].readIfPresent()

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Protocols/Ec2Query/EC2QueryError.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Protocols/Ec2Query/EC2QueryError.swift
@@ -7,7 +7,7 @@
 
 import protocol ClientRuntime.BaseError
 import enum ClientRuntime.BaseErrorDecodeError
-import class SmithyHTTPAPI.HttpResponse
+import class SmithyHTTPAPI.HTTPResponse
 import class SmithyXML.Reader
 
 public struct EC2QueryError: BaseError {
@@ -16,10 +16,10 @@ public struct EC2QueryError: BaseError {
     public let requestID: String?
     public let errorBodyReader: Reader
 
-    public let httpResponse: HttpResponse
+    public let httpResponse: HTTPResponse
     public let responseReader: Reader
 
-    public init(httpResponse: HttpResponse, responseReader: Reader, noErrorWrapping: Bool) throws {
+    public init(httpResponse: HTTPResponse, responseReader: Reader, noErrorWrapping: Bool) throws {
         self.httpResponse = httpResponse
         self.responseReader = responseReader
         self.errorBodyReader = responseReader["Errors"]["Error"]

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Protocols/RestJSON/RestJSONError.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Protocols/RestJSON/RestJSONError.swift
@@ -7,7 +7,7 @@
 
 import protocol ClientRuntime.BaseError
 import enum ClientRuntime.BaseErrorDecodeError
-import class SmithyHTTPAPI.HttpResponse
+import class SmithyHTTPAPI.HTTPResponse
 import class SmithyJSON.Reader
 
 public struct RestJSONError: BaseError {
@@ -15,7 +15,7 @@ public struct RestJSONError: BaseError {
     public let message: String?
     public let requestID: String?
 
-    public let httpResponse: HttpResponse
+    public let httpResponse: HTTPResponse
     private let responseReader: Reader
     public var errorBodyReader: Reader { responseReader }
 
@@ -31,7 +31,7 @@ public struct RestJSONError: BaseError {
     // error message header returned by event stream errors
     let X_AMZN_EVENT_ERROR_MESSAGE_HEADER_NAME = ":error-message"
 
-    public init(httpResponse: HttpResponse, responseReader: SmithyJSON.Reader, noErrorWrapping: Bool) throws {
+    public init(httpResponse: HTTPResponse, responseReader: SmithyJSON.Reader, noErrorWrapping: Bool) throws {
         let type = try httpResponse.headers.value(for: X_AMZN_ERROR_TYPE_HEADER_NAME)
                    ?? responseReader["code"].readIfPresent()
                    ?? responseReader["__type"].readIfPresent()
@@ -49,7 +49,7 @@ public struct RestJSONError: BaseError {
 
         self.code = sanitizeErrorType(type)
         self.message = message
-        self.requestID = httpResponse.requestId
+        self.requestID = httpResponse.requestID
         self.httpResponse = httpResponse
         self.responseReader = responseReader
     }

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Protocols/RestXML/RestXMLError.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Protocols/RestXML/RestXMLError.swift
@@ -7,25 +7,25 @@
 
 import protocol ClientRuntime.BaseError
 import enum ClientRuntime.BaseErrorDecodeError
-import class SmithyHTTPAPI.HttpResponse
+import class SmithyHTTPAPI.HTTPResponse
 import class SmithyXML.Reader
 
 public struct RestXMLError: BaseError {
     public let code: String
     public let message: String?
     public let requestID: String?
-    public var requestID2: String? { httpResponse.requestId2 }
+    public var requestID2: String? { httpResponse.requestID2 }
 
-    public let httpResponse: HttpResponse
+    public let httpResponse: HTTPResponse
     private let responseReader: Reader
     public let errorBodyReader: Reader
 
-    public init(httpResponse: HttpResponse, responseReader: Reader, noErrorWrapping: Bool) throws {
+    public init(httpResponse: HTTPResponse, responseReader: Reader, noErrorWrapping: Bool) throws {
         self.errorBodyReader = Self.errorBodyReader(responseReader: responseReader, noErrorWrapping: noErrorWrapping)
         let code: String? = try errorBodyReader["Code"].readIfPresent()
         if code == nil && httpResponse.statusCode != .notFound { throw BaseErrorDecodeError.missingRequiredData }
         let message: String? = try errorBodyReader["Message"].readIfPresent()
-        let requestID: String? = try responseReader["RequestId"].readIfPresent() ?? httpResponse.requestId
+        let requestID: String? = try responseReader["RequestId"].readIfPresent() ?? httpResponse.requestID
         self.code = code ?? "NotFound"
         self.message = message
         self.requestID = requestID

--- a/Sources/Core/AWSClientRuntime/Tests/AWSClientRuntimeTests/Middlewares/FlexibleChecksumsMiddlewareTests.swift
+++ b/Sources/Core/AWSClientRuntime/Tests/AWSClientRuntimeTests/Middlewares/FlexibleChecksumsMiddlewareTests.swift
@@ -251,7 +251,7 @@ class FlexibleChecksumsMiddlewareTests: XCTestCase {
     ) async throws -> () {
         var isChecksumValidated = false
         let mockHandler = MockHandler { (_, input) in
-            let httpResponse = HttpResponse(body: responseBody, statusCode: HttpStatusCode.ok)
+            let httpResponse = HTTPResponse(body: responseBody, statusCode: .ok)
             httpResponse.headers.add(name: expectedHeader, value: expectedChecksum)
             let mockOutput = try await MockOutput.responseClosure(httpResponse)
             let output = OperationOutput<MockOutput>(httpResponse: httpResponse, output: mockOutput)
@@ -291,7 +291,7 @@ class FlexibleChecksumsMiddlewareTests: XCTestCase {
             if expectedHeader != "" {
                 XCTAssert(input.headers.value(for: expectedHeader) != nil, file: file, line: line)
             }
-            let httpResponse = HttpResponse(body: responseBody, statusCode: HttpStatusCode.ok)
+            let httpResponse = HTTPResponse(body: responseBody, statusCode: .ok)
             httpResponse.headers.add(name: expectedHeader, value: expectedChecksum)
             let mockOutput = try await MockOutput.responseClosure(httpResponse)
             let output = OperationOutput<MockOutput>(httpResponse: httpResponse, output: mockOutput)
@@ -327,7 +327,7 @@ class FlexibleChecksumsMiddlewareTests: XCTestCase {
         var validatedChecksum: String? = nil
         let mockHandler = MockHandler { (_, input) in
             let responseBody = ByteStream.data(Data("Hello, world!".utf8))
-            let httpResponse = HttpResponse(body: responseBody, statusCode: HttpStatusCode.ok)
+            let httpResponse = HTTPResponse(body: responseBody, statusCode: .ok)
             httpResponse.headers.addAll(headers: responseHeaders)
             let mockOutput = try await MockOutput.responseClosure(httpResponse)
             let output = OperationOutput<MockOutput>(httpResponse: httpResponse, output: mockOutput)
@@ -380,7 +380,7 @@ class FlexibleChecksumsMiddlewareTests: XCTestCase {
             // Verify that the request headers are correctly set
             XCTAssertEqual(input.headers.value(for: "x-amz-content-sha256"), "UNSIGNED-PAYLOAD")
             XCTAssertEqual(input.headers.value(for: "x-amz-checksum-sha256"), expectedChecksumSHA256)
-            let httpResponse = HttpResponse(body: ByteStream.noStream, statusCode: HttpStatusCode.ok)
+            let httpResponse = HTTPResponse(body: ByteStream.noStream, statusCode: .ok)
             let mockOutput = try await MockOutput.responseClosure(httpResponse)
             return OperationOutput<MockOutput>(httpResponse: httpResponse, output: mockOutput)
         }

--- a/Sources/Core/AWSClientRuntime/Tests/AWSClientRuntimeTests/Middlewares/Sha256TreeHashMiddlewareTests.swift
+++ b/Sources/Core/AWSClientRuntime/Tests/AWSClientRuntimeTests/Middlewares/Sha256TreeHashMiddlewareTests.swift
@@ -25,7 +25,7 @@ class Sha256TreeHashMiddlewareTests: XCTestCase {
         let streamInput = MockStreamInput(body: byteStream)
         var stack = OperationStack<MockStreamInput, MockOutput>(id: "TreeHashMiddlewareTestStack")
         stack.serializeStep.intercept(position: .before, middleware: MockSerializeStreamMiddleware())
-        let mockHttpResponse = HttpResponse(body: .noStream, statusCode: .accepted)
+        let mockHttpResponse = HTTPResponse(body: .noStream, statusCode: .accepted)
         let mockOutput = MockOutput()
         let output = OperationOutput<MockOutput>(httpResponse: mockHttpResponse, output: mockOutput)
         stack.finalizeStep.intercept(position: .after, middleware: Sha256TreeHashMiddleware<MockStreamInput, MockOutput>())

--- a/Sources/Core/AWSClientRuntime/Tests/AWSClientRuntimeTests/Protocols/Ec2Query/Ec2ErrorRequestIdTests.swift
+++ b/Sources/Core/AWSClientRuntime/Tests/AWSClientRuntimeTests/Protocols/Ec2Query/Ec2ErrorRequestIdTests.swift
@@ -26,7 +26,7 @@ class Ec2ErrorRequestIdTests: XCTestCase {
             <RequestID>abcdefg12345</RequestID>
         </Ec2Response>
         """.utf8)
-        let httpResponse = HttpResponse(body: .data(data), statusCode: .ok)
+        let httpResponse = HTTPResponse(body: .data(data), statusCode: .ok)
         let response = try EC2QueryError(httpResponse: httpResponse, responseReader: Reader.from(data: data), noErrorWrapping: true)
         XCTAssertEqual(response.requestID, "abcdefg12345")
     }
@@ -43,7 +43,7 @@ class Ec2ErrorRequestIdTests: XCTestCase {
             <RequestId>abcdefg12345</RequestId>
         </Ec2Response>
         """.utf8)
-        let httpResponse = HttpResponse(body: .data(data), statusCode: .ok)
+        let httpResponse = HTTPResponse(body: .data(data), statusCode: .ok)
         let response = try EC2QueryError(httpResponse: httpResponse, responseReader: Reader.from(data: data), noErrorWrapping: true)
         XCTAssertEqual(response.requestID, "abcdefg12345")
     }

--- a/Sources/Core/AWSClientRuntime/Tests/AWSClientRuntimeTests/Protocols/RestJSON/RestJSONErrorTests.swift
+++ b/Sources/Core/AWSClientRuntime/Tests/AWSClientRuntimeTests/Protocols/RestJSON/RestJSONErrorTests.swift
@@ -39,7 +39,7 @@ class RestJSONErrorTests: HttpResponseTestBase {
                 header: "Header",
                 topLevel: "Top level"
             )
-            XCTAssertEqual(actual.httpResponse.statusCode, HttpStatusCode(rawValue: 400))
+            XCTAssertEqual(actual.httpResponse.statusCode, HTTPStatusCode(rawValue: 400))
             XCTAssertEqual(actual.header, expected.header)
             XCTAssertEqual(actual.topLevel, expected.topLevel)
         } else {
@@ -63,7 +63,7 @@ class RestJSONErrorTests: HttpResponseTestBase {
 
 public struct ComplexError: AWSServiceError, HTTPError, Error {
     public var typeName: String?
-    public var httpResponse = HttpResponse()
+    public var httpResponse = HTTPResponse()
     public var message: String?
     public var requestID: String?
     public var header: String?
@@ -102,7 +102,7 @@ extension ComplexError {
 
 public enum GreetingWithErrorsError {
     
-    static func httpError(from httpResponse: HttpResponse) async throws -> Swift.Error {
+    static func httpError(from httpResponse: HTTPResponse) async throws -> Swift.Error {
         let data = try await httpResponse.data()
         let responseReader = try SmithyJSON.Reader.from(data: data)
         let baseError = try AWSClientRuntime.RestJSONError(httpResponse: httpResponse, responseReader: responseReader, noErrorWrapping: false)

--- a/Sources/Core/AWSClientRuntime/Tests/AWSClientRuntimeTests/Retry/AWSRetryErrorInfoProviderTests.swift
+++ b/Sources/Core/AWSClientRuntime/Tests/AWSClientRuntimeTests/Retry/AWSRetryErrorInfoProviderTests.swift
@@ -117,12 +117,12 @@ private struct TestServiceError: ServiceError, Error {
 }
 
 private struct TestHTTPError: HTTPError, Error {
-    var httpResponse: HttpResponse
+    var httpResponse: HTTPResponse
 
     init(statusCode: Int, headers: [String: String] = [:]) throws {
-        let status = try XCTUnwrap(HttpStatusCode(rawValue: statusCode))
+        let status = try XCTUnwrap(HTTPStatusCode(rawValue: statusCode))
         let httpHeaders = Headers(Dictionary(uniqueKeysWithValues: headers.map { ($0.key, [$0.value]) }))
-        self.httpResponse = HttpResponse(headers: httpHeaders, statusCode: status)
+        self.httpResponse = HTTPResponse(headers: httpHeaders, statusCode: status)
     }
 }
 

--- a/Sources/Core/AWSSDKChecksums/Sources/AWSSDKChecksums/AWSChunkedUtil.swift
+++ b/Sources/Core/AWSSDKChecksums/Sources/AWSSDKChecksums/AWSChunkedUtil.swift
@@ -10,12 +10,12 @@ import struct Smithy.AttributeKey
 import enum Smithy.ByteStream
 import enum Smithy.ClientError
 import struct SmithyHTTPAPI.Headers
-import class SmithyHTTPAPI.SdkHttpRequestBuilder
+import class SmithyHTTPAPI.HTTPRequestBuilder
 import enum SmithyChecksumsAPI.ChecksumAlgorithm
 import class SmithyChecksums.ChunkedStream
 import AwsCommonRuntimeKit
 
-extension SdkHttpRequestBuilder {
+extension HTTPRequestBuilder {
     public func setAwsChunkedHeaders() throws {
 
         // Check if self.body is of the case ByteStream.stream(let stream)

--- a/Sources/Core/AWSSDKHTTPAuth/Sources/AWSSDKHTTPAuth/AWSSigV4Signer.swift
+++ b/Sources/Core/AWSSDKHTTPAuth/Sources/AWSSDKHTTPAuth/AWSSigV4Signer.swift
@@ -7,8 +7,8 @@
 
 import class AwsCommonRuntimeKit.HTTPRequestBase
 import class AwsCommonRuntimeKit.Signer
-import class SmithyHTTPAPI.SdkHttpRequest
-import class SmithyHTTPAPI.SdkHttpRequestBuilder
+import class SmithyHTTPAPI.HTTPRequest
+import class SmithyHTTPAPI.HTTPRequestBuilder
 import enum AwsCommonRuntimeKit.CommonRunTimeError
 import enum Smithy.ClientError
 import enum SmithyHTTPAuthAPI.AWSSignedBodyHeader
@@ -37,10 +37,10 @@ public class AWSSigV4Signer: SmithyHTTPAuthAPI.Signer {
     public init() {}
 
     public func signRequest<IdentityT: SmithyIdentityAPI.Identity>(
-        requestBuilder: SmithyHTTPAPI.SdkHttpRequestBuilder,
+        requestBuilder: HTTPRequestBuilder,
         identity: IdentityT,
         signingProperties: Smithy.Attributes
-    ) async throws -> SmithyHTTPAPI.SdkHttpRequestBuilder {
+    ) async throws -> HTTPRequestBuilder {
         guard let isBidirectionalStreamingEnabled = signingProperties.get(
             key: SigningPropertyKeys.bidirectionalStreaming
         ) else {
@@ -160,7 +160,7 @@ public class AWSSigV4Signer: SmithyHTTPAuthAPI.Signer {
     let logger: Smithy.SwiftLogger = SwiftLogger(label: "AWSSigV4Signer")
 
     public func sigV4SignedURL(
-        requestBuilder: SmithyHTTPAPI.SdkHttpRequestBuilder,
+        requestBuilder: HTTPRequestBuilder,
         awsCredentialIdentityResolver: any AWSCredentialIdentityResolver,
         signingName: Swift.String,
         signingRegion: Swift.String,
@@ -202,9 +202,9 @@ public class AWSSigV4Signer: SmithyHTTPAuthAPI.Signer {
     }
 
     public func sigV4SignedRequest(
-        requestBuilder: SmithyHTTPAPI.SdkHttpRequestBuilder,
+        requestBuilder: HTTPRequestBuilder,
         signingConfig: AWSSigningConfig
-    ) async -> SmithyHTTPAPI.SdkHttpRequest? {
+    ) async -> HTTPRequest? {
         let originalRequest = requestBuilder.build()
         do {
             let crtUnsignedRequest = try originalRequest.toHttpRequest()

--- a/Sources/Core/AWSSDKHTTPAuth/Tests/AWSSDKHTTPAuthTests/SigV4SigningTests.swift
+++ b/Sources/Core/AWSSDKHTTPAuth/Tests/AWSSDKHTTPAuthTests/SigV4SigningTests.swift
@@ -29,7 +29,7 @@ class Sigv4SigningTests: XCTestCase {
         let dateString = "2024-01-16T12:36:00Z"
         let date = try XCTUnwrap(TimestampFormatter(format: .dateTime).date(from: dateString))
 
-        let requestBuilder = SdkHttpRequestBuilder()
+        let requestBuilder = HTTPRequestBuilder()
             .withHost("example.amazonaws.com")
             .withPath("/")
             .withMethod(.get)
@@ -62,7 +62,7 @@ class Sigv4SigningTests: XCTestCase {
         let dateString = "2024-01-16T12:36:00Z"
         let date = try XCTUnwrap(TimestampFormatter(format: .dateTime).date(from: dateString))
 
-        let requestBuilder = SdkHttpRequestBuilder()
+        let requestBuilder = HTTPRequestBuilder()
             .withHost("example.amazonaws.com")
             .withPath("/")
             .withMethod(.get)
@@ -98,7 +98,7 @@ class Sigv4SigningTests: XCTestCase {
         let dateString = "2024-01-16T12:36:00Z"
         let date = try XCTUnwrap(TimestampFormatter(format: .dateTime).date(from: dateString))
 
-        let requestBuilder = SdkHttpRequestBuilder()
+        let requestBuilder = HTTPRequestBuilder()
             .withHost("example.amazonaws.com")
             .withPath("/")
             .withMethod(.get)
@@ -135,7 +135,7 @@ class Sigv4SigningTests: XCTestCase {
         let dateString = "2024-01-16T12:36:00Z"
         let date = try XCTUnwrap(TimestampFormatter(format: .dateTime).date(from: dateString))
 
-        let requestBuilder = SdkHttpRequestBuilder()
+        let requestBuilder = HTTPRequestBuilder()
             .withHost("example.amazonaws.com")
             .withPath("/")
             .withMethod(.get)
@@ -171,7 +171,7 @@ class Sigv4SigningTests: XCTestCase {
         let dateString = "2024-01-16T12:36:00Z"
         let date = try XCTUnwrap(TimestampFormatter(format: .dateTime).date(from: dateString))
 
-        let requestBuilder = SdkHttpRequestBuilder()
+        let requestBuilder = HTTPRequestBuilder()
             .withHost("example.amazonaws.com")
             .withPath("/")
             .withMethod(.get)
@@ -207,7 +207,7 @@ class Sigv4SigningTests: XCTestCase {
         let dateString = "2024-01-16T12:36:00Z"
         let date = try XCTUnwrap(TimestampFormatter(format: .dateTime).date(from: dateString))
 
-        let requestBuilder = SdkHttpRequestBuilder()
+        let requestBuilder = HTTPRequestBuilder()
             .withHost("example.amazonaws.com")
             .withPath("/")
             .withMethod(.get)
@@ -243,7 +243,7 @@ class Sigv4SigningTests: XCTestCase {
         let dateString = "2024-01-16T12:36:00Z"
         let date = try XCTUnwrap(TimestampFormatter(format: .dateTime).date(from: dateString))
 
-        let requestBuilder = SdkHttpRequestBuilder()
+        let requestBuilder = HTTPRequestBuilder()
             .withHost("example.amazonaws.com")
             .withPath("/")
             .withMethod(.get)
@@ -279,7 +279,7 @@ class Sigv4SigningTests: XCTestCase {
         let dateString = "2015-08-30T12:36:00Z"
         let date = try XCTUnwrap(TimestampFormatter(format: .dateTime).date(from: dateString))
 
-        let requestBuilder = SdkHttpRequestBuilder()
+        let requestBuilder = HTTPRequestBuilder()
             .withHost("example.amazonaws.com")
             .withPath("")
             .withMethod(.get)

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/PutObjectPresignedURLMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/PutObjectPresignedURLMiddleware.kt
@@ -27,9 +27,9 @@ class PutObjectPresignedURLMiddleware(
             """
             extension $typeName: Smithy.RequestMessageSerializer {
                 public typealias InputType = ${inputSymbol.name}
-                public typealias RequestType = SmithyHTTPAPI.SdkHttpRequest
+                public typealias RequestType = SmithyHTTPAPI.HTTPRequest
                 
-                public func apply(input: InputType, builder: SmithyHTTPAPI.SdkHttpRequestBuilder, attributes: Smithy.Context) throws {
+                public func apply(input: InputType, builder: SmithyHTTPAPI.HTTPRequestBuilder, attributes: Smithy.Context) throws {
                     let metadata = input.metadata ?? [:]
                     for (metadataKey, metadataValue) in metadata {
                         let queryItem = ${'$'}N(

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGeneratorTests.kt
@@ -13,7 +13,7 @@ class PresignerGeneratorTests {
         contents.shouldSyntacticSanityCheck()
         val expectedContents = """
 extension GetFooInput {
-    public func presign(config: ExampleClient.ExampleClientConfiguration, expiration: Foundation.TimeInterval) async throws -> SmithyHTTPAPI.SdkHttpRequest? {
+    public func presign(config: ExampleClient.ExampleClientConfiguration, expiration: Foundation.TimeInterval) async throws -> SmithyHTTPAPI.HTTPRequest? {
         let serviceName = "example"
         let input = self
         let context = Smithy.ContextBuilder()
@@ -63,7 +63,7 @@ extension GetFooInput {
         contents.shouldSyntacticSanityCheck()
         val expectedContents = """
 extension PostFooInput {
-    public func presign(config: ExampleClient.ExampleClientConfiguration, expiration: Foundation.TimeInterval) async throws -> SmithyHTTPAPI.SdkHttpRequest? {
+    public func presign(config: ExampleClient.ExampleClientConfiguration, expiration: Foundation.TimeInterval) async throws -> SmithyHTTPAPI.HTTPRequest? {
         let serviceName = "example"
         let input = self
         let context = Smithy.ContextBuilder()
@@ -116,7 +116,7 @@ extension PostFooInput {
         contents.shouldSyntacticSanityCheck()
         val expectedContents = """
 extension PutFooInput {
-    public func presign(config: ExampleClient.ExampleClientConfiguration, expiration: Foundation.TimeInterval) async throws -> SmithyHTTPAPI.SdkHttpRequest? {
+    public func presign(config: ExampleClient.ExampleClientConfiguration, expiration: Foundation.TimeInterval) async throws -> SmithyHTTPAPI.HTTPRequest? {
         let serviceName = "example"
         let input = self
         let context = Smithy.ContextBuilder()
@@ -169,7 +169,7 @@ extension PutFooInput {
         contents.shouldSyntacticSanityCheck()
         val expectedContents = """
 extension PutObjectInput {
-    public func presign(config: S3Client.S3ClientConfiguration, expiration: Foundation.TimeInterval) async throws -> SmithyHTTPAPI.SdkHttpRequest? {
+    public func presign(config: S3Client.S3ClientConfiguration, expiration: Foundation.TimeInterval) async throws -> SmithyHTTPAPI.HTTPRequest? {
         let serviceName = "S3"
         let input = self
         let context = Smithy.ContextBuilder()

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AWSJSONHttpResponseBindingErrorGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsjson/AWSJSONHttpResponseBindingErrorGeneratorTests.kt
@@ -23,7 +23,7 @@ class AWSJSONHttpResponseBindingErrorGeneratorTests {
         val expectedContents = """
 enum GreetingWithErrorsOutputError {
 
-    static func httpError(from httpResponse: SmithyHTTPAPI.HttpResponse) async throws -> Swift.Error {
+    static func httpError(from httpResponse: SmithyHTTPAPI.HTTPResponse) async throws -> Swift.Error {
         let data = try await httpResponse.data()
         let responseReader = try SmithyJSON.Reader.from(data: data)
         let baseError = try AWSClientRuntime.AWSJSONError(httpResponse: httpResponse, responseReader: responseReader, noErrorWrapping: false)

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/StructDecodeWrappedXMLGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsquery/StructDecodeWrappedXMLGeneratorTests.kt
@@ -22,7 +22,7 @@ class StructDecodeWrappedXMLGeneratorTests {
         val expectedContents = """
 extension FlattenedXmlMapOutput {
 
-    static func httpOutput(from httpResponse: SmithyHTTPAPI.HttpResponse) async throws -> FlattenedXmlMapOutput {
+    static func httpOutput(from httpResponse: SmithyHTTPAPI.HTTPResponse) async throws -> FlattenedXmlMapOutput {
         let data = try await httpResponse.data()
         let responseReader = try SmithyXML.Reader.from(data: data)
         let reader = responseReader["FlattenedXmlMapResult"]

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsrestjson/AWSRestJson1HttpResponseBindingErrorGeneratableTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsrestjson/AWSRestJson1HttpResponseBindingErrorGeneratableTests.kt
@@ -20,7 +20,7 @@ class AWSRestJson1HttpResponseBindingErrorGeneratableTests {
         val expectedContents = """
 enum GreetingWithErrorsOutputError {
 
-    static func httpError(from httpResponse: SmithyHTTPAPI.HttpResponse) async throws -> Swift.Error {
+    static func httpError(from httpResponse: SmithyHTTPAPI.HTTPResponse) async throws -> Swift.Error {
         let data = try await httpResponse.data()
         let responseReader = try SmithyJSON.Reader.from(data: data)
         let baseError = try AWSClientRuntime.RestJSONError(httpResponse: httpResponse, responseReader: responseReader, noErrorWrapping: false)

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/Route53InvalidBatchErrorIntegrationTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/Route53InvalidBatchErrorIntegrationTests.kt
@@ -28,7 +28,7 @@ class Route53InvalidBatchErrorIntegrationTests {
         val expectedContents = """
 enum ChangeResourceRecordSetsOutputError {
 
-    static func httpError(from httpResponse: SmithyHTTPAPI.HttpResponse) async throws -> Swift.Error {
+    static func httpError(from httpResponse: SmithyHTTPAPI.HTTPResponse) async throws -> Swift.Error {
         let data = try await httpResponse.data()
         let responseReader = try SmithyXML.Reader.from(data: data)
         let baseError = try AWSClientRuntime.RestXMLError(httpResponse: httpResponse, responseReader: responseReader, noErrorWrapping: false)

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/ec2query/Ec2QueryHttpResponseBindingErrorGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/ec2query/Ec2QueryHttpResponseBindingErrorGeneratorTests.kt
@@ -23,7 +23,7 @@ class Ec2QueryHttpResponseBindingErrorGeneratorTests {
         val expectedContents = """
 enum GreetingWithErrorsOutputError {
 
-    static func httpError(from httpResponse: SmithyHTTPAPI.HttpResponse) async throws -> Swift.Error {
+    static func httpError(from httpResponse: SmithyHTTPAPI.HTTPResponse) async throws -> Swift.Error {
         let data = try await httpResponse.data()
         let responseReader = try SmithyXML.Reader.from(data: data)
         let baseError = try AWSClientRuntime.EC2QueryError(httpResponse: httpResponse, responseReader: responseReader, noErrorWrapping: false)
@@ -81,7 +81,7 @@ public struct ComplexError: ClientRuntime.ModeledError, AWSClientRuntime.AWSServ
     public static var fault: ClientRuntime.ErrorFault { .client }
     public static var isRetryable: Swift.Bool { false }
     public static var isThrottling: Swift.Bool { false }
-    public internal(set) var httpResponse = SmithyHTTPAPI.HttpResponse()
+    public internal(set) var httpResponse = SmithyHTTPAPI.HTTPResponse()
     public internal(set) var message: Swift.String?
     public internal(set) var requestID: Swift.String?
 

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/restxml/AWSRestXMLHTTPResponseBindingErrorGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/restxml/AWSRestXMLHTTPResponseBindingErrorGeneratorTests.kt
@@ -24,7 +24,7 @@ class AWSRestXMLHTTPResponseBindingErrorGeneratorTests {
         val expectedContents = """
 enum GreetingWithErrorsOutputError {
 
-    static func httpError(from httpResponse: SmithyHTTPAPI.HttpResponse) async throws -> Swift.Error {
+    static func httpError(from httpResponse: SmithyHTTPAPI.HTTPResponse) async throws -> Swift.Error {
         let data = try await httpResponse.data()
         let responseReader = try SmithyXML.Reader.from(data: data)
         let baseError = try AWSClientRuntime.RestXMLError(httpResponse: httpResponse, responseReader: responseReader, noErrorWrapping: false)
@@ -85,7 +85,7 @@ public struct ComplexXMLError: ClientRuntime.ModeledError, AWSClientRuntime.AWSS
     public static var fault: ClientRuntime.ErrorFault { .client }
     public static var isRetryable: Swift.Bool { false }
     public static var isThrottling: Swift.Bool { false }
-    public internal(set) var httpResponse = SmithyHTTPAPI.HttpResponse()
+    public internal(set) var httpResponse = SmithyHTTPAPI.HTTPResponse()
     public internal(set) var message: Swift.String?
     public internal(set) var requestID: Swift.String?
 

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/restxml/serde/S3UnwrappedXMLOutputTraitTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/restxml/serde/S3UnwrappedXMLOutputTraitTests.kt
@@ -17,7 +17,7 @@ class S3UnwrappedXMLOutputTraitTests {
         val expectedContents = """
 extension GetBucketLocationOutput {
 
-    static func httpOutput(from httpResponse: SmithyHTTPAPI.HttpResponse) async throws -> GetBucketLocationOutput {
+    static func httpOutput(from httpResponse: SmithyHTTPAPI.HTTPResponse) async throws -> GetBucketLocationOutput {
         let data = try await httpResponse.data()
         let responseReader = try SmithyXML.Reader.from(data: data)
         let reader = responseReader.unwrap()


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1381

## Description of changes
Accommodates the renames performed in https://github.com/smithy-lang/smithy-swift/pull/785 .

Also: disabled an ill-advised Swiftlint rule.  See discussion: https://github.com/realm/SwiftLint/issues/5263

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.