### PR TITLE
chore: Run "latest" Mac builds on macOS 26

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -76,12 +76,6 @@ jobs:
           xcrun simctl list > /dev/null
           sudo xcodebuild -downloadPlatform tvOS
           sudo xcodebuild -runFirstLaunch
-          cd aws-sdk-swift
-          set -o pipefail && \
-          NSUnbufferedIO=YES xcodebuild \
-            -scheme aws-sdk-swift-Package \
-            -showdestinations \
-            test 2>&1
       - name: Checkout aws-sdk-swift
         uses: actions/checkout@v4
         with:
@@ -91,6 +85,14 @@ jobs:
         with:
           AUTOMATION_USER_SSH_PRIVATE_KEY: ${{ secrets.AUTOMATION_USER_SSH_PRIVATE_KEY }}
           STAGING_PARTNER_REPO: ${{ secrets.STAGING_PARTNER_REPO }}
+      - name: Show destinations
+        run: |
+          cd aws-sdk-swift
+          set -o pipefail && \
+          NSUnbufferedIO=YES xcodebuild \
+            -scheme aws-sdk-swift-Package \
+            -showdestinations \
+            test 2>&1
       - name: Cache Gradle
         uses: actions/cache@v4
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Show destinations
         run: |
           cd aws-sdk-swift
-          xcrun create "iPhone 17" "iPhone 17"
+          xcrun simctl create "iPhone 17" "iPhone 17"
           xcrun simctl list > /dev/null
           set -o pipefail && \
           NSUnbufferedIO=YES xcodebuild \

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -56,26 +56,12 @@ jobs:
       - name: Configure Xcode
         run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app
       - name: Install visionOS sim if needed
-        if: ${{ contains(matrix.destination, 'platform=visionOS Simulator') }}
+        if: ${{ contains(matrix.runner, 'macos-14') && contains(matrix.destination, 'platform=visionOS Simulator') }}
         run: |
           sudo xcodebuild -runFirstLaunch
           xcrun simctl list > /dev/null
           sudo xcodebuild -downloadPlatform visionOS
           sudo xcodebuild -runFirstLaunch
-#     - name: Install iOS 26 sim if needed
-#       if: ${{ contains(matrix.xcode, '26') && contains(matrix.destination, 'platform=iOS Simulator') }}
-#       run: |
-#         sudo xcodebuild -runFirstLaunch
-#         xcrun simctl list > /dev/null
-#         sudo xcodebuild -downloadPlatform iOS
-#         sudo xcodebuild -runFirstLaunch
-#     - name: Install tvOS 26 sim if needed
-#       if: ${{ contains(matrix.xcode, '26') && contains(matrix.destination, 'platform=tvOS Simulator') }}
-#       run: |
-#         sudo xcodebuild -runFirstLaunch
-#         xcrun simctl list > /dev/null
-#         sudo xcodebuild -downloadPlatform tvOS
-#         sudo xcodebuild -runFirstLaunch
       - name: Checkout aws-sdk-swift
         uses: actions/checkout@v4
         with:
@@ -85,16 +71,6 @@ jobs:
         with:
           AUTOMATION_USER_SSH_PRIVATE_KEY: ${{ secrets.AUTOMATION_USER_SSH_PRIVATE_KEY }}
           STAGING_PARTNER_REPO: ${{ secrets.STAGING_PARTNER_REPO }}
-#     - name: Show destinations
-#       run: |
-#         cd aws-sdk-swift
-#         xcrun simctl create "iPhone 17" "iPhone 17"
-#         xcrun simctl list > /dev/null
-#         set -o pipefail && \
-#         NSUnbufferedIO=YES xcodebuild \
-#           -scheme aws-sdk-swift-Package \
-#           -showdestinations \
-#           2>&1
       - name: Cache Gradle
         uses: actions/cache@v4
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -88,6 +88,7 @@ jobs:
       - name: Show destinations
         run: |
           cd aws-sdk-swift
+          xcrun create "iPhone 17" "iPhone 17"
           xcrun simctl list > /dev/null
           set -o pipefail && \
           NSUnbufferedIO=YES xcodebuild \

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -85,16 +85,16 @@ jobs:
         with:
           AUTOMATION_USER_SSH_PRIVATE_KEY: ${{ secrets.AUTOMATION_USER_SSH_PRIVATE_KEY }}
           STAGING_PARTNER_REPO: ${{ secrets.STAGING_PARTNER_REPO }}
