### PR TITLE
chore: Remove package scope property

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSSwiftDependency.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/AWSSwiftDependency.kt
@@ -15,7 +15,6 @@ class AWSSwiftDependency {
                 "aws-sdk-swift",
                 "../../../aws-sdk-swift",
                 "AWSSDKChecksums",
-                SwiftDependency.DistributionMethod.SPR,
             )
         val AWS_SDK_IDENTITY_API =
             SwiftDependency(
@@ -25,7 +24,6 @@ class AWSSwiftDependency {
                 "aws-sdk-swift",
                 "../../../aws-sdk-swift",
                 "AWSSDKIdentityAPI",
-                SwiftDependency.DistributionMethod.SPR,
             )
         val AWS_SDK_IDENTITY =
             SwiftDependency(
@@ -35,7 +33,6 @@ class AWSSwiftDependency {
                 "aws-sdk-swift",
                 "../../../aws-sdk-swift",
                 "AWSSDKIdentity",
-                SwiftDependency.DistributionMethod.SPR,
             )
         val AWS_SDK_HTTP_AUTH =
             SwiftDependency(
@@ -45,7 +42,6 @@ class AWSSwiftDependency {
                 "aws-sdk-swift",
                 "../../../aws-sdk-swift",
                 "AWSSDKHTTPAuth",
-                SwiftDependency.DistributionMethod.SPR,
             )
         val AWS_SDK_EVENT_STREAMS_AUTH =
             SwiftDependency(
@@ -55,7 +51,6 @@ class AWSSwiftDependency {
                 "aws-sdk-swift",
                 "../../../aws-sdk-swift",
                 "AWSSDKEventStreamsAuth",
-                SwiftDependency.DistributionMethod.SPR,
             )
         val AWS_CLIENT_RUNTIME =
             SwiftDependency(
@@ -65,7 +60,6 @@ class AWSSwiftDependency {
                 "aws-sdk-swift",
                 "../../../aws-sdk-swift",
                 "AWSClientRuntime",
-                SwiftDependency.DistributionMethod.SPR,
             )
     }
 }


### PR DESCRIPTION
## Description of changes
Companion to smithy-swift PR https://github.com/smithy-lang/smithy-swift/pull/954.
Removes the `distributionMethod` property from AWS's `SwiftDependency` instances.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.