### PR TITLE
chore: Move transcribe streaming integration tests to us-east-2

### DIFF
--- a/IntegrationTests/Services/AWSTranscribeStreamingIntegrationTests/TranscribeStreamingTests.swift
+++ b/IntegrationTests/Services/AWSTranscribeStreamingIntegrationTests/TranscribeStreamingTests.swift
@@ -52,7 +52,7 @@ final class TranscribeStreamingTests: XCTestCase {
         let dataRate = Double(audioDataSize) / duration
         let delay = Double(chunkSize) / dataRate
 
-        let client = try TranscribeStreamingClient(region: "us-west-2")
+        let client = try TranscribeStreamingClient(region: "us-east-2")
 
         let audioStream = AsyncThrowingStream<TranscribeStreamingClientTypes.AudioStream, Error> { continuation in
             Task {


### PR DESCRIPTION
## Description of changes
Moves transcribe streaming integration tests to `us-east-2` due to problems occurring in `us-west-2` today.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.