### PR TITLE
chore: Remove "dev preview" notice from API docs

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/DocIndex.Base.md
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/DocIndex.Base.md
@@ -4,6 +4,4 @@ A pure-Swift SDK for accessing all published AWS services.
 
 ## Overview
 
-**The AWS SDK for Swift is currently in developer preview and is intended strictly for feedback purposes only. Do not use this SDK for production workloads. Refer to the SDK [stability guidelines](docs/stability.md) for more detail.**
-
 This SDK is open-source.  Code is available on Github [here](https://github.com/awslabs/aws-sdk-swift).


### PR DESCRIPTION
## Description of changes
https://github.com/awslabs/aws-sdk-swift/pull/1792 attempted to remove the "dev preview" notice, but removed it from the generated index only, so that the notice returned when the API doc index was regenerated.

This PR changes the "base" content of the API doc generated index so that the deletion will be applied to all future API doc indexes.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.