### PR TITLE
chore: Update to aws-crt-swift 0.36.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -256,7 +256,7 @@ func addResolvedTargets() {
 
 addDependencies(
     clientRuntimeVersion: "0.68.0",
-    crtVersion: "0.33.0"
+    crtVersion: "0.36.0"
 )
 
 // Uncomment this line to exclude runtime unit tests

--- a/Sources/Core/AWSSDKIdentity/Tests/AWSSDKIdentityTests/AWSCredentialIdentityResolverTests/ProcessAWSCredentialIdentityResolverTests.swift
+++ b/Sources/Core/AWSSDKIdentity/Tests/AWSSDKIdentityTests/AWSCredentialIdentityResolverTests/ProcessAWSCredentialIdentityResolverTests.swift
@@ -13,7 +13,7 @@ import struct AWSSDKIdentity.ProcessAWSCredentialIdentityResolver
 // ProcessCredentialsProvider is not useful on iOS platform so this test will remain disabled for now
 #if !os(iOS)
 class ProcessAWSCredentialIdentityResolverTests: XCTestCase {
-    let configPath = Bundle.module.path(forResource: "config", ofType: nil)!
+    let configPath = Bundle.module.path(forResource: "config_with_process", ofType: nil)!
     let credentialsPath = Bundle.module.path(forResource: "credentials", ofType: nil)!
 
     func testGetCredentialsWithDefaultProfile() async throws {

--- a/Sources/Core/AWSSDKIdentity/Tests/AWSSDKIdentityTests/AWSCredentialIdentityResolverTests/ProfileAWSCredentialIdentityResolverTests.swift
+++ b/Sources/Core/AWSSDKIdentity/Tests/AWSSDKIdentityTests/AWSCredentialIdentityResolverTests/ProfileAWSCredentialIdentityResolverTests.swift
@@ -10,8 +10,9 @@ import struct AWSSDKIdentity.ProfileAWSCredentialIdentityResolver
 @_spi(FileBasedConfig) @testable import AWSClientRuntime
 
 class ProfileAWSCredentialIdentityResolverTests: XCTestCase {
-        let configPath = Bundle.module.path(forResource: "config", ofType: nil)!
-        let credentialsPath = Bundle.module.path(forResource: "credentials", ofType: nil)!
+    let configPath = Bundle.module.path(forResource: "config", ofType: nil)!
+    let configWithProcessPath = Bundle.module.path(forResource: "config_with_process", ofType: nil)!
+    let credentialsPath = Bundle.module.path(forResource: "credentials", ofType: nil)!
     
     func testGetCredentialsWithDefaultProfile() async throws {
         let subject = try ProfileAWSCredentialIdentityResolver(
@@ -19,11 +20,22 @@ class ProfileAWSCredentialIdentityResolverTests: XCTestCase {
             credentialsFilePath: credentialsPath
         )
         let credentials = try await subject.getIdentity()
-        
+
         XCTAssertEqual(credentials.accessKey, "access_key_default_cred")
         XCTAssertEqual(credentials.secret, "secret_default_cred")
     }
-    
+
+    func testGetCredentialsWithDefaultProfileContainingProcess() async throws {
+        let subject = try ProfileAWSCredentialIdentityResolver(
+            configFilePath: configWithProcessPath,
+            credentialsFilePath: credentialsPath
+        )
+        let credentials = try await subject.getIdentity()
+
+        XCTAssertEqual(credentials.accessKey, "AccessKey123")
+        XCTAssertEqual(credentials.secret, "SecretAccessKey123")
+    }
+
     func testGetCredentialsWithNamedProfileFromConfigFile() async throws {
         let subject = try ProfileAWSCredentialIdentityResolver(
             profileName: "credentials-provider-config-tests-profile",

--- a/Sources/Core/AWSSDKIdentity/Tests/AWSSDKIdentityTests/Resources/config_with_process
+++ b/Sources/Core/AWSSDKIdentity/Tests/AWSSDKIdentityTests/Resources/config_with_process
@@ -1,6 +1,7 @@
 [default]
 aws_access_key_id = access_key_default_config
 aws_secret_access_key = secret_default_config
+credential_process = echo '{"Version": 1, "AccessKeyId": "AccessKey123", "SecretAccessKey": "SecretAccessKey123", "SessionToken": "SessionToken123","Expiration":"2020-02-25T06:03:31Z"}'
 
 [profile credentials-provider-config-tests-profile]
 aws_access_key_id = access_key_profile_config
@@ -9,3 +10,4 @@ aws_secret_access_key = secret_profile_config
 [profile credentials-process-config-tests-profile]
 aws_access_key_id = access_key_profile_config
 aws_secret_access_key = secret_profile_config
+credential_process = echo '{"Version": 1, "AccessKeyId": "AccessKey123", "SecretAccessKey": "SecretAccessKey123", "SessionToken": "SessionToken123","Expiration":"2020-02-25T06:03:31Z"}'

--- a/packageDependencies.plist
+++ b/packageDependencies.plist
@@ -5,7 +5,7 @@
 	<key>awsCRTSwiftBranch</key>
 	<string>main</string>
 	<key>awsCRTSwiftVersion</key>
-	<string>0.33.0</string>
+	<string>0.36.0</string>
 	<key>clientRuntimeBranch</key>
 	<string>main</string>
 	<key>clientRuntimeVersion</key>


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/1739

## Description of changes
Uses aws-crt-swift 0.36.0.

There is a change in profile credential provider behavior: profile credential provider now uses a process for obtaining credentials if one is provided in the profile.  (This has been confirmed with @waahm7 as an intentional change in credential resolution behavior).  Tests have been updated to reflect the new behavior, and profile resolution tests are now provided with and without 

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.