### PR TITLE
chore: Update to aws-crt-swift 0.44.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ import PackageDescription
 // MARK: - Dynamic Content
 
 let clientRuntimeVersion: Version = "0.116.0"
-let crtVersion: Version = "0.43.0"
+let crtVersion: Version = "0.44.0"
 
 let excludeRuntimeUnitTests = false
 

--- a/packageDependencies.plist
+++ b/packageDependencies.plist
@@ -5,7 +5,7 @@
 	<key>awsCRTSwiftBranch</key>
 	<string>main</string>
 	<key>awsCRTSwiftVersion</key>
-	<string>0.43.0</string>
+	<string>0.44.0</string>
 	<key>clientRuntimeBranch</key>
 	<string>main</string>
 	<key>clientRuntimeVersion</key>


### PR DESCRIPTION
## Description of changes
Upgrade aws-crt-swift to [0.44.0](https://github.com/awslabs/aws-crt-swift/releases/tag/v0.44.0)

This version lifts the upper limit on event stream message size from 16MB to 256MB.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.