### PR TITLE
feat: Ship patch versions for aws-sdk-swift

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/AWSSDKSwiftCLI/Subcommands/PrepareRelease.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/AWSSDKSwiftCLI/Subcommands/PrepareRelease.swift
@@ -72,7 +72,7 @@ struct PrepareRelease {
     let sourceCodeArtifactId: String
     
     typealias DiffChecker = (_ branch: String, _ version: Version) throws -> Bool
-    /// Returns true if the repsoitory has changes given the current branch and the version to compare, otherwise returns false
+    /// Returns true if the repository has changes given the current branch and the version to compare, otherwise returns false
     let diffChecker: DiffChecker
     
     /// Prepares a release for the specified repository.
@@ -144,7 +144,13 @@ struct PrepareRelease {
     /// - Parameter previousVersion: The version of the previous release
     /// - Returns: A new version to be used for this release
     func createNewVersion(_ previousVersion: Version) throws -> Version {
-        let newVersion = previousVersion.incrementingMinor()
+        let newVersion: Version
+        switch repoType {
+        case .awsSdkSwift:
+            newVersion = previousVersion.incrementingPatch()
+        case .smithySwift:
+            newVersion = previousVersion.incrementingMinor()
+        }
         do {
             try "\(newVersion)".write(toFile: "Package.version" , atomically: true, encoding: .utf8)
         } catch {

--- a/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Commands/PrepareReleaseTests.swift
+++ b/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Commands/PrepareReleaseTests.swift
@@ -32,10 +32,10 @@ class PrepareReleaseTests: CLITestCase {
         }
         ProcessRunner.testRunner = runner
         let previousVersion = try Version("1.2.3")
-        let newVersion = try Version("1.3.0")
+        let newVersion = try Version("1.2.4")
         createPackageVersion(previousVersion)
         
-        let subject = PrepareRelease.mock(diffChecker: { _,_ in true })
+        let subject = PrepareRelease.mock(repoType: .awsSdkSwift, diffChecker: { _,_ in true })
         try! subject.run()
         
         let versionFromFile = try! Version.fromFile("Package.version")
@@ -73,17 +73,28 @@ class PrepareReleaseTests: CLITestCase {
     
     // MARK: createNewVersion()
     
-    func testCreateNewVersion() throws {
+    func testCreateNewSDKVersion() throws {
         let previousVersion = try Version("1.2.3")
-        let newVersion = try Version("1.3.0")
-        let subject = PrepareRelease.mock()
+        let newVersion = try Version("1.2.4")
+        let subject = PrepareRelease.mock(repoType: .awsSdkSwift)
         let result = try! subject.createNewVersion(previousVersion)
         XCTAssertEqual(result, newVersion)
-        
+
         let versionFromFile = try! Version.fromFile("Package.version")
         XCTAssertEqual(versionFromFile, newVersion)
     }
-    
+
+    func testCreateNewSmithySwiftVersion() throws {
+        let previousVersion = try Version("1.2.3")
+        let newVersion = try Version("1.3.0")
+        let subject = PrepareRelease.mock(repoType: .smithySwift)
+        let result = try! subject.createNewVersion(previousVersion)
+        XCTAssertEqual(result, newVersion)
+
+        let versionFromFile = try! Version.fromFile("Package.version")
+        XCTAssertEqual(versionFromFile, newVersion)
+    }
+
     // MARK: getPreviousVersion()
     
     func testGetPreviousVersionFromPackageVersion() throws {


### PR DESCRIPTION
## Issue \#
#1721

## Description of changes
Patch version will now automatically increment for aws-sdk-swift on a new release instead of minor version.  Since current version is `0.76.0`, the next version after this change would be `0.76.1`.

Minor versions will continue to increment for smithy-swift.

A change to accommodate manual bumps to minor & major version will follow.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.