### PR TITLE
chore: Bump aws-crt-swift version to 0.40.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ import PackageDescription
 // MARK: - Dynamic Content
 
 let clientRuntimeVersion: Version = "0.98.0"
-let crtVersion: Version = "0.39.0"
+let crtVersion: Version = "0.40.0"
 
 let excludeRuntimeUnitTests = false
 

--- a/Sources/Core/AWSSDKIdentity/Tests/AWSSDKIdentityTests/AWSCredentialIdentityResolverTests/STSAssumeRoleAWSCredentialIdentityResolverTests.swift
+++ b/Sources/Core/AWSSDKIdentity/Tests/AWSSDKIdentityTests/AWSCredentialIdentityResolverTests/STSAssumeRoleAWSCredentialIdentityResolverTests.swift
@@ -11,19 +11,6 @@ import struct AWSSDKIdentity.EnvironmentAWSCredentialIdentityResolver
 import enum Smithy.ClientError
 
 class STSAssumeRoleAWSCredentialIdentityResolverTests: XCTestCase {
-    func testInit() {
-        // For now we'll lean on CRT to test the implementation of this provider
-        // so just assert that we created the provider without crashing.
-        // Note: The underlying CRT provider throws an error if the role is invalid,
-        // so we'll assert that is the case here since mocking out a valid STS Assume Role is out scope for now.
-        // TODO: Add an integration test for this provider
-        XCTAssertThrowsError(try STSAssumeRoleAWSCredentialIdentityResolver(
-            awsCredentialIdentityResolver: try EnvironmentAWSCredentialIdentityResolver(),
-            roleArn: "invalid-role",
-            sessionName: "some-session"
-        ))
-    }
-
     func testInvalidSessionName() async throws {
         XCTAssertThrowsError(try STSAssumeRoleAWSCredentialIdentityResolver(
                 awsCredentialIdentityResolver: try EnvironmentAWSCredentialIdentityResolver(),

--- a/packageDependencies.plist
+++ b/packageDependencies.plist
@@ -5,7 +5,7 @@
 	<key>awsCRTSwiftBranch</key>
 	<string>main</string>
 	<key>awsCRTSwiftVersion</key>
-	<string>0.39.0</string>
+	<string>0.40.0</string>
 	<key>clientRuntimeBranch</key>
 	<string>main</string>
 	<key>clientRuntimeVersion</key>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- New v0.40.0 of aws-crt-swift fixes a bug with the underlying sts assume role credentials provider where initialization would throw error due to missing bootstrap argument. Link to release: https://github.com/awslabs/aws-crt-swift/releases/tag/v0.40.0
- Delete a test case that wrongly depends on this bug behavior.

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.