### PR TITLE
fix: Restore the old Partitions.swift file

### DIFF
--- a/Sources/Core/AWSSDKPartitions/Sources/AWSSDKPartitions/Partitions.swift
+++ b/Sources/Core/AWSSDKPartitions/Sources/AWSSDKPartitions/Partitions.swift
@@ -1,0 +1,278 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Code is auto-generated. DO NOT EDIT!
+
+public let partitions = #"""
+{
+  "partitions" : [ {
+    "id" : "aws",
+    "outputs" : {
+      "dnsSuffix" : "amazonaws.com",
+      "dualStackDnsSuffix" : "api.aws",
+      "implicitGlobalRegion" : "us-east-1",
+      "name" : "aws",
+      "supportsDualStack" : true,
+      "supportsFIPS" : true
+    },
+    "regionRegex" : "^(us|eu|ap|sa|ca|me|af|il|mx)\\-\\w+\\-\\d+$",
+    "regions" : {
+      "af-south-1" : {
+        "description" : "Africa (Cape Town)"
+      },
+      "ap-east-1" : {
+        "description" : "Asia Pacific (Hong Kong)"
+      },
+      "ap-east-2" : {
+        "description" : "Asia Pacific (Taipei)"
+      },
+      "ap-northeast-1" : {
+        "description" : "Asia Pacific (Tokyo)"
+      },
+      "ap-northeast-2" : {
+        "description" : "Asia Pacific (Seoul)"
+      },
+      "ap-northeast-3" : {
+        "description" : "Asia Pacific (Osaka)"
+      },
+      "ap-south-1" : {
+        "description" : "Asia Pacific (Mumbai)"
+      },
+      "ap-south-2" : {
+        "description" : "Asia Pacific (Hyderabad)"
+      },
+      "ap-southeast-1" : {
+        "description" : "Asia Pacific (Singapore)"
+      },
+      "ap-southeast-2" : {
+        "description" : "Asia Pacific (Sydney)"
+      },
+      "ap-southeast-3" : {
+        "description" : "Asia Pacific (Jakarta)"
+      },
+      "ap-southeast-4" : {
+        "description" : "Asia Pacific (Melbourne)"
+      },
+      "ap-southeast-5" : {
+        "description" : "Asia Pacific (Malaysia)"
+      },
+      "ap-southeast-6" : {
+        "description" : "Asia Pacific (New Zealand)"
+      },
+      "ap-southeast-7" : {
+        "description" : "Asia Pacific (Thailand)"
+      },
+      "aws-global" : {
+        "description" : "aws global region"
+      },
+      "ca-central-1" : {
+        "description" : "Canada (Central)"
+      },
+      "ca-west-1" : {
+        "description" : "Canada West (Calgary)"
+      },
+      "eu-central-1" : {
+        "description" : "Europe (Frankfurt)"
+      },
+      "eu-central-2" : {
+        "description" : "Europe (Zurich)"
+      },
+      "eu-north-1" : {
+        "description" : "Europe (Stockholm)"
+      },
+      "eu-south-1" : {
+        "description" : "Europe (Milan)"
+      },
+      "eu-south-2" : {
+        "description" : "Europe (Spain)"
+      },
+      "eu-west-1" : {
+        "description" : "Europe (Ireland)"
+      },
+      "eu-west-2" : {
+        "description" : "Europe (London)"
+      },
+      "eu-west-3" : {
+        "description" : "Europe (Paris)"
+      },
+      "il-central-1" : {
+        "description" : "Israel (Tel Aviv)"
+      },
+      "me-central-1" : {
+        "description" : "Middle East (UAE)"
+      },
+      "me-south-1" : {
+        "description" : "Middle East (Bahrain)"
+      },
+      "mx-central-1" : {
+        "description" : "Mexico (Central)"
+      },
+      "sa-east-1" : {
+        "description" : "South America (Sao Paulo)"
+      },
+      "us-east-1" : {
+        "description" : "US East (N. Virginia)"
+      },
+      "us-east-2" : {
+        "description" : "US East (Ohio)"
+      },
+      "us-west-1" : {
+        "description" : "US West (N. California)"
+      },
+      "us-west-2" : {
+        "description" : "US West (Oregon)"
+      }
+    }
+  }, {
+    "id" : "aws-cn",
+    "outputs" : {
+      "dnsSuffix" : "amazonaws.com.cn",
+      "dualStackDnsSuffix" : "api.amazonwebservices.com.cn",
+      "implicitGlobalRegion" : "cn-northwest-1",
+      "name" : "aws-cn",
+      "supportsDualStack" : true,
+      "supportsFIPS" : true
+    },
+    "regionRegex" : "^cn\\-\\w+\\-\\d+$",
+    "regions" : {
+      "aws-cn-global" : {
+        "description" : "aws-cn global region"
+      },
+      "cn-north-1" : {
+        "description" : "China (Beijing)"
+      },
+      "cn-northwest-1" : {
+        "description" : "China (Ningxia)"
+      }
+    }
+  }, {
+    "id" : "aws-eusc",
+    "outputs" : {
+      "dnsSuffix" : "amazonaws.eu",
+      "dualStackDnsSuffix" : "api.amazonwebservices.eu",
+      "implicitGlobalRegion" : "eusc-de-east-1",
+      "name" : "aws-eusc",
+      "supportsDualStack" : true,
+      "supportsFIPS" : true
+    },
+    "regionRegex" : "^eusc\\-(de)\\-\\w+\\-\\d+$",
+    "regions" : {
+      "eusc-de-east-1" : {
+        "description" : "EU (Germany)"
+      }
+    }
+  }, {
+    "id" : "aws-iso",
+    "outputs" : {
+      "dnsSuffix" : "c2s.ic.gov",
+      "dualStackDnsSuffix" : "api.aws.ic.gov",
+      "implicitGlobalRegion" : "us-iso-east-1",
+      "name" : "aws-iso",
+      "supportsDualStack" : true,
+      "supportsFIPS" : true
+    },
+    "regionRegex" : "^us\\-iso\\-\\w+\\-\\d+$",
+    "regions" : {
+      "aws-iso-global" : {
+        "description" : "aws-iso global region"
+      },
+      "us-iso-east-1" : {
+        "description" : "US ISO East"
+      },
+      "us-iso-west-1" : {
+        "description" : "US ISO WEST"
+      }
+    }
+  }, {
+    "id" : "aws-iso-b",
+    "outputs" : {
+      "dnsSuffix" : "sc2s.sgov.gov",
+      "dualStackDnsSuffix" : "api.aws.scloud",
+      "implicitGlobalRegion" : "us-isob-east-1",
+      "name" : "aws-iso-b",
+      "supportsDualStack" : true,
+      "supportsFIPS" : true
+    },
+    "regionRegex" : "^us\\-isob\\-\\w+\\-\\d+$",
+    "regions" : {
+      "aws-iso-b-global" : {
+        "description" : "aws-iso-b global region"
+      },
+      "us-isob-east-1" : {
+        "description" : "US ISOB East (Ohio)"
+      },
+      "us-isob-west-1" : {
+        "description" : "US ISOB West"
+      }
+    }
+  }, {
+    "id" : "aws-iso-e",
+    "outputs" : {
+      "dnsSuffix" : "cloud.adc-e.uk",
+      "dualStackDnsSuffix" : "api.cloud-aws.adc-e.uk",
+      "implicitGlobalRegion" : "eu-isoe-west-1",
+      "name" : "aws-iso-e",
+      "supportsDualStack" : true,
+      "supportsFIPS" : true
+    },
+    "regionRegex" : "^eu\\-isoe\\-\\w+\\-\\d+$",
+    "regions" : {
+      "aws-iso-e-global" : {
+        "description" : "aws-iso-e global region"
+      },
+      "eu-isoe-west-1" : {
+        "description" : "EU ISOE West"
+      }
+    }
+  }, {
+    "id" : "aws-iso-f",
+    "outputs" : {
+      "dnsSuffix" : "csp.hci.ic.gov",
+      "dualStackDnsSuffix" : "api.aws.hci.ic.gov",
+      "implicitGlobalRegion" : "us-isof-south-1",
+      "name" : "aws-iso-f",
+      "supportsDualStack" : true,
+      "supportsFIPS" : true
+    },
+    "regionRegex" : "^us\\-isof\\-\\w+\\-\\d+$",
+    "regions" : {
+      "aws-iso-f-global" : {
+        "description" : "aws-iso-f global region"
+      },
+      "us-isof-east-1" : {
+        "description" : "US ISOF EAST"
+      },
+      "us-isof-south-1" : {
+        "description" : "US ISOF SOUTH"
+      }
+    }
+  }, {
+    "id" : "aws-us-gov",
+    "outputs" : {
+      "dnsSuffix" : "amazonaws.com",
+      "dualStackDnsSuffix" : "api.aws",
+      "implicitGlobalRegion" : "us-gov-west-1",
+      "name" : "aws-us-gov",
+      "supportsDualStack" : true,
+      "supportsFIPS" : true
+    },
+    "regionRegex" : "^us\\-gov\\-\\w+\\-\\d+$",
+    "regions" : {
+      "aws-us-gov-global" : {
+        "description" : "aws-us-gov global region"
+      },
+      "us-gov-east-1" : {
+        "description" : "AWS GovCloud (US-East)"
+      },
+      "us-gov-west-1" : {
+        "description" : "AWS GovCloud (US-West)"
+      }
+    }
+  } ],
+  "version" : "1.1"
+}
+"""#


### PR DESCRIPTION
## Description of changes
Restore this file to prevent failure in automatic build system.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.