### PR TITLE
chore: Roll back IMDSv2.1 extension, back to IMDSv2

### DIFF
--- a/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/IMDSAWSCredentialIdentityResolver.swift
+++ b/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/IMDSAWSCredentialIdentityResolver.swift
@@ -15,24 +15,14 @@ import struct Foundation.URL
 import struct Smithy.Attributes
 import typealias AWSSDKCommon.CRTFileBasedConfiguration
 
-// Temporary enum used until IMDS moves fully to IMDSv2.1.
-private enum IMDSAPIVersion {
-    case unknown
-    case legacy // IMDSv2, w/o accountID
-    case extended // IMDSv2.1, w/ AccountID
-}
-
 /// A credentials provider that uses IMDSv2 to fetch credentials within an EC2 instance.
 public actor IMDSAWSCredentialIdentityResolver: AWSCredentialIdentityResolver {
     /// The IMDS client used to fetch IMDS metadata.
     private let imdsClient: EC2InstanceMetadataProvider
     /// The manual config for the name of the EC2 instance profile from which temporary IMDS credentials get sourced.
     private let ec2InstanceProfileName: String?
-
-    private var apiVersion: IMDSAPIVersion = .unknown
-    private var credentialURLBase: String = ""
-    // The name of the instance profile resolved by querying IMDS.
-    private var resolvedProfile: String?
+    /// The IMDS metadata category used to fetch EC2 instance role name if needed. Adding <role-name> to this string fetches temporary credentials for the role.
+    private let credentialURLBase: String = "/latest/meta-data/iam/security-credentials/"
 
     /// Creates a credentials provider that sources credentials from ec2 instance metadata.
     /// It will use IMDSv2 to fetch the credentials.
@@ -76,52 +66,26 @@ public actor IMDSAWSCredentialIdentityResolver: AWSCredentialIdentityResolver {
 
     public func getIdentity(identityProperties: Attributes?) async throws -> AWSCredentialIdentity {
         try throwIfIMDSDisabled()
-        credentialURLBase = resolveCredentialURLBase()
 
-        // Resolve profile name to use.
-        var profileName = ec2InstanceProfileName ?? resolvedProfile ?? ""
-        if profileName.isEmpty {
-            do {
-                let profileFromIMDS = try await imdsClient.get(path: credentialURLBase)
-                resolvedProfile = profileFromIMDS
-                profileName = profileFromIMDS
-                if apiVersion == .unknown {
-                    apiVersion = .extended
-                }
-            } catch IMDSError.metadata(.nonRetryable(let message)) {
-                if message.contains("404") {
-                    // Change version to .legacy and recurse.
-                    apiVersion = .legacy
-                    return try await getIdentity(identityProperties: identityProperties)
-                }
-            }
+        // Resolve profile name to use. Use either customer provided one, or fetch from IMDS.
+        var resolvedProfile = ec2InstanceProfileName ?? ""
+        if resolvedProfile.isEmpty {
+            let profileFromIMDS = try await imdsClient.get(path: credentialURLBase)
+            resolvedProfile = profileFromIMDS
+        }
+
+        guard !resolvedProfile.isEmpty else {
+            throw IMDSError.failedToResolveProfileName
         }
 
         // Fetch JSON credential response from IMDS.
-        var jsonCredentialString = ""
         do {
-            let path = credentialURLBase + profileName
-            jsonCredentialString = try await imdsClient.get(path: path)
-            if apiVersion == .unknown {
-                apiVersion = .extended
-            }
+            let path = credentialURLBase + resolvedProfile
+            var jsonCredentialString = try await imdsClient.get(path: path)
+            return try parseJSONCredentials(jsonCredentialString: jsonCredentialString)
         } catch IMDSError.metadata(.nonRetryable(let message)) where message.contains("404") {
-            if apiVersion == .unknown {
-                // Fallback to .legacy and recurse.
-                apiVersion = .legacy
-                return try await getIdentity(identityProperties: identityProperties)
-            } else if ec2InstanceProfileName == nil {
-                // Remove profile name previously resolved from IMDS and recurse.
-                resolvedProfile = nil
-                return try await getIdentity(identityProperties: identityProperties)
-            } else {
-                throw IMDSError.invalidProfileName
-            }
-        } catch {
             throw IMDSError.invalidProfileName
         }
-
-        return try parseJSONCredentials(jsonCredentialString: jsonCredentialString)
     }
 
     private func throwIfIMDSDisabled() throws {
@@ -139,12 +103,6 @@ public actor IMDSAWSCredentialIdentityResolver: AWSCredentialIdentityResolver {
                 + "IMDS is disabled via env var or shared config file."
             )
         }
-    }
-
-    private func resolveCredentialURLBase() -> String {
-        return apiVersion == .legacy
-        ? "/latest/meta-data/iam/security-credentials/"
-        : "/latest/meta-data/iam/security-credentials-extended/"
     }
 
     private func parseJSONCredentials(

--- a/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/IMDSClient/IMDSError.swift
+++ b/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/IMDSClient/IMDSError.swift
@@ -23,4 +23,5 @@ public enum IMDSError: Error {
     case reachedMaxRetries
     case invalidRetryValue(String)
     case invalidProfileName
+    case failedToResolveProfileName
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Roll back IMDSv2.1 extension, abck to IMDSv2.
  - Removes profile name caching behavior & temporary enum `IMDSAPIVersion` and its usage
- Manually tested on dev instance of EC2.

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.