### PR TITLE
chore: Fix path to Partitions.swift

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/AWSSDKSwiftCLI/Subcommands/PrepareRelease.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/AWSSDKSwiftCLI/Subcommands/PrepareRelease.swift
@@ -208,7 +208,7 @@ struct PrepareRelease {
                 "packageDependencies.plist",
                 "Sources/Services",
                 "Sources/Core/AWSSDKForSwift/Documentation.docc/AWSSDKForSwift.md",
-                "Sources/Core/AWSSDKPartitions/Source/AWSSDKPartitions/Partitions.swift",
+                "Sources/Core/AWSSDKPartitions/Sources/AWSSDKPartitions/Partitions.swift",
             ]
         case .smithySwift:
             files = ["Package.version", "Package.version.next"]

--- a/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Commands/PrepareReleaseTests.swift
+++ b/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Commands/PrepareReleaseTests.swift
@@ -184,7 +184,7 @@ class PrepareReleaseTests: CLITestCase {
         ProcessRunner.testRunner = runner
         let subject = PrepareRelease.mock(repoType: .awsSdkSwift)
         try! subject.stageFiles()
-        XCTAssertTrue(command.hasSuffix("git add Package.swift Package.version Package.version.next packageDependencies.plist Sources/Services Sources/Core/AWSSDKForSwift/Documentation.docc/AWSSDKForSwift.md Sources/Core/AWSSDKPartitions/Source/AWSSDKPartitions/Partitions.swift"))
+        XCTAssertTrue(command.hasSuffix("git add Package.swift Package.version Package.version.next packageDependencies.plist Sources/Services Sources/Core/AWSSDKForSwift/Documentation.docc/AWSSDKForSwift.md Sources/Core/AWSSDKPartitions/Sources/AWSSDKPartitions/Partitions.swift"))
     }
     
     func testStageFilesForSmithySwift() {


### PR DESCRIPTION
## Description of changes
Fix the path to the `Partitions.swift` file in release tooling.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.