### PR TITLE
fix: Use full UUIDs for random identifiers in integration tests

### DIFF
--- a/IntegrationTests/AWSIntegrationTestUtils/String+Identifier.swift
+++ b/IntegrationTests/AWSIntegrationTestUtils/String+Identifier.swift
@@ -1,0 +1,32 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+import struct Foundation.UUID
+
+package extension String {
+    
+    /// Returns an identifier that contains a UUID and is 63 or less chars in length.
+    ///
+    /// Size is selected to be compatible with the requirement that bucket names be 63 characters or less.
+    /// - Parameter service: The name (or abbreviation) of the service being identified.
+    /// May contain only A-Z, a-z, 0-9, and dash(-).  May not be empty.  May not be long enough to result in an
+    /// identifier 64 chars or longer.  Uppercase characters in the service will be downcased in the identifier.
+    /// - Returns: The identifier.
+    static func uniqueID(service: String) -> String {
+        let prefix = "sdkinttest-"
+        guard !service.isEmpty else {
+            fatalError("Service cannot be empty")
+        }
+        guard service.lowercased().allSatisfy({ "abcdefghijklmnopqrstuvwxyz0123456789-".contains($0) }) else {
+            fatalError("Service cannot contain characters other than alphanumeric & dash")
+        }
+        guard prefix.count + service.count + 36 < 64 else {
+            fatalError("Service name is too long.  Limit is \(63 - prefix.count - 36)")
+        }
+        return (prefix + service + UUID().uuidString).lowercased()
+    }
+}

--- a/IntegrationTests/Services/AWSCloudFrontKeyValueStoreIntegrationTests/CloudFrontKeyValueStoreSigV4ATests.swift
+++ b/IntegrationTests/Services/AWSCloudFrontKeyValueStoreIntegrationTests/CloudFrontKeyValueStoreSigV4ATests.swift
@@ -11,6 +11,7 @@ import ClientRuntime
 import AWSClientRuntime
 import AWSCloudFront
 import AWSCloudFrontKeyValueStore
