### PR TITLE
fix: RPCv2CBOR query compatible support

### DIFF
--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Protocols/AWSJSON/AWSJSONError.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Protocols/AWSJSON/AWSJSONError.swift
@@ -35,21 +35,3 @@ public struct AWSJSONError: BaseError {
         self.responseReader = responseReader
     }
 }
-
-extension AWSJSONError {
-    @_spi(SmithyReadWrite)
-    public static func makeQueryCompatibleError(
-        httpResponse: HTTPResponse,
-        responseReader: Reader,
-        noErrorWrapping: Bool,
-        errorDetails: String?
-    ) throws -> AWSJSONError {
-        let errorCode = try AwsQueryCompatibleErrorDetails.parse(errorDetails).code
-        return try AWSJSONError(
-            httpResponse: httpResponse,
-            responseReader: responseReader,
-            noErrorWrapping: noErrorWrapping,
-            code: errorCode
-        )
-    }
-}

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Protocols/AWSQuery/AWSQueryCompatibleUtils.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Protocols/AWSQuery/AWSQueryCompatibleUtils.swift
@@ -5,21 +5,39 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+@_spi(SmithyReadWrite) import class SmithyJSON.Reader
 @_spi(SmithyReadWrite) import struct ClientRuntime.RpcV2CborError
 @_spi(SmithyReadWrite) import class SmithyCBOR.Reader
 import class SmithyHTTPAPI.HTTPResponse
 
-// support awsQueryCompatible trait
-extension RpcV2CborError {
-    @_spi(SmithyReadWrite)
+@_spi(SmithyReadWrite)
+public enum AWSQueryCompatibleUtils {
+
+    // CBOR
     public static func makeQueryCompatibleError(
         httpResponse: HTTPResponse,
-        responseReader: Reader,
+        responseReader: SmithyCBOR.Reader,
         noErrorWrapping: Bool,
         errorDetails: String?
     ) throws -> RpcV2CborError {
         let errorCode = try AwsQueryCompatibleErrorDetails.parse(errorDetails).code
         return try RpcV2CborError(
+            httpResponse: httpResponse,
+            responseReader: responseReader,
+            noErrorWrapping: noErrorWrapping,
+            code: errorCode
+        )
+    }
+
+    // awsJson1_0
+    public static func makeQueryCompatibleError(
+        httpResponse: HTTPResponse,
+        responseReader: SmithyJSON.Reader,
+        noErrorWrapping: Bool,
+        errorDetails: String?
+    ) throws -> AWSJSONError {
+        let errorCode = try AwsQueryCompatibleErrorDetails.parse(errorDetails).code
+        return try AWSJSONError(
             httpResponse: httpResponse,
             responseReader: responseReader,
             noErrorWrapping: noErrorWrapping,

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHTTPProtocolCustomizations.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSHTTPProtocolCustomizations.kt
@@ -77,4 +77,6 @@ abstract class AWSHTTPProtocolCustomizations : DefaultHTTPProtocolCustomizations
     override val endpointMiddlewareSymbol: Symbol = AWSClientRuntimeTypes.Core.AWSEndpointResolverMiddleware
 
     override val unknownServiceErrorSymbol: Symbol = AWSClientRuntimeTypes.Core.UnknownAWSHTTPServiceError
+
+    override val queryCompatibleUtilsSymbol: Symbol = AWSClientRuntimeTypes.AWSQuery.AWSQueryCompatibleUtils
 }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/swiftmodules/AWSClientRuntimeTypes.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/swiftmodules/AWSClientRuntimeTypes.kt
@@ -8,6 +8,7 @@ import software.amazon.smithy.swift.codegen.swiftmodules.SwiftSymbol
 object AWSClientRuntimeTypes {
     object AWSQuery {
         val AWSQueryError = runtimeSymbol("AWSQueryError", SwiftDeclaration.STRUCT, listOf("SmithyReadWrite"))
+        val AWSQueryCompatibleUtils = runtimeSymbol("AWSQueryCompatibleUtils", SwiftDeclaration.ENUM, listOf("SmithyReadWrite"))
     }
 
     object EC2Query {


### PR DESCRIPTION
## Description of changes
Fixes a compile error that occurs when a RPCv2CBOR-based service uses backward query compatibility for errors.
- Moves AWS JSON & CBOR query-compatibility code to a utility type instead of extending the base errors for those protocols.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.