### PR TITLE
chore: Disable the 25x bidirectional streaming test on Linux

### DIFF
--- a/IntegrationTests/Services/AWSTranscribeStreamingIntegrationTests/TranscribeStreamingTests.swift
+++ b/IntegrationTests/Services/AWSTranscribeStreamingIntegrationTests/TranscribeStreamingTests.swift
@@ -19,16 +19,20 @@ final class TranscribeStreamingTests: XCTestCase {
         try await attempt()
     }
 
+#if !os(Linux)
+
     // Concurrent stream transcription frequently fails on the CRT HTTP client with errors
     // such as:
-    // code: 2058, message: "The connection has closed or is closing."
     // code: 2087, message: "Stream acquisition failed because stream manager failed to acquire a connection"
+    // This test is disabled on Linux until a solution can be found for this error.
     func test_25xConcurrent_streamTranscription() async throws {
         // By default the TranscribeStreaming service allows 25 concurrent transcriptions.
         // More than that (which can happen when multiple test runs are being performed) will result
         // in throttling / resource exceeded errors, which may be retried (see retry logic below.)
         try await repeatConcurrently(count: 25, test: attempt)
     }
+
+#endif
 
     // MARK: - Private / implementation methods
 


### PR DESCRIPTION
## Description of changes
The 25x concurrent test intermittently fails on Linux due to an undiagnosed error in the CRT HTTP client.

This PR disables that test on Linux until a fix is ready.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.