### PR TITLE
fix: Refine rules for members of HTTP body per-protocol

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/awsjson/AWSJSON1_0ProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/awsjson/AWSJSON1_0ProtocolGenerator.kt
@@ -15,7 +15,6 @@ import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.traits.HostLabelTrait
 import software.amazon.smithy.swift.codegen.integration.HttpBindingResolver
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
-import software.amazon.smithy.swift.codegen.integration.isInHttpBody
 import software.amazon.smithy.swift.codegen.integration.isEventStreaming
 import software.amazon.smithy.swift.codegen.integration.middlewares.ContentTypeMiddleware
 import software.amazon.smithy.swift.codegen.integration.middlewares.OperationInputBodyMiddleware
@@ -60,8 +59,11 @@ class AWSJSON1_0ProtocolGenerator : AWSHTTPBindingProtocolGenerator(AWSJSONCusto
         )
     }
 
-    override fun httpBodyMembers(ctx: ProtocolGenerator.GenerationContext, shape: Shape): List<MemberShape> {
-        return shape
+    override fun httpBodyMembers(
+        ctx: ProtocolGenerator.GenerationContext,
+        shape: Shape,
+    ): List<MemberShape> =
+        shape
             .members()
             // The only place an input member can be bound to in AWS JSON other than the body
             // is the host prefix, using the host label trait.
@@ -70,5 +72,4 @@ class AWSJSON1_0ProtocolGenerator : AWSHTTPBindingProtocolGenerator(AWSJSONCusto
             // with streaming member excluded during encoding the input struct.
             .filter { !it.targetOrSelf(ctx.model).isEventStreaming }
             .toList()
-    }
 }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/awsjson/AWSJSON1_0ProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/awsjson/AWSJSON1_0ProtocolGenerator.kt
@@ -12,13 +12,11 @@ import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
-import software.amazon.smithy.model.traits.HostLabelTrait
 import software.amazon.smithy.swift.codegen.integration.HttpBindingResolver
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.isEventStreaming
 import software.amazon.smithy.swift.codegen.integration.middlewares.ContentTypeMiddleware
 import software.amazon.smithy.swift.codegen.integration.middlewares.OperationInputBodyMiddleware
-import software.amazon.smithy.swift.codegen.model.hasTrait
 import software.amazon.smithy.swift.codegen.model.targetOrSelf
 
 @Suppress("ktlint:standard:class-naming")
@@ -65,9 +63,6 @@ class AWSJSON1_0ProtocolGenerator : AWSHTTPBindingProtocolGenerator(AWSJSONCusto
     ): List<MemberShape> =
         shape
             .members()
-            // The only place an input member can be bound to in AWS JSON other than the body
-            // is the host prefix, using the host label trait.
-            .filter { !it.hasTrait<HostLabelTrait>() }
             // For RPC protocols that support event streaming, we need to send initial request
             // with streaming member excluded during encoding the input struct.
             .filter { !it.targetOrSelf(ctx.model).isEventStreaming }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/awsjson/AWSJSON1_0ProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/awsjson/AWSJSON1_0ProtocolGenerator.kt
@@ -8,12 +8,19 @@ package software.amazon.smithy.aws.swift.codegen.protocols.awsjson
 import software.amazon.smithy.aws.swift.codegen.AWSHTTPBindingProtocolGenerator
 import software.amazon.smithy.aws.swift.codegen.middleware.AWSXAmzTargetMiddleware
 import software.amazon.smithy.aws.traits.protocols.AwsJson1_0Trait
+import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.traits.HostLabelTrait
 import software.amazon.smithy.swift.codegen.integration.HttpBindingResolver
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
+import software.amazon.smithy.swift.codegen.integration.isInHttpBody
+import software.amazon.smithy.swift.codegen.integration.isEventStreaming
 import software.amazon.smithy.swift.codegen.integration.middlewares.ContentTypeMiddleware
 import software.amazon.smithy.swift.codegen.integration.middlewares.OperationInputBodyMiddleware
