### PR TITLE
feat: Add Bedrock API key support

### DIFF
--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Customizations/BedrockAPIKeyPlugin.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Customizations/BedrockAPIKeyPlugin.swift
@@ -1,0 +1,26 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import class Foundation.ProcessInfo
+import protocol ClientRuntime.Plugin
+import protocol ClientRuntime.ClientConfiguration
+import protocol ClientRuntime.DefaultHttpClientConfiguration
+import struct SmithyIdentity.BearerTokenIdentity
+import struct SmithyIdentity.StaticBearerTokenIdentityResolver
+
+public struct BedrockAPIKeyPlugin: Plugin {
+
+    public init() {}
+
+    public func configureClient(clientConfiguration: any ClientRuntime.ClientConfiguration) async throws {
+        guard var config = clientConfiguration as? DefaultHttpClientConfiguration else { return }
+        guard let bearerToken = ProcessInfo.processInfo.environment["AWS_BEARER_TOKEN_BEDROCK"] else { return }
+        config.authSchemePreference = ["smithy.api#httpBearerAuth"] + (config.authSchemePreference ?? [])
+        let identity = BearerTokenIdentity(token: bearerToken)
+        config.bearerTokenIdentityResolver = StaticBearerTokenIdentityResolver(token: identity)
+    }
+}

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSClientConfigurationIntegration.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSClientConfigurationIntegration.kt
@@ -9,24 +9,32 @@ import software.amazon.smithy.aws.swift.codegen.config.AWSDefaultClientConfigura
 import software.amazon.smithy.aws.swift.codegen.config.AWSEndpointClientConfiguration
 import software.amazon.smithy.aws.swift.codegen.config.AWSRegionClientConfiguration
 import software.amazon.smithy.aws.swift.codegen.plugins.AuthSchemePlugin
+import software.amazon.smithy.aws.swift.codegen.plugins.BedrockAPIKeyPlugin
 import software.amazon.smithy.aws.swift.codegen.plugins.DefaultAWSAuthSchemePlugin
 import software.amazon.smithy.aws.swift.codegen.plugins.EndpointPlugin
+import software.amazon.smithy.aws.traits.auth.SigV4Trait
 import software.amazon.smithy.swift.codegen.config.ClientConfiguration
 import software.amazon.smithy.swift.codegen.integration.Plugin
 import software.amazon.smithy.swift.codegen.integration.ProtocolGenerator
 import software.amazon.smithy.swift.codegen.integration.ServiceConfig
 import software.amazon.smithy.swift.codegen.integration.SwiftIntegration
 import software.amazon.smithy.swift.codegen.integration.plugins.DefaultAWSClientPlugin
+import software.amazon.smithy.swift.codegen.model.getTrait
 
 class AWSClientConfigurationIntegration : SwiftIntegration {
     override fun clientConfigurations(ctx: ProtocolGenerator.GenerationContext): List<ClientConfiguration> =
         listOf(AWSDefaultClientConfiguration(), AWSRegionClientConfiguration(), AWSEndpointClientConfiguration(ctx))
 
-    override fun plugins(serviceConfig: ServiceConfig): List<Plugin> =
-        listOf(
+    override fun plugins(ctx: ProtocolGenerator.GenerationContext, serviceConfig: ServiceConfig): List<Plugin> {
+        val list = mutableListOf(
             DefaultAWSClientPlugin(),
             EndpointPlugin(serviceConfig),
             DefaultAWSAuthSchemePlugin(serviceConfig),
             AuthSchemePlugin(serviceConfig),
         )
+        if (ctx.service.getTrait<SigV4Trait>()?.name == "bedrock") {
+            list.add(BedrockAPIKeyPlugin())
+        }
+        return list
+    }
 }

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/plugins/BedrockAPIKeyPlugin.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/plugins/BedrockAPIKeyPlugin.kt
@@ -1,0 +1,10 @@
+package software.amazon.smithy.aws.swift.codegen.plugins
+
+import software.amazon.smithy.aws.swift.codegen.swiftmodules.AWSClientRuntimeTypes
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.swift.codegen.integration.Plugin
+
+class BedrockAPIKeyPlugin(): Plugin {
+    override val className: Symbol = AWSClientRuntimeTypes.Customizations.BedrockAPIKeyPlugin
+    override val isDefault: Boolean = true
+}

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/swiftmodules/AWSClientRuntimeTypes.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/swiftmodules/AWSClientRuntimeTypes.kt
@@ -33,9 +33,8 @@ object AWSClientRuntimeTypes {
         }
     }
 
-    object RpcV2Cbor {
-        val RpcV2CborError = runtimeSymbol("RpcV2CborError", SwiftDeclaration.STRUCT, listOf("SmithyReadWrite"))
-        val CborValidateResponseHeaderMiddleware = runtimeSymbol("CborValidateResponseHeaderMiddleware", SwiftDeclaration.STRUCT)
+    object Customizations {
+        val BedrockAPIKeyPlugin = runtimeSymbol("BedrockAPIKeyPlugin", SwiftDeclaration.STRUCT)
     }
 
     object Core {


### PR DESCRIPTION
## Description of changes
Adds support for Bedrock API keys.  See https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html for details about this Bedrock feature.
- Adds a `BedrockAPIKeyPlugin` that detects the API key in the process environment, then loads it into the client.
- Plugin is added to all service clients in the `bedrock` sigv4 signing domain.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.