### PR TITLE
chore: Trim whitespace before parsing Version

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSCLIUtils/Version.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSCLIUtils/Version.swift
@@ -22,7 +22,7 @@ public struct Version: Equatable {
     }
 
     public init(_ value: String) throws {
-        let components = value.split(separator: ".")
+        let components = value.trimmingCharacters(in: .whitespacesAndNewlines).split(separator: ".")
         guard components.count == 3 else {
             throw Error("Version does not have three components")
         }

--- a/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Utils/VersionUtilsTests.swift
+++ b/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Utils/VersionUtilsTests.swift
@@ -10,7 +10,14 @@ import AWSCLIUtils
 import XCTest
 
 class VersionUtilsTests: XCTestCase {
-    
+
+    func testIgnoresLeadingAndTrailingWhitespace() throws {
+        try XCTAssertEqual(
+            Version("\r\n\t 1.2.1\r\n\t "),
+            Version("1.2.1")
+        )
+    }
+
     func testIncrementingMajor() throws {
         try XCTAssertEqual(
             Version("1.2.1").incrementingMajor(),


### PR DESCRIPTION
## Description of changes
- In CLI tools, trim whitespace before parsing project version, i.e. from the `Package.version` and `Package.version.next` files.
- Test is added to verify whitespace is successfully trimmed.

This will make the tools more forgiving when versions are inadvertently saved with whitespace, i.e. by text editors.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.