### PR TITLE
fix: Make Context thread-safe

### DIFF
--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/Sha256TreeHashMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/Sha256TreeHashMiddleware.swift
@@ -46,7 +46,7 @@ public struct Sha256TreeHashMiddleware<OperationStackInput, OperationStackOutput
             if let treeHash = treeHash, let linearHash = linearHash {
                 builder.withHeader(name: X_AMZ_SHA256_TREE_HASH_HEADER_NAME, value: treeHash)
                 // provide the value but let CRT add the SHA256 header during signing
-                context.attributes.set(key: AttributeKey(name: X_AMZ_CONTENT_SHA256_HEADER_NAME), value: linearHash)
+                context.set(key: AttributeKey(name: X_AMZ_CONTENT_SHA256_HEADER_NAME), value: linearHash)
             }
         case .noStream:
             break

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/UserAgent/BusinessMetrics.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/UserAgent/BusinessMetrics.swift
@@ -48,11 +48,11 @@ private extension String {
 
 public extension Context {
     var businessMetrics: Dictionary<String, String> {
-        get { attributes.get(key: businessMetricsKey) ?? [:] }
+        get { get(key: businessMetricsKey) ?? [:] }
         set(newPair) {
             var combined = businessMetrics
             combined.merge(newPair) { (_, new) in new }
-            attributes.set(key: businessMetricsKey, value: combined)
+            set(key: businessMetricsKey, value: combined)
         }
     }
 }

--- a/Sources/Core/AWSClientRuntime/Tests/AWSClientRuntimeTests/Middlewares/FlexibleChecksumsMiddlewareTests.swift
+++ b/Sources/Core/AWSClientRuntime/Tests/AWSClientRuntimeTests/Middlewares/FlexibleChecksumsMiddlewareTests.swift
@@ -267,7 +267,7 @@ class FlexibleChecksumsMiddlewareTests: XCTestCase {
             "Stream is not 'chunked eligible'",
             file: file, line: line
         )
-        if let validatedChecksum = self.builtContext.attributes.get(key: AttributeKey<String>(name: "ChecksumHeaderValidated")), validatedChecksum == expectedHeader {
+        if let validatedChecksum = self.builtContext.get(key: AttributeKey<String>(name: "ChecksumHeaderValidated")), validatedChecksum == expectedHeader {
             isChecksumValidated = true
         }
         if expectedChecksum != "" {
@@ -304,7 +304,7 @@ class FlexibleChecksumsMiddlewareTests: XCTestCase {
             }
         }
 
-        if let validatedChecksum = self.builtContext.attributes.get(key: AttributeKey<String>(name: "ChecksumHeaderValidated")), validatedChecksum == expectedHeader {
+        if let validatedChecksum = self.builtContext.get(key: AttributeKey<String>(name: "ChecksumHeaderValidated")), validatedChecksum == expectedHeader {
             isChecksumValidated = true
         }
         if expectedChecksum != "" {
@@ -329,7 +329,7 @@ class FlexibleChecksumsMiddlewareTests: XCTestCase {
             }
         } else {
             try await handleMiddleware()
-            validatedChecksum = self.builtContext.attributes.get(key: AttributeKey<String>(name: "ChecksumHeaderValidated"))
+            validatedChecksum = self.builtContext.get(key: AttributeKey<String>(name: "ChecksumHeaderValidated"))
             if validatedChecksum != nil && validatedChecksum == expectedValidationHeader {
                 isChecksumValidated = true
             }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/RulesBasedAuthSchemeResolverGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/RulesBasedAuthSchemeResolverGenerator.kt
@@ -131,7 +131,7 @@ class RulesBasedAuthSchemeResolverGenerator {
                 }
 
                 // Get endpoint param from middleware context
-                openBlock("guard let endpointParam = context.attributes.get(key: \$N<EndpointParams>(name: \"EndpointParams\")) else {", "}", SmithyTypes.AttributeKey) {
+                openBlock("guard let endpointParam = context.get(key: \$N<EndpointParams>(name: \"EndpointParams\")) else {", "}", SmithyTypes.AttributeKey) {
                     write("throw \$N.dataNotFound(\"Endpoint param not configured in middleware context for rules-based auth scheme resolver params construction.\")", SmithyTypes.ClientError)
                 }
 

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/OperationEndpointResolverMiddleware.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/middleware/OperationEndpointResolverMiddleware.kt
@@ -52,7 +52,7 @@ class OperationEndpointResolverMiddleware(
 
         // Write code that saves endpoint params to middleware context for use in auth scheme middleware when using rules-based auth scheme resolvers
         if (AuthSchemeResolverGenerator.usesRulesBasedAuthResolver(ctx)) {
-            writer.write("context.attributes.set(key: \$N<EndpointParams>(name: \"EndpointParams\"), value: endpointParams)", SmithyTypes.AttributeKey)
+            writer.write("context.set(key: \$N<EndpointParams>(name: \"EndpointParams\"), value: endpointParams)", SmithyTypes.AttributeKey)
         }
 
         super.renderSpecific(ctx, writer, op, operationStackName, "applyEndpoint")

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/PresignerGeneratorTests.kt
@@ -270,7 +270,7 @@ extension PutObjectInput {
         builder.retryErrorInfoProvider(AWSClientRuntime.AWSRetryErrorInfoProvider.errorInfo(for:))
         builder.applySigner(ClientRuntime.SignerMiddleware<PutObjectOutput>())
         let endpointParams = EndpointParams()
-        context.attributes.set(key: Smithy.AttributeKey<EndpointParams>(name: "EndpointParams"), value: endpointParams)
+        context.set(key: Smithy.AttributeKey<EndpointParams>(name: "EndpointParams"), value: endpointParams)
         builder.applyEndpoint(AWSClientRuntime.EndpointResolverMiddleware<PutObjectOutput, EndpointParams>(endpointResolverBlock: { [config] in try config.endpointResolver.resolve(params: ${'$'}0) }, endpointParams: endpointParams))
         builder.interceptors.add(AWSClientRuntime.UserAgentMiddleware<PutObjectInput, PutObjectOutput>(serviceID: serviceName, version: S3Client.version, config: config))
         builder.selectAuthScheme(ClientRuntime.AuthSchemeMiddleware<PutObjectOutput>())

--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/RulesBasedAuthSchemeResolverGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/customizations/RulesBasedAuthSchemeResolverGeneratorTests.kt
@@ -129,7 +129,7 @@ public struct DefaultS3AuthSchemeResolver: S3AuthSchemeResolver {
         guard let opName = context.getOperation() else {
             throw Smithy.ClientError.dataNotFound("Operation name not configured in middleware context for auth scheme resolver params construction.")
         }
-        guard let endpointParam = context.attributes.get(key: Smithy.AttributeKey<EndpointParams>(name: "EndpointParams")) else {
+        guard let endpointParam = context.get(key: Smithy.AttributeKey<EndpointParams>(name: "EndpointParams")) else {
             throw Smithy.ClientError.dataNotFound("Endpoint param not configured in middleware context for rules-based auth scheme resolver params construction.")
         }
         return S3AuthSchemeResolverParameters(operation: opName)


### PR DESCRIPTION
## Description of changes
https://github.com/smithy-lang/smithy-swift/pull/853 changes the `Context` type to make it thread-safe.

This PR gets/sets `Context` attributes by accessing the `Context` directly (which now has thread-safe accessors) rather than by accessing the Context's `attributes` property (which has now been made private).

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.