### PR TITLE
chore: Run repo-sync workflow only in source repo

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,6 @@
 name: Lint
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   git-sync:
+    if: github.repository == 'awslabs/aws-sdk-swift'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
…int CI from running with new commits in main.

<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->
1934

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Adds if condition check on repo-sync workflow so it only runs in source repo (it running in private repo is no-op bc it just fails anyways, but each new commit in private repo gets marked with red X which doesn't look good)
- Removes new commit to main triggering lint workflow

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.