### PR TITLE
chore: Use Swift 6.2 as Linux latest

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -155,7 +155,7 @@ jobs:
           - jammy
         version:
           - "5.9"
-          - "6.1"
+          - "6.2"
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -164,7 +164,7 @@ jobs:
           - jammy
         version:
           - "5.9"
-          - "6.1"
+          - "6.2"
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:


### PR DESCRIPTION
## Description of changes
Use Swift 6.2 as the latest Linux image for CI & integration tests.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.