### PR TITLE
chore: Use macOS 15 with Xcode 16 on CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,12 +22,12 @@ jobs:
           - Xcode_16
         destination:
           - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-          - 'platform=iOS Simulator,OS=18.0,name=iPhone 15'
+          - 'platform=iOS Simulator,OS=18.0,name=iPhone 16'
           - 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=tvOS Simulator,OS=18.0,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro'
           - 'platform=visionOS Simulator,OS=2.0,name=Apple Vision Pro'
-          - 'platform=OS X'
+          - 'platform=macOS'
         exclude:
           # Don't run old macOS with new Xcode
           - runner: macos-13
@@ -45,7 +45,7 @@ jobs:
           # Don't run new simulators with old Xcode
           - destination: 'platform=tvOS Simulator,OS=18.0,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_15.2
-          - destination: 'platform=iOS Simulator,OS=18.0,name=iPhone 15'
+          - destination: 'platform=iOS Simulator,OS=18.0,name=iPhone 16'
             xcode: Xcode_15.2
           - destination: 'platform=visionOS Simulator,OS=2.0,name=Apple Vision Pro'
             xcode: Xcode_15.2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
         # This matrix runs tests on iOS sim & Mac, on oldest & newest supported Xcodes
         runner:
           - macos-13
-          - macos-14
+          - macos-15
         xcode:
           - Xcode_15.2
           - Xcode_16
@@ -33,7 +33,7 @@ jobs:
           - runner: macos-13
             xcode: Xcode_16
           # Don't run new macOS with old Xcode
-          - runner: macos-14
+          - runner: macos-15
             xcode: Xcode_15.2
           # Don't run old simulators with new Xcode
           - destination: 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -19,24 +19,24 @@ jobs:
         # This matrix runs tests on iOS sim & Mac, on oldest & newest supported Xcodes
         runner:
           - macos-13
-          - macos-14
+          - macos-15
         xcode:
           - Xcode_15.2
           - Xcode_16
         destination:
           - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-          - 'platform=iOS Simulator,OS=18.0,name=iPhone 15'
+          - 'platform=iOS Simulator,OS=18.0,name=iPhone 16'
           - 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=tvOS Simulator,OS=18.0,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro'
           - 'platform=visionOS Simulator,OS=2.0,name=Apple Vision Pro'
-          - 'platform=OS X'
+          - 'platform=macOS'
         exclude:
           # Don't run old macOS with new Xcode
           - runner: macos-13
             xcode: Xcode_16
           # Don't run new macOS with old Xcode
-          - runner: macos-14
+          - runner: macos-15
             xcode: Xcode_15.2
           # Don't run old simulators with new Xcode
           - destination: 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
@@ -48,7 +48,7 @@ jobs:
           # Don't run new simulators with old Xcode
           - destination: 'platform=tvOS Simulator,OS=18.0,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_15.2
-          - destination: 'platform=iOS Simulator,OS=18.0,name=iPhone 15'
+          - destination: 'platform=iOS Simulator,OS=18.0,name=iPhone 16'
             xcode: Xcode_15.2
           - destination: 'platform=visionOS Simulator,OS=2.0,name=Apple Vision Pro'
             xcode: Xcode_15.2


### PR DESCRIPTION
## Description of changes
Github intends to remove Xcode 16 from the `macos-14` CI runner on Oct. 28:
https://github.com/actions/runner-images/issues/10703
Accordingly, we need to move our Xcode 16-based builds onto the `macos-15` CI runner by that date.

Per the reference above, the `macos-13` runner will remain unchanged so no need to change our builds that run there.

This PR updates Xcode 16 builds to use the `macos-15` runner instead of `macos-14`.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.