+import software.amazon.smithy.swift.codegen.model.hasTrait
+import software.amazon.smithy.swift.codegen.model.targetOrSelf
 
 @Suppress("ktlint:standard:class-naming")
 class AWSJSON1_0ProtocolGenerator : AWSHTTPBindingProtocolGenerator(AWSJSONCustomizations()) {
@@ -51,5 +58,17 @@ class AWSJSON1_0ProtocolGenerator : AWSHTTPBindingProtocolGenerator(AWSJSONCusto
             operation,
             ContentTypeMiddleware(ctx.model, ctx.symbolProvider, resolver.determineRequestContentType(operation), true),
         )
+    }
+
+    override fun httpBodyMembers(ctx: ProtocolGenerator.GenerationContext, shape: Shape): List<MemberShape> {
+        return shape
+            .members()
+            // The only place an input member can be bound to in AWS JSON other than the body
+            // is the host prefix, using the host label trait.
+            .filter { !it.hasTrait<HostLabelTrait>() }
+            // For RPC protocols that support event streaming, we need to send initial request
+            // with streaming member excluded during encoding the input struct.
+            .filter { !it.targetOrSelf(ctx.model).isEventStreaming }
+            .toList()
     }
 }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/awsjson/AWSJSON1_1ProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/awsjson/AWSJSON1_1ProtocolGenerator.kt
@@ -16,7 +16,6 @@ import software.amazon.smithy.model.traits.HostLabelTrait
 import software.amazon.smithy.swift.codegen.integration.HttpBindingResolver
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.isEventStreaming
-import software.amazon.smithy.swift.codegen.integration.isInHttpBody
 import software.amazon.smithy.swift.codegen.integration.middlewares.ContentTypeMiddleware
 import software.amazon.smithy.swift.codegen.integration.middlewares.OperationInputBodyMiddleware
 import software.amazon.smithy.swift.codegen.model.hasTrait
@@ -58,8 +57,11 @@ class AWSJSON1_1ProtocolGenerator : AWSHTTPBindingProtocolGenerator(AWSJSONCusto
         )
     }
 
-    override fun httpBodyMembers(ctx: ProtocolGenerator.GenerationContext, shape: Shape): List<MemberShape> {
-        return shape
+    override fun httpBodyMembers(
+        ctx: ProtocolGenerator.GenerationContext,
+        shape: Shape,
+    ): List<MemberShape> =
+        shape
             .members()
             // The only place an input member can be bound to in AWS JSON other than the body
             // is the host prefix, using the host label trait.
@@ -68,5 +70,4 @@ class AWSJSON1_1ProtocolGenerator : AWSHTTPBindingProtocolGenerator(AWSJSONCusto
             // with streaming member excluded during encoding the input struct.
             .filter { !it.targetOrSelf(ctx.model).isEventStreaming }
             .toList()
-    }
 }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/awsjson/AWSJSON1_1ProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/awsjson/AWSJSON1_1ProtocolGenerator.kt
@@ -12,13 +12,11 @@ import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
-import software.amazon.smithy.model.traits.HostLabelTrait
 import software.amazon.smithy.swift.codegen.integration.HttpBindingResolver
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.isEventStreaming
 import software.amazon.smithy.swift.codegen.integration.middlewares.ContentTypeMiddleware
 import software.amazon.smithy.swift.codegen.integration.middlewares.OperationInputBodyMiddleware
-import software.amazon.smithy.swift.codegen.model.hasTrait
 import software.amazon.smithy.swift.codegen.model.targetOrSelf
 
 @Suppress("ktlint:standard:class-naming")
@@ -63,9 +61,6 @@ class AWSJSON1_1ProtocolGenerator : AWSHTTPBindingProtocolGenerator(AWSJSONCusto
     ): List<MemberShape> =
         shape
             .members()
-            // The only place an input member can be bound to in AWS JSON other than the body
-            // is the host prefix, using the host label trait.
-            .filter { !it.hasTrait<HostLabelTrait>() }
             // For RPC protocols that support event streaming, we need to send initial request
             // with streaming member excluded during encoding the input struct.
             .filter { !it.targetOrSelf(ctx.model).isEventStreaming }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/awsquery/AWSQueryProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/awsquery/AWSQueryProtocolGenerator.kt
@@ -15,7 +15,6 @@ import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.traits.HostLabelTrait
 import software.amazon.smithy.swift.codegen.integration.HttpBindingResolver
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
-import software.amazon.smithy.swift.codegen.integration.isInHttpBody
 import software.amazon.smithy.swift.codegen.integration.middlewares.ContentTypeMiddleware
 import software.amazon.smithy.swift.codegen.integration.middlewares.OperationInputBodyMiddleware
 import software.amazon.smithy.swift.codegen.model.hasTrait
@@ -54,12 +53,14 @@ open class AWSQueryProtocolGenerator : AWSHTTPBindingProtocolGenerator(AWSQueryC
         )
     }
 