+import AWSIntegrationTestUtils
 
 /// Tests SigV4a signing flow using CloudFrontKeyValueStore.
 class CloudFrontKeyValueStoreSigV4ATests: XCTestCase {
@@ -23,7 +24,7 @@ class CloudFrontKeyValueStoreSigV4ATests: XCTestCase {
     private let region = "us-east-1"
 
     // Temporary name of the KVS to use for the test
-    private let kvsName = "sigv4a-test-kvs-" + UUID().uuidString.split(separator: "-").first!.lowercased()
+    private let kvsName = String.uniqueID(service: "sigv4a-kvs")
 
     // The Etag to use to call CloudFront::deletKeyValueStore
     private var cfEtag: String!

--- a/IntegrationTests/Services/AWSCognitoIdentityIntegrationTests/CognitoAWSCredentialIdentityResolverTests.swift
+++ b/IntegrationTests/Services/AWSCognitoIdentityIntegrationTests/CognitoAWSCredentialIdentityResolverTests.swift
@@ -12,6 +12,7 @@ import AWSSTS
 import ClientRuntime
 import SmithyWaitersAPI
 import XCTest
+import AWSIntegrationTestUtils
 
 /// Tests CognitoAWSCredentialIdentityResolver using STS::getCallerIdentity.
 class CognitoAWSCredentialIdentityResolverTests: XCTestCase {
@@ -19,7 +20,7 @@ class CognitoAWSCredentialIdentityResolverTests: XCTestCase {
 
     private var cognitoIdentityClient: CognitoIdentityClient!
     private var iamClient: IAMClient!
-    private let identityPoolName = "aws-cognito-integration-test-\(UUID().uuidString.split(separator: "-").first!.lowercased())"
+    private let identityPoolName = String.uniqueID(service: "cognito")
     private var identityPoolId: String!
     private var roleName: String!
 
@@ -38,7 +39,7 @@ class CognitoAWSCredentialIdentityResolverTests: XCTestCase {
             )
         ).identityPoolId
         // Create an IAM role for unauthenticated users
-        roleName = "CognitoUnauth_\(identityPoolName)"
+        roleName = String.uniqueID(service: "cog-role")
         let trustPolicy = """
         {
             "Version": "2012-10-17",

--- a/IntegrationTests/Services/AWSCognitoIdentityIntegrationTests/UnauthenticatedAPITests.swift
+++ b/IntegrationTests/Services/AWSCognitoIdentityIntegrationTests/UnauthenticatedAPITests.swift
@@ -12,6 +12,7 @@ import AWSClientRuntime
 import ClientRuntime
 import class SmithyHTTPAPI.HTTPRequest
 import class SmithyHTTPAPI.HTTPResponse
+import AWSIntegrationTestUtils
 
 /// Tests unauthenciated API using AWSCognitoIdentity::getId
 class UnauthenticatedAPITests: XCTestCase {
@@ -22,7 +23,7 @@ class UnauthenticatedAPITests: XCTestCase {
 
     private var accountID: String!
     private var identityPoolID: String!
-    private let identityPoolName = "idpool" + UUID().uuidString.split(separator: "-").first!.lowercased()
+    private let identityPoolName = String.uniqueID(service: "idpool")
 
     override func setUp() async throws {
         // STS client for getting the account ID, an input parameter for the unauthenticated API, getId().

--- a/IntegrationTests/Services/AWSEventBridgeIntegrationTests/EventBridgeSigV4ATests.swift
+++ b/IntegrationTests/Services/AWSEventBridgeIntegrationTests/EventBridgeSigV4ATests.swift
@@ -11,6 +11,7 @@ import AWSEventBridge
 import ClientRuntime
 import AWSClientRuntime
 import AWSRoute53
+import AWSIntegrationTestUtils
 
 /// Tests SigV4a signing flow using EventBridge's global endpoint.
 class EventBridgeSigV4ATests: XCTestCase {
@@ -28,8 +29,8 @@ class EventBridgeSigV4ATests: XCTestCase {
     private let secondaryRegion = "us-east-1"
 
     // Name for the EventBridge global endpoint
-    private let endpointName = "sigv4a-test-global-endpoint-\(UUID().uuidString.split(separator: "-").first!.lowercased())"
-    private let eventBusName = "sigv4a-integ-test-eventbus-\(UUID().uuidString.split(separator: "-").first!.lowercased())"
+    private let endpointName = String.uniqueID(service: "eb-globalendpt")
+    private let eventBusName = String.uniqueID(service: "eb-eventbus")
     private var endpointId: String!
 
     private var healthCheckId: String!
@@ -58,7 +59,7 @@ class EventBridgeSigV4ATests: XCTestCase {
             type: .https
         )
         let createHealthCheckInput = CreateHealthCheckInput(
-            callerReference: UUID().uuidString.split(separator: "-").first!.lowercased(),
+            callerReference: String.uniqueID(service: "r53-healthchk"),
             healthCheckConfig: healthCheckConfig
         )
         let healthCheck = try await route53Client.createHealthCheck(input: createHealthCheckInput)

--- a/IntegrationTests/Services/AWSGlacierIntegrationTests/GlacierTests.swift
+++ b/IntegrationTests/Services/AWSGlacierIntegrationTests/GlacierTests.swift
@@ -11,6 +11,7 @@ import AWSGlacier
 import AWSSTS
 import enum Smithy.ByteStream
 import SmithyWaitersAPI
+import AWSIntegrationTestUtils
 
 /// Tests that Glacier operations run successfully
 class GlacierTests: XCTestCase {
@@ -18,7 +19,7 @@ class GlacierTests: XCTestCase {
     var stsClient: STSClient!
     var accountId: String!
     var archiveId: String!
-    let vaultName = UUID().uuidString.split(separator: "-").first!.lowercased() + "integ-test-vault"
+    let vaultName = String.uniqueID(service: "s3-glacier")
 
     override func setUp() async throws {
         stsClient = try STSClient(region: "us-east-1")

--- a/IntegrationTests/Services/AWSKinesisIntegrationTests/KinesisTests.swift
+++ b/IntegrationTests/Services/AWSKinesisIntegrationTests/KinesisTests.swift
@@ -10,6 +10,7 @@ import AWSKinesis
 import ClientRuntime
 import AWSClientRuntime
 import SmithyWaitersAPI
+import AWSIntegrationTestUtils
 
 class KinesisTests: XCTestCase {
 
@@ -23,7 +24,7 @@ class KinesisTests: XCTestCase {
         // Client must have AWS credentials set that allow access to the Kinesis service.
         // Resources will be cleaned up before the test concludes, pass or fail, unless the test crashes.
 
-        let streamName = UUID().uuidString
+        let streamName = String.uniqueID(service: "kinesis")
         let client = try KinesisClient(region: "us-west-2")
 
         do {
@@ -36,7 +37,7 @@ class KinesisTests: XCTestCase {
             let streamARN = stream.streamDescription?.streamARN
 
             // Make a set of 10 records, add them to the stream
-            var recordStrings = (1...10).map { _ in UUID().uuidString }
+            var recordStrings = (1...10).map { _ in String.uniqueID(service: "kinesis") }
             for record in recordStrings {
                 let putRecordInput = PutRecordInput(data: record.data(using: .utf8), explicitHashKey: nil, partitionKey: "Test", sequenceNumberForOrdering: nil, streamName: streamName)
                 let _ = try await client.putRecord(input: putRecordInput)
@@ -48,7 +49,7 @@ class KinesisTests: XCTestCase {
             let shard = shardList.shards?.first!
 
             // Create a consumer for the shard
-            let consumerName = UUID().uuidString
+            let consumerName = String.uniqueID(service: "kinesis")
             let consumerInput = RegisterStreamConsumerInput(consumerName: consumerName, streamARN: stream.streamDescription?.streamARN)
             let consumer = try await client.registerStreamConsumer(input: consumerInput)
             let consumerARN = consumer.consumer?.consumerARN

--- a/IntegrationTests/Services/AWSS3IntegrationTests/S3ConcurrentTests.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/S3ConcurrentTests.swift
@@ -41,18 +41,18 @@ final class S3ConcurrentTests: S3XCTestCase, @unchecked Sendable {
     // Puts data to S3, gets the uploaded file, asserts retrieved data == original data, deletes S3 object
     @Sendable
     private func getObject(data: Data) async throws {
-       let objectKey = UUID().uuidString.split(separator: "-").first!.lowercased()
-       let putObjectInput = PutObjectInput(body: .data(data), bucket: bucketName, key: objectKey)
+        let objectKey = String.uniqueID(service: "s3")
+        let putObjectInput = PutObjectInput(body: .data(data), bucket: bucketName, key: objectKey)
 
-       _ = try await client.putObject(input: putObjectInput)
+        _ = try await client.putObject(input: putObjectInput)
 
-       let retrievedData = try await client.getObject(input: GetObjectInput(
-           bucket: bucketName, key: objectKey
-       )).body?.readData()
+        let retrievedData = try await client.getObject(input: GetObjectInput(
+            bucket: bucketName, key: objectKey
+        )).body?.readData()
 
-       XCTAssertEqual(data, retrievedData)
+        XCTAssertEqual(data, retrievedData)
 
-       let deleteObjectInput = DeleteObjectInput(bucket: bucketName, key: objectKey)
-       _ = try await client.deleteObject(input: deleteObjectInput)
+        let deleteObjectInput = DeleteObjectInput(bucket: bucketName, key: objectKey)
+        _ = try await client.deleteObject(input: deleteObjectInput)
    }
 }

--- a/IntegrationTests/Services/AWSS3IntegrationTests/S3ContentMD5HeaderTests.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/S3ContentMD5HeaderTests.swift
@@ -17,7 +17,7 @@ final class S3ContentMD5HeaderTests: S3XCTestCase {
         try await super.setUp()
         // Generate 3 UUIDs to use as object keys and save them
         for _ in 1...3 {
-            objectKeys.append("key-\(UUID().uuidString.split(separator: "-").first!.lowercased())")
+            objectKeys.append(String.uniqueID(service: "s3"))
         }
     }
 

--- a/IntegrationTests/Services/AWSS3IntegrationTests/S3EmptyBody404Tests.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/S3EmptyBody404Tests.swift
@@ -30,7 +30,7 @@ class S3EmptyBody404Tests: S3XCTestCase {
 
             // Perform the S3 HeadObject operation on a nonexistent object.
             // This will cause the 404 error without a body.
-            let input = HeadObjectInput(bucket: bucketName, key: UUID().uuidString)
+            let input = HeadObjectInput(bucket: bucketName, key: String.uniqueID(service: "s3"))
             _ = try await client.headObject(input: input)
 
             // If an error was not thrown by the HeadObject call, fail the test.

--- a/IntegrationTests/Services/AWSS3IntegrationTests/S3ErrorTests.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/S3ErrorTests.swift
@@ -11,12 +11,13 @@ import XCTest
 import AWSS3
 import AWSClientRuntime
 import SmithyIdentity
+import AWSIntegrationTestUtils
 
 class S3ErrorTests: S3XCTestCase {
 
     func test_noSuchKey_throwsNoSuchKeyWhenUnknownKeyIsUsed() async throws {
         do {
-            let input = GetObjectInput(bucket: bucketName, key: UUID().uuidString)
+            let input = GetObjectInput(bucket: bucketName, key: String.uniqueID(service: "s3-error"))
             _ = try await client.getObject(input: input)
             XCTFail("Request should not have succeeded")
         } catch let error as NoSuchKey {
@@ -42,7 +43,7 @@ class S3ErrorTests: S3XCTestCase {
 
     func test_requestID_hasARequestIDAndRequestID2() async throws {
         do {
-            let input = GetObjectInput(bucket: bucketName, key: UUID().uuidString)
+            let input = GetObjectInput(bucket: bucketName, key: String.uniqueID(service: "s3-error"))
             _ = try await client.getObject(input: input)
             XCTFail("Request should not have succeeded")
         } catch let error as NoSuchKey {
@@ -57,7 +58,7 @@ class S3ErrorTests: S3XCTestCase {
 
     func test_InvalidObjectState_hasReadableProperties() async throws {
         do {
-            let key = UUID().uuidString + ".txt"
+            let key = String.uniqueID(service: "s3-error") + ".txt"
             let putInput = PutObjectInput(bucket: bucketName, key: key, storageClass: .glacier)
             _ = try await client.putObject(input: putInput)
             let getInput = GetObjectInput(bucket: bucketName, key: key)
@@ -77,7 +78,7 @@ class S3ErrorTests: S3XCTestCase {
             let credentials = AWSCredentialIdentity(accessKey: "AKIDEXAMPLE", secret: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
             let awsCredentialIdentityResolver = StaticAWSCredentialIdentityResolver(credentials)
             let config = try await S3Client.S3ClientConfiguration(awsCredentialIdentityResolver: awsCredentialIdentityResolver, region: region)
-            let input = GetObjectInput(bucket: bucketName, key: UUID().uuidString)
+            let input = GetObjectInput(bucket: bucketName, key: String.uniqueID(service: "s3-error"))
             _ = try await S3Client(config: config).getObject(input: input)
             XCTFail("Request should not have succeeded")
         } catch let error as InvalidAccessKeyId {

--- a/IntegrationTests/Services/AWSS3IntegrationTests/S3ExpressXCTestCase.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/S3ExpressXCTestCase.swift
@@ -7,6 +7,7 @@
 
 import XCTest
 import AWSS3
+import AWSIntegrationTestUtils
 
 class S3ExpressXCTestCase: XCTestCase {
     // Region in which to run the test
@@ -28,10 +29,8 @@ class S3ExpressXCTestCase: XCTestCase {
     }
 
     @discardableResult
-    func createS3ExpressBucket(
-        baseName: String = String(UUID().uuidString.prefix(8)).lowercased()
-    ) async throws -> String {
-        let bucket = bucket(baseName: baseName)
+    func createS3ExpressBucket() async throws -> String {
+        let bucket = bucket()
         let input = CreateBucketInput(
             bucket: bucket,
             createBucketConfiguration: .init(
@@ -53,8 +52,8 @@ class S3ExpressXCTestCase: XCTestCase {
         _ = try await client.deleteBucket(input: deleteBucketInput)
     }
 
-    // Helper method to create a S3Express-compliant bucket name
-    func bucket(baseName: String) -> String {
-        "a\(baseName)--\(azID)--x-s3"
+    // Helper method to create a random, S3Express-compliant bucket name
+    func bucket() -> String {
+        "inttest-\(UUID().uuidString.lowercased())--\(azID)--x-s3"
     }
 }

--- a/IntegrationTests/Services/AWSS3IntegrationTests/S3SigV4ATests.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/S3SigV4ATests.swift
@@ -16,6 +16,7 @@ import AWSS3Control
 import AWSSTS
 import ClientRuntime
 import AWSClientRuntime
+import AWSIntegrationTestUtils
 
 /// Tests SigV4A signing flow using S3's Multi-Region Access Point (MRAP).
 class S3SigV4ATests: S3XCTestCase {
@@ -29,8 +30,8 @@ class S3SigV4ATests: S3XCTestCase {
     private var mrapArnFormat = "arn:aws:s3::%@:accesspoint/%@"
     private var mrapArn: String!
     private var mrapAlias: String!
-    private let mrapNamePrefix = "aws-sdk-s3-integration-test-"
-    private let mrapName = "aws-sdk-s3-integration-test-" + UUID().uuidString.split(separator: "-").first!.lowercased()
+    private let mrapNamePrefix = "sdk-inttest-"
+    private let mrapName = "sdk-inttest-" + UUID().uuidString.lowercased()  // 3-50 chars long
     private var mrapConfig: S3ControlClientTypes.CreateMultiRegionAccessPointInput!
 
     // The S3 control client used to create and delete MRAP
@@ -41,7 +42,7 @@ class S3SigV4ATests: S3XCTestCase {
     private var accountId: String!
 
     // Key string used for putting object in tests
-    private let key = UUID().uuidString.split(separator: "-").first!.lowercased()
+    private let key = String.uniqueID(service: "s3-sigv4a")
 
     private let NSEC_PER_SEC = 1_000_000_000
 
@@ -182,7 +183,7 @@ class S3SigV4ATests: S3XCTestCase {
         // Create S3 Multi-Region Access Point (MRAP)
         let createMRAPInput = CreateMultiRegionAccessPointInput(
             accountId: accountId,
-            clientToken: UUID().uuidString.split(separator: "-").first!.lowercased(),
+            clientToken: UUID().uuidString.lowercased(),
             details: mrapConfig
         )
         _ = try await s3ControlClient.createMultiRegionAccessPoint(input: createMRAPInput)

--- a/IntegrationTests/Services/AWSS3IntegrationTests/S3XCTestCase.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/S3XCTestCase.swift
@@ -10,6 +10,7 @@ import FoundationNetworking
 #endif
 import XCTest
 import AWSS3
+import AWSIntegrationTestUtils
 
 /// Provides a basic set of functions that can be used to perform S3 integration tests.
 /// Creates a bucket for testing before every test, then deletes the bucket after the test completes.
@@ -37,7 +38,7 @@ class S3XCTestCase: XCTestCase {
     }
 
     override func setUp() async throws {
-        self.bucketName = "sdk-int-test-s3-\(UUID().uuidString.lowercased())" // 52 char bucket name (max 63)
+        self.bucketName = String.uniqueID(service: "s3")
         self.client = try S3Client(region: region)
         try await createBucket(bucketName: bucketName)
         try await super.setUp()

--- a/IntegrationTests/Services/AWSSQSIntegrationTests/SQSTests.swift
+++ b/IntegrationTests/Services/AWSSQSIntegrationTests/SQSTests.swift
@@ -9,6 +9,7 @@ import XCTest
 import AWSSQS
 import ClientRuntime
 import AWSClientRuntime
+import AWSIntegrationTestUtils
 
 /// Tests AWS SQS queue creation and deletion.
 class SQSTests: XCTestCase {
@@ -20,7 +21,7 @@ class SQSTests: XCTestCase {
 
     override func setUp() async throws {
         self.client = try SQSClient(region: "us-west-1")
-        queueName = "integration-test-queue-\(UUID().uuidString)"
+        queueName = String.uniqueID(service: "sqs")
     }
 
     override func tearDown() async throws {

--- a/IntegrationTests/Services/AWSSTSIntegrationTests/STSAssumeRoleAWSCredentialIdentityResolverTests.swift
+++ b/IntegrationTests/Services/AWSSTSIntegrationTests/STSAssumeRoleAWSCredentialIdentityResolverTests.swift
@@ -11,12 +11,10 @@ import AWSSTS
 import AWSIAM
 import AWSSDKIdentity
 import ClientRuntime
+import AWSIntegrationTestUtils
 #if canImport(InMemoryExporter)
 import InMemoryExporter
 #endif
-//#if os(Linux)
-//import OpenTelemetryConcurrency
-//#endif
 
 class STSAssumeRoleAWSCredentialIdentityResolverTests: XCTestCase {
     private let region = "us-east-1"
@@ -29,8 +27,8 @@ class STSAssumeRoleAWSCredentialIdentityResolverTests: XCTestCase {
 
     // Used to create temporary role assumed by STS assume role credentials provider.
     private var iamClient: IAMClient!
-    private let roleName = "aws-sts-integration-test-\(UUID().uuidString.split(separator: "-").first!.lowercased())"
-    private let roleSessionName = "aws-sts-integration-test-\(UUID().uuidString.split(separator: "-").first!.lowercased())"
+    private let roleName = String.uniqueID(service: "sts")
+    private let roleSessionName = String.uniqueID(service: "sts")
     private var roleArn: String!
 
     // JSON assume role policy

--- a/IntegrationTests/Services/AWSSTSIntegrationTests/STSWebIdentityAWSCredentialIdentityResolverTests.swift
+++ b/IntegrationTests/Services/AWSSTSIntegrationTests/STSWebIdentityAWSCredentialIdentityResolverTests.swift
@@ -13,6 +13,7 @@ import ClientRuntime
 import AWSClientRuntime
 import Foundation
 import AWSSDKIdentity
+import AWSIntegrationTestUtils
 
 /// Tests STS web identity credentials provider using STS::getCallerIdentity.
 class STSWebIdentityAWSCredentialIdentityResolverTests: XCTestCase {
@@ -30,7 +31,7 @@ class STSWebIdentityAWSCredentialIdentityResolverTests: XCTestCase {
     private var cognitoIdentityClient: CognitoIdentityClient!
     // Regular STS client used to fetch the account ID used in fetching cognito ID.
     private var stsClient: STSClient!
-    private let identityPoolName = "aws-sts-integration-test-\(UUID().uuidString.split(separator: "-").first!.lowercased())"
+    private let identityPoolName = String.uniqueID(service: "sts-web-id")
     private var identityPoolId: String!
     private var oidcToken: String!
     private var oidcTokenFilePath: String!
@@ -39,8 +40,8 @@ class STSWebIdentityAWSCredentialIdentityResolverTests: XCTestCase {
 
     // Used to create temporary role assumed by STS web identity credentials provider.
     private var iamClient: IAMClient!
-    private let roleName = "aws-sts-integration-test-\(UUID().uuidString.split(separator: "-").first!.lowercased())"
-    private let roleSessionName = "aws-sts-integration-test-\(UUID().uuidString.split(separator: "-").first!.lowercased())"
+    private let roleName = String.uniqueID(service: "sts-web-id")
+    private let roleSessionName = String.uniqueID(service: "sts-web-id")
     private var roleArn: String!
 
     // JSON assume role policy


### PR DESCRIPTION
## Description of changes
Recently it was noted that there were occasional name collisions between S3 buckets when the buckets were named using the first 8 digits of a UUID for randomness.  Switching to full UUIDs appears to have eliminated the problem.

This PR takes every other place that something less than a full UUID was used in a random name, and converts it to a full UUID.
- A helper method was created for generating random names that are easily identifiable to a specific test.
- One test was refactored to move its cleanup steps into a `tearDown` method.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.