### PR TITLE
chore: Disable CI on AL2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -139,7 +139,6 @@ jobs:
       matrix:
         os:
           - jammy
-          - amazonlinux2
         version:
           - "5.9"
           - "6.0"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -141,7 +141,6 @@ jobs:
       matrix:
         os:
           - jammy
-          - amazonlinux2
         version:
           - "5.9"
           - "6.0"


### PR DESCRIPTION
## Description of changes
[Github Runner v2.321.0](https://github.com/actions/runner/releases/tag/v2.321.0) removed Node 16.  Since AL2 is not compatible with Node 20 due to the glibc version it uses, several important Github Actions may no longer run on AL2.

This PR disables CI on AL2.  Linux is still covered by running Ubuntu tests.  It is likely that we will not be able to test Amazon Linux on Github again until Swift adopts a newer version of Amazon Linux, i.e. 2023.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.