### PR TITLE
chore: Increased randomization in integration test bucket names

### DIFF
--- a/IntegrationTests/Services/AWSS3IntegrationTests/S3XCTestCase.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/S3XCTestCase.swift
@@ -36,16 +36,19 @@ class S3XCTestCase: XCTestCase {
         }
     }
 
-    override func setUp() async throws{
-        self.bucketName = "aws-sdk-s3-integration-test-\(UUID().uuidString.split(separator: "-").first!.lowercased())"
+    override func setUp() async throws {
+        self.bucketName = "sdk-int-test-s3-\(UUID().uuidString.lowercased())" // 52 char bucket name (max 63)
         self.client = try S3Client(region: region)
         try await createBucket(bucketName: bucketName)
+        try await super.setUp()
     }
 
     /// Empty & delete the test bucket before each test.
     override func tearDown() async throws {
+        try await super.tearDown()
         try await emptyBucket()
         try await deleteBucket(bucketName: bucketName)
+        self.client = nil
     }
 
     // MARK: Helpers


### PR DESCRIPTION
## Description of changes
Increase the randomness of S3 integration test bucket names by using the entire UUID in the bucket name, not just the first 8 chars.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.