### PR TITLE
feat: Re-export SmithyIdentity components to hide Smithy dependency

### DIFF
--- a/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentity.swift
+++ b/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentity.swift
@@ -1,0 +1,13 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import struct SmithyIdentity.AWSCredentialIdentity
+
+/// A type representing AWS credentials for authenticating with an AWS service
+///
+/// For more information see [AWS security credentials](https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html#AccessKeys)
+public typealias AWSCredentialIdentity = SmithyIdentity.AWSCredentialIdentity

--- a/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/CustomAWSCredentialIdentityResolver.swift
+++ b/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/CustomAWSCredentialIdentityResolver.swift
@@ -1,0 +1,11 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import struct SmithyIdentity.CustomAWSCredentialIdentityResolver
+
+/// A credential identity resolver that provides a fixed set of credentials
+public typealias CustomAWSCredentialIdentityResolver = SmithyIdentity.CustomAWSCredentialIdentityResolver

--- a/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/StaticAWSCredentialIdentityResolver.swift
+++ b/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/StaticAWSCredentialIdentityResolver.swift
@@ -1,0 +1,11 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import struct SmithyIdentity.StaticAWSCredentialIdentityResolver
+
+/// A credential identity resolver that provides a fixed set of credentials
+public typealias StaticAWSCredentialIdentityResolver = SmithyIdentity.StaticAWSCredentialIdentityResolver


### PR DESCRIPTION
## Issue \#
#1691

## Description of changes
`AWSSDKIdentity` re-exports the AWS credential-related types in `SmithyIdentity` to simplify the user experience and place all SDK identity providers in one place.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.