### PR TITLE
fix: Fix signing region source

### DIFF
--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Endpoints/EndpointResolverMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Endpoints/EndpointResolverMiddleware.swift
@@ -80,20 +80,6 @@ extension EndpointResolverMiddleware: ApplyEndpoint {
             builder.withProtocol(protocolType)
         }
 
-        if let signingName = signingName {
-            attributes.signingName = signingName
-            attributes.selectedAuthScheme = selectedAuthScheme?.getCopyWithUpdatedSigningProperty(
-                key: SigningPropertyKeys.signingName, value: signingName
-            )
-        }
-
-        if let signingRegion = signingRegion {
-            attributes.signingRegion = signingRegion
-            attributes.selectedAuthScheme = selectedAuthScheme?.getCopyWithUpdatedSigningProperty(
-                key: SigningPropertyKeys.signingRegion, value: signingRegion
-            )
-        }
-
         if let signingAlgorithm = signingAlgorithm {
             attributes.signingAlgorithm = SigningAlgorithm(rawValue: signingAlgorithm)
         }

--- a/Sources/Core/AWSSDKHTTPAuth/Sources/AWSSDKHTTPAuth/SigV4AAuthScheme.swift
+++ b/Sources/Core/AWSSDKHTTPAuth/Sources/AWSSDKHTTPAuth/SigV4AAuthScheme.swift
@@ -34,7 +34,7 @@ public struct SigV4AAuthScheme: AuthScheme {
         updatedSigningProperties.set(key: SigningPropertyKeys.signingName, value: context.signingName)
         updatedSigningProperties.set(
             key: SigningPropertyKeys.signingRegion,
-            value: signingProperties.get(key: SigningPropertyKeys.signingRegion)
+            value: signingProperties.get(key: SigningPropertyKeys.signingRegion) ?? context.signingRegion
         )
 
         // Set expiration flag

--- a/Sources/Core/AWSSDKHTTPAuth/Sources/AWSSDKHTTPAuth/SigV4AAuthScheme.swift
+++ b/Sources/Core/AWSSDKHTTPAuth/Sources/AWSSDKHTTPAuth/SigV4AAuthScheme.swift
@@ -32,7 +32,10 @@ public struct SigV4AAuthScheme: AuthScheme {
 
         // Set signing name and signing region flags
         updatedSigningProperties.set(key: SigningPropertyKeys.signingName, value: context.signingName)
-        updatedSigningProperties.set(key: SigningPropertyKeys.signingRegion, value: context.signingRegion)
+        updatedSigningProperties.set(
+            key: SigningPropertyKeys.signingRegion,
+            value: signingProperties.get(key: SigningPropertyKeys.signingRegion)
+        )
 
         // Set expiration flag
         //

--- a/Sources/Core/AWSSDKHTTPAuth/Sources/AWSSDKHTTPAuth/SigV4AuthScheme.swift
+++ b/Sources/Core/AWSSDKHTTPAuth/Sources/AWSSDKHTTPAuth/SigV4AuthScheme.swift
@@ -41,7 +41,7 @@ public struct SigV4AuthScheme: AuthScheme {
         updatedSigningProperties.set(key: SigningPropertyKeys.signingName, value: context.signingName)
         updatedSigningProperties.set(
             key: SigningPropertyKeys.signingRegion,
-            value: signingProperties.get(key: SigningPropertyKeys.signingRegion)
+            value: signingProperties.get(key: SigningPropertyKeys.signingRegion) ?? context.signingRegion
         )
 
         // Set expiration flag

--- a/Sources/Core/AWSSDKHTTPAuth/Sources/AWSSDKHTTPAuth/SigV4AuthScheme.swift
+++ b/Sources/Core/AWSSDKHTTPAuth/Sources/AWSSDKHTTPAuth/SigV4AuthScheme.swift
@@ -39,7 +39,10 @@ public struct SigV4AuthScheme: AuthScheme {
 
         // Set signing name and signing region flags
         updatedSigningProperties.set(key: SigningPropertyKeys.signingName, value: context.signingName)
-        updatedSigningProperties.set(key: SigningPropertyKeys.signingRegion, value: context.signingRegion)
+        updatedSigningProperties.set(
+            key: SigningPropertyKeys.signingRegion,
+            value: signingProperties.get(key: SigningPropertyKeys.signingRegion)
+        )
 
         // Set expiration flag
         //


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Get signing region from resolved auth option first, instead of getting it from the context first. This removes the need to override signing region in the endpoint resolver middleware as well.
- Below outlines how signing region is resolved and used for rules based auth:
  - `signingRegionSet` property is taken from the endpoint resolved from endpoint rules engine
  - If the property was missing, use signing region configured on request context instead (middleware context / interceptor context)
  - If the property was present, use the first value in that list to sign the request

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.