### PR TITLE
fix: Disable Bedrock integration test

### DIFF
--- a/IntegrationTests/Services/AWSBedrockRuntimeIntegrationTests/BedrockAPIKeyTests.swift
+++ b/IntegrationTests/Services/AWSBedrockRuntimeIntegrationTests/BedrockAPIKeyTests.swift
@@ -14,7 +14,7 @@ final class BedrockAPIKeyIntegrationTests: XCTestCase {
     let envVarName = "AWS_BEARER_TOKEN_BEDROCK"
     let apiKeyDuration: TimeInterval = 600.0
 
-    func test_apiKey_createsAPIKeyAndCallsWithIt() async throws {
+    func xtest_apiKey_createsAPIKeyAndCallsWithIt() async throws {
         // Set a Bedrock API token into the environment.
         let generator = BedrockAPIKeyGenerator(region: region, duration: apiKeyDuration)
         let token = try await generator.generate()


### PR DESCRIPTION
## Description of changes
Disables one integration test to unblock the automated build system.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.