### PR TITLE
fix: ANY_STRING_EQUALS waiter matcher match on one string

### DIFF
--- a/codegen/protocol-test-codegen-local/Tests/swift-codegen/Tests/WaitersTests/OutputMatcherTests.swift
+++ b/codegen/protocol-test-codegen-local/Tests/swift-codegen/Tests/WaitersTests/OutputMatcherTests.swift
@@ -226,7 +226,14 @@ class OutputMatcherTests: XCTestCase {
     // JMESPath comparator: "allStringEquals"
     // JMESPath expected value: "abc"
 
-    func test_projection_acceptorMatchesWhenProjectedValuesMatchExpectation() async throws {
+    func test_projection_acceptorMatchesWhenSingleProjectedValueMatchesExpectation() async throws {
+        let output = GetWidgetOutput(dataMap: ["x": "abc"])
+        let subject = try WaitersClient.projectionMatcherWaiterConfig().acceptors[0]
+        let match = subject.evaluate(input: anInput, result: .success(output))
+        XCTAssertEqual(match, .success(.success(output)))
+    }
+
+    func test_projection_acceptorMatchesWhenMultipleProjectedValuesMatchExpectation() async throws {
         let output = GetWidgetOutput(dataMap: ["x": "abc", "y": "abc", "z": "abc"])
         let subject = try WaitersClient.projectionMatcherWaiterConfig().acceptors[0]
         let match = subject.evaluate(input: anInput, result: .success(output))

--- a/codegen/protocol-test-codegen-local/Tests/swift-codegen/Tests/WaitersTests/OutputMatcherTests.swift
+++ b/codegen/protocol-test-codegen-local/Tests/swift-codegen/Tests/WaitersTests/OutputMatcherTests.swift
@@ -226,11 +226,32 @@ class OutputMatcherTests: XCTestCase {
     // JMESPath comparator: "allStringEquals"
     // JMESPath expected value: "abc"
 
+    func test_projection_acceptorDoesNotMatchWhenProjectedValueIsNil() async throws {
+        let output = GetWidgetOutput(dataMap: nil)
+        let subject = try WaitersClient.projectionMatcherWaiterConfig().acceptors[0]
+        let match = subject.evaluate(input: anInput, result: .success(output))
+        XCTAssertNil(match)
+    }
+
+    func test_projection_acceptorDoesNotMatchWhenProjectedValueIsEmpty() async throws {
+        let output = GetWidgetOutput(dataMap: [:])
+        let subject = try WaitersClient.projectionMatcherWaiterConfig().acceptors[0]
+        let match = subject.evaluate(input: anInput, result: .success(output))
+        XCTAssertNil(match)
+    }
+
     func test_projection_acceptorMatchesWhenSingleProjectedValueMatchesExpectation() async throws {
         let output = GetWidgetOutput(dataMap: ["x": "abc"])
         let subject = try WaitersClient.projectionMatcherWaiterConfig().acceptors[0]
         let match = subject.evaluate(input: anInput, result: .success(output))
         XCTAssertEqual(match, .success(.success(output)))
+    }
+
+    func test_projection_acceptorMatchesWhenSingleProjectedValueDoesNotMatchExpectation() async throws {
+        let output = GetWidgetOutput(dataMap: ["x": "def"])
+        let subject = try WaitersClient.projectionMatcherWaiterConfig().acceptors[0]
+        let match = subject.evaluate(input: anInput, result: .success(output))
+        XCTAssertNil(match)
     }
 
     func test_projection_acceptorMatchesWhenMultipleProjectedValuesMatchExpectation() async throws {


### PR DESCRIPTION
## Issue \#
#1981

## Description of changes
Adds test for matching `ALL_STRING_EQUALS` for one string.

This test verifies a bugfix in https://github.com/smithy-lang/smithy-swift/pull/947.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.