### PR TITLE
chore: Remove Elastic Inference

### DIFF
--- a/sdk.properties
+++ b/sdk.properties
@@ -3,5 +3,5 @@
 
 # Use this line to exclude one or more AWS services:
 # excludeModels=s3,sts,dynamodb
-excludeModels=iot-1click-devices-service,iot-1click-projects
+excludeModels=iot-1click-devices-service,iot-1click-projects,elastic-inference
 


### PR DESCRIPTION
## Description of changes
Remove the Elastic Inference service, which is being shut down.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.