### PR TITLE
Revert "feat: Decompose CRT default chain into individual wrappers"

### DIFF
--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/AWSClientConfigDefaultsProvider.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/AWSClientConfigDefaultsProvider.swift
@@ -6,7 +6,7 @@
 //
 
 @_spi(FileBasedConfig) import AWSSDKCommon
-import AWSSDKIdentity
+@_spi(DefaultAWSCredentialIdentityResolverChain) import AWSSDKIdentity
 import SmithyIdentity
 import SmithyIdentityAPI
 import struct ClientRuntime.DefaultSDKRuntimeConfiguration
@@ -28,10 +28,13 @@ public class AWSClientConfigDefaultsProvider: ClientConfigDefaultsProvider {
         _ awsCredentialIdentityResolver: (any AWSCredentialIdentityResolver)? = nil
     ) throws -> any AWSCredentialIdentityResolver {
         let resolvedAWSCredentialIdentityResolver: any AWSCredentialIdentityResolver
+        let fileBasedConfig = try CRTFileBasedConfiguration.make()
         if let awsCredentialIdentityResolver {
             resolvedAWSCredentialIdentityResolver = awsCredentialIdentityResolver
         } else {
-            resolvedAWSCredentialIdentityResolver = DefaultAWSCredentialIdentityResolverChain()
+            resolvedAWSCredentialIdentityResolver = try DefaultAWSCredentialIdentityResolverChain(
+                fileBasedConfig: fileBasedConfig
+            )
         }
         return resolvedAWSCredentialIdentityResolver
     }

--- a/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/DefaultAWSCredentialIdentityResolverChain.swift
+++ b/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/DefaultAWSCredentialIdentityResolverChain.swift
@@ -9,8 +9,6 @@ import class AwsCommonRuntimeKit.CredentialsProvider
 import ClientRuntime
 import protocol SmithyIdentity.AWSCredentialIdentityResolvedByCRT
 @_spi(FileBasedConfig) import AWSSDKCommon
-import protocol SmithyIdentity.AWSCredentialIdentityResolver
-import struct Smithy.Attributes
 
 // swiftlint:disable type_name
 // ^ Required to mute swiftlint warning about type name being too long.
@@ -26,33 +24,21 @@ import struct Smithy.Attributes
 /// 5. EC2 Instance Metadata (IMDSv2)
 ///
 /// The credentials retrieved from the chain are cached for 15 minutes.
-public struct DefaultAWSCredentialIdentityResolverChain: AWSCredentialIdentityResolver {
+public struct DefaultAWSCredentialIdentityResolverChain: AWSCredentialIdentityResolvedByCRT {
+    public let crtAWSCredentialIdentityResolver: AwsCommonRuntimeKit.CredentialsProvider
+
     /// Creates a credential identity resolver that uses the default AWS credential identity resolver chain used by most AWS SDKs.
-    public init() {}
+    public init() throws {
+        let fileBasedConfig = try CRTFileBasedConfiguration()
+        try self.init(fileBasedConfig: fileBasedConfig)
+    }
 
-    public func getIdentity(identityProperties: Attributes?) async throws -> AWSCredentialIdentity {
-        typealias ResolverFactory = () throws -> any AWSCredentialIdentityResolver
-
-        let resolverFactories: [ResolverFactory] = [
-            { try EnvironmentAWSCredentialIdentityResolver() },
-            { try ProfileAWSCredentialIdentityResolver() },
-            { try STSWebIdentityAWSCredentialIdentityResolver() },
-            { try ECSAWSCredentialIdentityResolver() },
-            { try IMDSAWSCredentialIdentityResolver() }
-        ]
-
-        let lastIndex = resolverFactories.count - 1
-        for index in 0..<lastIndex {
-            do {
-                let resolver = try resolverFactories[index]()
-                return try await resolver.getIdentity(identityProperties: identityProperties)
-            } catch {
-                // Continue to the next resolver factory.
-            }
-        }
-
-        // The error thrown from the last resolver is not caught and instead gets thrown to caller.
-        return try await resolverFactories[lastIndex]().getIdentity(identityProperties: identityProperties)
+    @_spi(DefaultAWSCredentialIdentityResolverChain)
+    public init(fileBasedConfig: CRTFileBasedConfiguration) throws {
+        self.crtAWSCredentialIdentityResolver = try AwsCommonRuntimeKit.CredentialsProvider(source: .defaultChain(
+            bootstrap: SDKDefaultIO.shared.clientBootstrap,
+            fileBasedConfiguration: fileBasedConfig
+        ))
     }
 }
 

--- a/Sources/Core/AWSSDKIdentity/Tests/AWSSDKIdentityTests/AWSCredentialIdentityResolverTests/DefaultAWSCredentialIdentityResolverChainTests.swift
+++ b/Sources/Core/AWSSDKIdentity/Tests/AWSSDKIdentityTests/AWSCredentialIdentityResolverTests/DefaultAWSCredentialIdentityResolverChainTests.swift
@@ -19,7 +19,7 @@ class DefaultAWSCredentialIdentityResolverChainTests: XCTestCase {
             unsetenv("AWS_SECRET_ACCESS_KEY")
         }
 
-        let subject = DefaultAWSCredentialIdentityResolverChain()
+        let subject = try DefaultAWSCredentialIdentityResolverChain()
         let credentials = try await subject.getIdentity()
 
         XCTAssertEqual(credentials.accessKey, "some_access_key_b")


### PR DESCRIPTION
Reverts awslabs/aws-sdk-swift#1926

STS assume role credential provider was accidentally removed from the chain. Reverting this back temporarily, will put up a new PR.