### PR TITLE
fix: Make event stream tests tolerant of added event types

### DIFF
--- a/IntegrationTests/Services/AWSKinesisIntegrationTests/KinesisTests.swift
+++ b/IntegrationTests/Services/AWSKinesisIntegrationTests/KinesisTests.swift
@@ -76,8 +76,10 @@ class KinesisTests: XCTestCase {
                         let recordString = String(data: record.data ?? Data(), encoding: .utf8)
                         recordStrings.removeAll { recordString == $0 }
                     }
-                case .sdkUnknown(let message):
-                    print("Unknown event: \(message)")
+                default:
+                    // adding default here accommodates future addition of new event types by the service
+                    // the .sdkUnknown() event is ignored by this case as well
+                    break
                 }
 
                 // Once all the events have been received, stop streaming

--- a/IntegrationTests/Services/AWSS3IntegrationTests/S3EventStreamTests.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/S3EventStreamTests.swift
@@ -51,11 +51,11 @@ class S3EventStreamTests: S3XCTestCase {
             case .records(let record):
                 actualOutput = actualOutput + (String(data: record.payload ?? Data(), encoding: .utf8) ?? "")
             case .stats, .end:
-                continue
-            case .sdkUnknown(let data):
-                XCTFail(data)
+                break
             default:
-                XCTFail("Encountered an unexpected event in output stream.")
+                // adding default here accommodates future addition of new event types by the service
+                // the .sdkUnknown() event is ignored by this case as well
+                break
             }
         }
 

--- a/IntegrationTests/Services/AWSTranscribeStreamingIntegrationTests/TranscribeStreamingTests.swift
+++ b/IntegrationTests/Services/AWSTranscribeStreamingIntegrationTests/TranscribeStreamingTests.swift
@@ -90,8 +90,10 @@ final class TranscribeStreamingTests: XCTestCase, @unchecked Sendable {
                         fullMessage.append(transcript)
                     }
                 }
-            case .sdkUnknown(let data):
-                XCTFail(data)
+            default:
+                // adding default here accommodates future addition of new event types by the service
+                // the .sdkUnknown() event is ignored by this case as well
+                break
             }
         }
 


### PR DESCRIPTION
## Description of changes
Services are permitted to add new event types to existing event streaming operations.  These appear in the Swift SDK as new cases in existing enumerations.

Several of our integration tests are currently constructed in a way such that they will either:
- fail to compile if a new event type is modeled in an existing event stream
- fail at runtime if the service returns an event type that is not currently modeled

There are three event streaming integration tests in the SDK's integration test suite.  All 3 have been fixed here to be tolerant of both types of new events described above.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.