-    override fun httpBodyMembers(ctx: ProtocolGenerator.GenerationContext, shape: Shape): List<MemberShape> {
-        return shape
+    override fun httpBodyMembers(
+        ctx: ProtocolGenerator.GenerationContext,
+        shape: Shape,
+    ): List<MemberShape> =
+        shape
             .members()
             // The only place an input member can be bound to in AWSQuery other than the body
             // is the host prefix, using the host label trait.
             .filter { !it.hasTrait<HostLabelTrait>() }
             .toList()
-    }
 }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/awsquery/AWSQueryProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/awsquery/AWSQueryProtocolGenerator.kt
@@ -12,12 +12,10 @@ import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
-import software.amazon.smithy.model.traits.HostLabelTrait
 import software.amazon.smithy.swift.codegen.integration.HttpBindingResolver
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.middlewares.ContentTypeMiddleware
 import software.amazon.smithy.swift.codegen.integration.middlewares.OperationInputBodyMiddleware
-import software.amazon.smithy.swift.codegen.model.hasTrait
 
 open class AWSQueryProtocolGenerator : AWSHTTPBindingProtocolGenerator(AWSQueryCustomizations()) {
     override val defaultContentType = "application/x-www-form-urlencoded"
@@ -56,11 +54,5 @@ open class AWSQueryProtocolGenerator : AWSHTTPBindingProtocolGenerator(AWSQueryC
     override fun httpBodyMembers(
         ctx: ProtocolGenerator.GenerationContext,
         shape: Shape,
-    ): List<MemberShape> =
-        shape
-            .members()
-            // The only place an input member can be bound to in AWSQuery other than the body
-            // is the host prefix, using the host label trait.
-            .filter { !it.hasTrait<HostLabelTrait>() }
-            .toList()
+    ): List<MemberShape> = shape.members().toList()
 }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/ec2query/EC2QueryProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/ec2query/EC2QueryProtocolGenerator.kt
@@ -15,7 +15,6 @@ import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.traits.HostLabelTrait
 import software.amazon.smithy.swift.codegen.integration.HttpBindingResolver
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
-import software.amazon.smithy.swift.codegen.integration.isInHttpBody
 import software.amazon.smithy.swift.codegen.integration.middlewares.ContentTypeMiddleware
 import software.amazon.smithy.swift.codegen.integration.middlewares.OperationInputBodyMiddleware
 import software.amazon.smithy.swift.codegen.model.hasTrait
@@ -54,12 +53,14 @@ class EC2QueryProtocolGenerator : AWSHTTPBindingProtocolGenerator(EC2QueryCustom
         )
     }
 
-    override fun httpBodyMembers(ctx: ProtocolGenerator.GenerationContext, shape: Shape): List<MemberShape> {
-        return shape
+    override fun httpBodyMembers(
+        ctx: ProtocolGenerator.GenerationContext,
+        shape: Shape,
+    ): List<MemberShape> =
+        shape
             .members()
             // The only place an input member can be bound to in EC2Query other than the body
             // is the host prefix, using the host label trait.
             .filter { !it.hasTrait<HostLabelTrait>() }
             .toList()
-    }
 }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/ec2query/EC2QueryProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/ec2query/EC2QueryProtocolGenerator.kt
@@ -12,12 +12,10 @@ import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
-import software.amazon.smithy.model.traits.HostLabelTrait
 import software.amazon.smithy.swift.codegen.integration.HttpBindingResolver
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.middlewares.ContentTypeMiddleware
 import software.amazon.smithy.swift.codegen.integration.middlewares.OperationInputBodyMiddleware
-import software.amazon.smithy.swift.codegen.model.hasTrait
 
 class EC2QueryProtocolGenerator : AWSHTTPBindingProtocolGenerator(EC2QueryCustomizations()) {
     override val defaultContentType = "application/x-www-form-urlencoded"
@@ -56,11 +54,5 @@ class EC2QueryProtocolGenerator : AWSHTTPBindingProtocolGenerator(EC2QueryCustom
     override fun httpBodyMembers(
         ctx: ProtocolGenerator.GenerationContext,
         shape: Shape,
-    ): List<MemberShape> =
-        shape
-            .members()
-            // The only place an input member can be bound to in EC2Query other than the body
-            // is the host prefix, using the host label trait.
-            .filter { !it.hasTrait<HostLabelTrait>() }
-            .toList()
+    ): List<MemberShape> = shape.members().toList()
 }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/restjson/AWSRestJson1ProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/restjson/AWSRestJson1ProtocolGenerator.kt
