### PR TITLE
chore: Use iOS 26.0.1 simulator for CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -55,8 +55,6 @@ jobs:
     steps:
       - name: Configure Xcode
         run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app
-      - name: List all sims installed
-        run: xcrun simctl list
       - name: Checkout aws-sdk-swift
         uses: actions/checkout@v4
         with:
@@ -93,6 +91,8 @@ jobs:
           java-version: 17
       - name: Tools Versions
         run: ./aws-sdk-swift/scripts/ci_steps/log_tool_versions.sh
+      - name: List all sims installed
+        run: xcrun simctl list
       - name: Run CLI Unit Tests
         if: ${{ matrix.destination == 'platform=macOS' }}
         run: |
@@ -109,8 +109,8 @@ jobs:
           NSUnbufferedIO=YES xcodebuild \
             -scheme aws-sdk-swift-Package \
             -destination '${{ matrix.destination }}' \
-            test 2>&1 #\
-            # | xcbeautify
+            test 2>&1 \
+            | xcbeautify
       - name: Build and Run Protocol Tests
         run: |
           cd aws-sdk-swift/codegen/

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -30,7 +30,7 @@ jobs:
           - Xcode_26.0
         destination:
           - 'platform=iOS Simulator,OS=17.2,name=iPhone 15'
-          - 'platform=iOS Simulator,OS=26.0,name=iPhone 17'
+          - 'platform=iOS Simulator,OS=26.0.1,name=iPhone 17'
           - 'platform=tvOS Simulator,OS=17.2,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=tvOS Simulator,OS=26.0,name=Apple TV 4K (3rd generation) (at 1080p)'
           - 'platform=visionOS Simulator,OS=1.0,name=Apple Vision Pro'
@@ -53,7 +53,7 @@ jobs:
           # Don't run new simulators with old Xcode
           - destination: 'platform=tvOS Simulator,OS=26.0,name=Apple TV 4K (3rd generation) (at 1080p)'
             xcode: Xcode_15.2
-          - destination: 'platform=iOS Simulator,OS=26.0,name=iPhone 17'
+          - destination: 'platform=iOS Simulator,OS=26.0.1,name=iPhone 17'
             xcode: Xcode_15.2
           - destination: 'platform=visionOS Simulator,OS=26.0,name=Apple Vision Pro'
             xcode: Xcode_15.2
@@ -101,6 +101,8 @@ jobs:
           java-version: 17
       - name: Tools Versions
         run: ./aws-sdk-swift/scripts/ci_steps/log_tool_versions.sh
+      - name: List all sims installed
+        run: xcrun simctl list
       - name: Add Credentials to Test Plan
         run: |
           cd aws-sdk-swift


### PR DESCRIPTION
## Description of changes
Github has updated their `macos-26-arm64` runner image to version `20251022.0070` which uses iOS simulator 26.0.1 instead of 26.0.

See https://github.com/actions/runner-images/issues/13220

Update the xcodebuild destination accordingly.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.