### PR TITLE
chore: add announcement of macOS minimum bump to release notes

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Models/ReleaseNotesBuilder.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Models/ReleaseNotesBuilder.swift
@@ -18,6 +18,12 @@ struct ReleaseNotesBuilder {
     let features: Features
     let featuresIDToServiceName: [String: String]
 
+    static let macOSVersionBumpAnnouncement: String = """
+    **Heads up!**
+    On June 19th, the minimum supported macOS version for this SDK will increase from 10.15 to 12.
+    [Read more](https://github.com/awslabs/aws-sdk-swift/discussions/1940)
+    """
+
     // MARK: - Build
 
     func build() throws -> String {
@@ -26,7 +32,10 @@ struct ReleaseNotesBuilder {
         let fullCommitLogLink = [
             "\n**Full Changelog**: https://github.com/\(repoOrg.rawValue)/\(repoType.rawValue)/compare/\(previousVersion)...\(newVersion)"
         ]
-        let contents = ["## What's Changed"] + serviceClientChanges + sdkChanges + fullCommitLogLink
+        let contents = [
+            ReleaseNotesBuilder.macOSVersionBumpAnnouncement,
+            "## What's Changed"
+        ] + serviceClientChanges + sdkChanges + fullCommitLogLink
         return contents.joined(separator: .newline)
     }
 

--- a/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Models/ReleaseNotesBuilderTests.swift
+++ b/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Models/ReleaseNotesBuilderTests.swift
@@ -97,7 +97,7 @@ class ReleaseNotesBuilderTests: CLITestCase {
 
         **Full Changelog**: https://github.com/awslabs/aws-sdk-swift/compare/1.0.0...1.0.1
         """
-        XCTAssertEqual(releaseNotes, expected)
+        XCTAssertEqual(releaseNotes, ReleaseNotesBuilder.macOSVersionBumpAnnouncement + "\n" + expected)
     }
 
     func testNoServiceFeatureSectionPresent() throws {
@@ -117,7 +117,7 @@ class ReleaseNotesBuilderTests: CLITestCase {
 
         **Full Changelog**: https://github.com/awslabs/aws-sdk-swift/compare/1.0.0...1.0.1
         """
-        XCTAssertEqual(releaseNotes, expected)
+        XCTAssertEqual(releaseNotes, ReleaseNotesBuilder.macOSVersionBumpAnnouncement + "\n" + expected)
     }
 
     func testNoServiceDocSectionPresent() throws {
@@ -138,7 +138,7 @@ class ReleaseNotesBuilderTests: CLITestCase {
 
         **Full Changelog**: https://github.com/awslabs/aws-sdk-swift/compare/1.0.0...1.0.1
         """
-        XCTAssertEqual(releaseNotes, expected)
+        XCTAssertEqual(releaseNotes, ReleaseNotesBuilder.macOSVersionBumpAnnouncement + "\n" + expected)
     }
 
     func testNoSDKChangeSectionPresent() throws {
@@ -158,7 +158,7 @@ class ReleaseNotesBuilderTests: CLITestCase {
 
         **Full Changelog**: https://github.com/awslabs/aws-sdk-swift/compare/1.0.0...1.0.1
         """
-        XCTAssertEqual(releaseNotes, expected)
+        XCTAssertEqual(releaseNotes, ReleaseNotesBuilder.macOSVersionBumpAnnouncement + "\n" + expected)
     }
 
     func testNoSectionsPresentAndIrrelevantCommitsAreFiltered() throws {
@@ -173,7 +173,7 @@ class ReleaseNotesBuilderTests: CLITestCase {
 
         **Full Changelog**: https://github.com/awslabs/aws-sdk-swift/compare/1.0.0...1.0.1
         """
-        XCTAssertEqual(releaseNotes, expected)
+        XCTAssertEqual(releaseNotes, ReleaseNotesBuilder.macOSVersionBumpAnnouncement + "\n" + expected)
     }
 
     func testNullReleaseNotesFieldGetsHandledWithoutError() throws {
@@ -190,7 +190,7 @@ class ReleaseNotesBuilderTests: CLITestCase {
 
         **Full Changelog**: https://github.com/awslabs/aws-sdk-swift/compare/1.0.0...1.0.1
         """
-        XCTAssertEqual(releaseNotes, expected)
+        XCTAssertEqual(releaseNotes, ReleaseNotesBuilder.macOSVersionBumpAnnouncement + "\n" + expected)
     }
 
     private func setUpBuildRequestAndMappingJSONs(_ buildRequest: String, _ mapping: String) {


### PR DESCRIPTION
On June 18th we will be raising the minimum macOS version to 12. Add this to top of release notes everyday.

Ex.
<img width="899" alt="Screenshot 2025-05-20 at 3 37 38 PM" src="https://github.com/user-attachments/assets/f27212da-a60e-41e2-bc53-64540fdc31dd" />

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.