-      - name: Show destinations
-        run: |
-          cd aws-sdk-swift
-          xcrun simctl create "iPhone 17" "iPhone 17"
-          xcrun simctl list > /dev/null
-          set -o pipefail && \
-          NSUnbufferedIO=YES xcodebuild \
-            -scheme aws-sdk-swift-Package \
-            -showdestinations \
-            2>&1
+#     - name: Show destinations
+#       run: |
+#         cd aws-sdk-swift
+#         xcrun simctl create "iPhone 17" "iPhone 17"
+#         xcrun simctl list > /dev/null
+#         set -o pipefail && \
+#         NSUnbufferedIO=YES xcodebuild \
+#           -scheme aws-sdk-swift-Package \
+#           -showdestinations \
+#           2>&1
       - name: Cache Gradle
         uses: actions/cache@v4
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -69,6 +69,7 @@ jobs:
           xcrun simctl list > /dev/null
           sudo xcodebuild -downloadPlatform iOS
           sudo xcodebuild -runFirstLaunch
+          xcrun simctl create "iPhone 17" "iPhone 17"
           xcrun simctl list
       - name: Install tvOS 26 sim if needed
         if: ${{ contains(matrix.xcode, '26') && contains(matrix.destination, 'platform=tvOS Simulator') }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,7 @@ jobs:
         # This matrix runs tests on iOS sim & Mac, on oldest & newest supported Xcodes
         runner:
           - macos-14
-          - macos-15
+          - macos-26
         xcode:
           - Xcode_15.2
           - Xcode_26.0
@@ -36,7 +36,7 @@ jobs:
           - runner: macos-14
             xcode: Xcode_26.0
           # Don't run new macOS with old Xcode
-          - runner: macos-15
+          - runner: macos-26
             xcode: Xcode_15.2
           # Don't run old simulators with new Xcode
           - destination: 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
@@ -62,20 +62,20 @@ jobs:
           xcrun simctl list > /dev/null
           sudo xcodebuild -downloadPlatform visionOS
           sudo xcodebuild -runFirstLaunch
-      - name: Install iOS 26 sim if needed
-        if: ${{ contains(matrix.xcode, '26') && contains(matrix.destination, 'platform=iOS Simulator') }}
-        run: |
-          sudo xcodebuild -runFirstLaunch
-          xcrun simctl list > /dev/null
-          sudo xcodebuild -downloadPlatform iOS
-          sudo xcodebuild -runFirstLaunch
-      - name: Install tvOS 26 sim if needed
-        if: ${{ contains(matrix.xcode, '26') && contains(matrix.destination, 'platform=tvOS Simulator') }}
-        run: |
-          sudo xcodebuild -runFirstLaunch
-          xcrun simctl list > /dev/null
-          sudo xcodebuild -downloadPlatform tvOS
-          sudo xcodebuild -runFirstLaunch
+#     - name: Install iOS 26 sim if needed
+#       if: ${{ contains(matrix.xcode, '26') && contains(matrix.destination, 'platform=iOS Simulator') }}
+#       run: |
+#         sudo xcodebuild -runFirstLaunch
+#         xcrun simctl list > /dev/null
+#         sudo xcodebuild -downloadPlatform iOS
+#         sudo xcodebuild -runFirstLaunch
+#     - name: Install tvOS 26 sim if needed
+#       if: ${{ contains(matrix.xcode, '26') && contains(matrix.destination, 'platform=tvOS Simulator') }}
+#       run: |
+#         sudo xcodebuild -runFirstLaunch
+#         xcrun simctl list > /dev/null
+#         sudo xcodebuild -downloadPlatform tvOS
+#         sudo xcodebuild -runFirstLaunch
       - name: Checkout aws-sdk-swift
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -92,7 +92,7 @@ jobs:
           NSUnbufferedIO=YES xcodebuild \
             -scheme aws-sdk-swift-Package \
             -showdestinations \
-            test 2>&1
+            2>&1
       - name: Cache Gradle
         uses: actions/cache@v4
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -69,8 +69,6 @@ jobs:
           xcrun simctl list > /dev/null
           sudo xcodebuild -downloadPlatform iOS
           sudo xcodebuild -runFirstLaunch
-          xcrun simctl create "iPhone 17" "iPhone 17"
-          xcrun simctl list
       - name: Install tvOS 26 sim if needed
         if: ${{ contains(matrix.xcode, '26') && contains(matrix.destination, 'platform=tvOS Simulator') }}
         run: |
@@ -78,6 +76,12 @@ jobs:
           xcrun simctl list > /dev/null
           sudo xcodebuild -downloadPlatform tvOS
           sudo xcodebuild -runFirstLaunch
+          cd aws-sdk-swift
+          set -o pipefail && \
+          NSUnbufferedIO=YES xcodebuild \
+            -scheme aws-sdk-swift-Package \
+            -showdestinations \
+            test 2>&1
       - name: Checkout aws-sdk-swift
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -55,13 +55,6 @@ jobs:
     steps:
       - name: Configure Xcode
         run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app
-      - name: Install visionOS sim if needed
-        if: ${{ contains(matrix.runner, 'macos-14') && contains(matrix.destination, 'platform=visionOS Simulator') }}
-        run: |
-          sudo xcodebuild -runFirstLaunch
-          xcrun simctl list > /dev/null
-          sudo xcodebuild -downloadPlatform visionOS
-          sudo xcodebuild -runFirstLaunch
       - name: Checkout aws-sdk-swift
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -62,20 +62,21 @@ jobs:
           xcrun simctl list > /dev/null
           sudo xcodebuild -downloadPlatform visionOS
           sudo xcodebuild -runFirstLaunch
-#      - name: Install iOS 26 sim if needed
-#        if: ${{ contains(matrix.xcode, '26') && contains(matrix.destination, 'platform=iOS Simulator') }}
-#        run: |
-#          sudo xcodebuild -runFirstLaunch
-#          xcrun simctl list > /dev/null
-#          sudo xcodebuild -downloadPlatform iOS
-#          sudo xcodebuild -runFirstLaunch
-#      - name: Install tvOS 26 sim if needed
-#        if: ${{ contains(matrix.xcode, '26') && contains(matrix.destination, 'platform=tvOS Simulator') }}
-#        run: |
-#          sudo xcodebuild -runFirstLaunch
-#          xcrun simctl list > /dev/null
-#          sudo xcodebuild -downloadPlatform tvOS
-#          sudo xcodebuild -runFirstLaunch
+      - name: Install iOS 26 sim if needed
+        if: ${{ contains(matrix.xcode, '26') && contains(matrix.destination, 'platform=iOS Simulator') }}
+        run: |
+          sudo xcodebuild -runFirstLaunch
+          xcrun simctl list > /dev/null
+          sudo xcodebuild -downloadPlatform iOS
+          sudo xcodebuild -runFirstLaunch
+          xcrun simctl list
+      - name: Install tvOS 26 sim if needed
+        if: ${{ contains(matrix.xcode, '26') && contains(matrix.destination, 'platform=tvOS Simulator') }}
+        run: |
+          sudo xcodebuild -runFirstLaunch
+          xcrun simctl list > /dev/null
+          sudo xcodebuild -downloadPlatform tvOS
+          sudo xcodebuild -runFirstLaunch
       - name: Checkout aws-sdk-swift
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -62,20 +62,20 @@ jobs:
           xcrun simctl list > /dev/null
           sudo xcodebuild -downloadPlatform visionOS
           sudo xcodebuild -runFirstLaunch
-      - name: Install iOS 26 sim if needed
-        if: ${{ contains(matrix.xcode, '26') && contains(matrix.destination, 'platform=iOS Simulator') }}
-        run: |
-          sudo xcodebuild -runFirstLaunch
-          xcrun simctl list > /dev/null
-          sudo xcodebuild -downloadPlatform iOS
-          sudo xcodebuild -runFirstLaunch
-      - name: Install tvOS 26 sim if needed
-        if: ${{ contains(matrix.xcode, '26') && contains(matrix.destination, 'platform=tvOS Simulator') }}
-        run: |
-          sudo xcodebuild -runFirstLaunch
-          xcrun simctl list > /dev/null
-          sudo xcodebuild -downloadPlatform tvOS
-          sudo xcodebuild -runFirstLaunch
+#      - name: Install iOS 26 sim if needed
+#        if: ${{ contains(matrix.xcode, '26') && contains(matrix.destination, 'platform=iOS Simulator') }}
+#        run: |
+#          sudo xcodebuild -runFirstLaunch
+#          xcrun simctl list > /dev/null
+#          sudo xcodebuild -downloadPlatform iOS
+#          sudo xcodebuild -runFirstLaunch
+#      - name: Install tvOS 26 sim if needed
+#        if: ${{ contains(matrix.xcode, '26') && contains(matrix.destination, 'platform=tvOS Simulator') }}
+#        run: |
+#          sudo xcodebuild -runFirstLaunch
+#          xcrun simctl list > /dev/null
+#          sudo xcodebuild -downloadPlatform tvOS
+#          sudo xcodebuild -runFirstLaunch
       - name: Checkout aws-sdk-swift
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -88,6 +88,7 @@ jobs:
       - name: Show destinations
         run: |
           cd aws-sdk-swift
+          xcrun simctl list > /dev/null
           set -o pipefail && \
           NSUnbufferedIO=YES xcodebuild \
             -scheme aws-sdk-swift-Package \

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -60,13 +60,6 @@ jobs:
     steps:
       - name: Configure Xcode
         run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app
-      - name: Install visionOS sim if needed
-        if: ${{ contains(matrix.runner, 'macos-14') && contains(matrix.destination, 'platform=visionOS Simulator') }}
-        run: |
-          sudo xcodebuild -runFirstLaunch
-          xcrun simctl list > /dev/null
-          sudo xcodebuild -downloadPlatform visionOS
-          sudo xcodebuild -runFirstLaunch
       - name: Configure AWS Credentials for Integration Tests
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -24,7 +24,7 @@ jobs:
         # This matrix runs tests on iOS sim & Mac, on oldest & newest supported Xcodes
         runner:
           - macos-14
-          - macos-15
+          - macos-26
         xcode:
           - Xcode_15.2
           - Xcode_26.0
@@ -41,7 +41,7 @@ jobs:
           - runner: macos-14
             xcode: Xcode_26.0
           # Don't run new macOS with old Xcode
-          - runner: macos-15
+          - runner: macos-26
             xcode: Xcode_15.2
           # Don't run old simulators with new Xcode
           - destination: 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
@@ -61,25 +61,11 @@ jobs:
       - name: Configure Xcode
         run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app
       - name: Install visionOS sim if needed
-        if: ${{ contains(matrix.destination, 'platform=visionOS Simulator') }}
+        if: ${{ contains(matrix.runner, 'macos-14') && contains(matrix.destination, 'platform=visionOS Simulator') }}
         run: |
           sudo xcodebuild -runFirstLaunch
           xcrun simctl list > /dev/null
           sudo xcodebuild -downloadPlatform visionOS
-          sudo xcodebuild -runFirstLaunch
-      - name: Install iOS 26 sim if needed
-        if: ${{ contains(matrix.xcode, '26') && contains(matrix.destination, 'platform=iOS Simulator') }}
-        run: |
-          sudo xcodebuild -runFirstLaunch
-          xcrun simctl list > /dev/null
-          sudo xcodebuild -downloadPlatform iOS
-          sudo xcodebuild -runFirstLaunch
-      - name: Install tvOS 26 sim if needed
-        if: ${{ contains(matrix.xcode, '26') && contains(matrix.destination, 'platform=tvOS Simulator') }}
-        run: |
-          sudo xcodebuild -runFirstLaunch
-          xcrun simctl list > /dev/null
-          sudo xcodebuild -downloadPlatform tvOS
           sudo xcodebuild -runFirstLaunch
       - name: Configure AWS Credentials for Integration Tests
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Description of changes
- All install simulator steps are removed since Github runner images now ship with sims installed for the default macOS version.
- Latest macOS is changed to 26.  The `macos-26` runner is currently in beta, but unlike `macos-15` it ships with all Xcode 26 sims preinstalled & ready.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.