### PR TITLE
chore: Scale concurrent integration tests from 100x to 20x

### DIFF
--- a/IntegrationTests/Services/AWSS3IntegrationTests/S3ConcurrentTests.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/S3ConcurrentTests.swift
@@ -17,15 +17,15 @@ class S3ConcurrentTests: S3XCTestCase {
     let MEGABYTE: Double = 1_000_000
 
     // Payload below 1,048,576 bytes; sends as simple data payload
-    func test_100x_1MB_getObject() async throws {
+    func test_20x_1MB_getObject() async throws {
         fileData = try generateDummyTextData(numMegabytes: MEGABYTE)
-        try await repeatConcurrentlyWithArgs(count: 100, test: getObject, args: fileData!)
+        try await repeatConcurrentlyWithArgs(count: 20, test: getObject, args: fileData!)
     }
 
     // Payload over 1,048,576 bytes; uses aws chunked encoding & flexible checksum
-    func test_100x_1_5MB_getObject() async throws {
+    func test_20x_1_5MB_getObject() async throws {
         fileData = try generateDummyTextData(numMegabytes: MEGABYTE * 1.5)
-        try await repeatConcurrentlyWithArgs(count: 100, test: getObject, args: fileData!)
+        try await repeatConcurrentlyWithArgs(count: 20, test: getObject, args: fileData!)
     }
 
     /* Helper functions */


### PR DESCRIPTION
## Issue \#

## Description of changes
Reduce concurrent runs of S3 concurrent integration tests from 100x to 20x to try to reduce spurious failures.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.