@@ -23,10 +23,12 @@ class AWSRestJson1ProtocolGenerator : AWSHTTPBindingProtocolGenerator(RestJSONCu
             "RestJsonClientPopulatesDefaultsValuesWhenMissingInResponse", // TODO: broken in Smithy 1.53.0
         )
 
-    override fun httpBodyMembers(ctx: ProtocolGenerator.GenerationContext, shape: Shape): List<MemberShape> {
-        return shape
+    override fun httpBodyMembers(
+        ctx: ProtocolGenerator.GenerationContext,
+        shape: Shape,
+    ): List<MemberShape> =
+        shape
             .members()
             .filter { it.isInHttpBody() }
             .toList()
-    }
 }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/restjson/AWSRestJson1ProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/restjson/AWSRestJson1ProtocolGenerator.kt
@@ -6,7 +6,11 @@ package software.amazon.smithy.aws.swift.codegen.protocols.restjson
 
 import software.amazon.smithy.aws.swift.codegen.AWSHTTPBindingProtocolGenerator
 import software.amazon.smithy.aws.traits.protocols.RestJson1Trait
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
+import software.amazon.smithy.swift.codegen.integration.isInHttpBody
 
 class AWSRestJson1ProtocolGenerator : AWSHTTPBindingProtocolGenerator(RestJSONCustomizations()) {
     override val defaultContentType = "application/json"
@@ -18,4 +22,11 @@ class AWSRestJson1ProtocolGenerator : AWSHTTPBindingProtocolGenerator(RestJSONCu
             "RestJsonClientPopulatesDefaultValuesInInput", // TODO: broken in Smithy 1.53.0
             "RestJsonClientPopulatesDefaultsValuesWhenMissingInResponse", // TODO: broken in Smithy 1.53.0
         )
+
+    override fun httpBodyMembers(ctx: ProtocolGenerator.GenerationContext, shape: Shape): List<MemberShape> {
+        return shape
+            .members()
+            .filter { it.isInHttpBody() }
+            .toList()
+    }
 }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/restxml/RestXMLProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/restxml/RestXMLProtocolGenerator.kt
@@ -40,10 +40,12 @@ class RestXMLProtocolGenerator : AWSHTTPBindingProtocolGenerator(RestXMLCustomiz
         }
     }
 
-    override fun httpBodyMembers(ctx: ProtocolGenerator.GenerationContext, shape: Shape): List<MemberShape> {
-        return shape
+    override fun httpBodyMembers(
+        ctx: ProtocolGenerator.GenerationContext,
+        shape: Shape,
+    ): List<MemberShape> =
+        shape
             .members()
             .filter { it.isInHttpBody() }
             .toList()
-    }
 }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/restxml/RestXMLProtocolGenerator.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/protocols/restxml/RestXMLProtocolGenerator.kt
@@ -7,8 +7,11 @@ package software.amazon.smithy.aws.swift.codegen.protocols.restxml
 
 import software.amazon.smithy.aws.swift.codegen.AWSHTTPBindingProtocolGenerator
 import software.amazon.smithy.aws.traits.protocols.RestXmlTrait
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
+import software.amazon.smithy.swift.codegen.integration.isInHttpBody
 
 class RestXMLProtocolGenerator : AWSHTTPBindingProtocolGenerator(RestXMLCustomizations()) {
     override val defaultContentType: String = "application/xml"
@@ -35,5 +38,12 @@ class RestXMLProtocolGenerator : AWSHTTPBindingProtocolGenerator(RestXMLCustomiz
         for (shape in errorShapes) {
             renderCodableExtension(ctx, shape)
         }
+    }
+
+    override fun httpBodyMembers(ctx: ProtocolGenerator.GenerationContext, shape: Shape): List<MemberShape> {
+        return shape
+            .members()
+            .filter { it.isInHttpBody() }
+            .toList()
     }
 }


### PR DESCRIPTION
## Description of changes
Recently it was discovered that several AWS JSON-based services have input or output members with the `@httpLabel` trait applied, even though the trait has no meaning in AWS JSON.  Currently, AWS SDK for Swift does not serialize/deserialize a member containing `@httpLabel`, resulting in incorrect behavior on 15 AWS JSON services.

To correct:
- A customizable function returning HTTP body members is added to `HTTPBindingProtocolGenerator` in https://github.com/smithy-lang/smithy-swift/pull/907
- All six AWS protocols override that method in this PR to more exactly specify their HTTP body members.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.