### PR TITLE
chore: Sort imports

### DIFF
--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/AWSClientConfigDefaultsProvider.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/AWSClientConfigDefaultsProvider.swift
@@ -5,12 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import enum AWSSDKChecksums.AWSChecksumCalculationMode
 @_spi(FileBasedConfig) import class AWSSDKCommon.CRTFileBasedConfiguration
 import struct AWSSDKCommon.FieldResolver
+import class ClientRuntime.ClientConfigDefaultsProvider
 import struct SmithyRetries.ExponentialBackoffStrategy
 import struct SmithyRetriesAPI.RetryStrategyOptions
-import enum AWSSDKChecksums.AWSChecksumCalculationMode
-import class ClientRuntime.ClientConfigDefaultsProvider
 
 /// Provides default configuration properties for AWS services.
 public class AWSClientConfigDefaultsProvider: ClientConfigDefaultsProvider {

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/AWSServiceClient.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/AWSServiceClient.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import protocol ClientRuntime.Client
 import let AWSSDKDynamic.packageVersion
+import protocol ClientRuntime.Client
 
 public protocol AWSServiceClient: ClientRuntime.Client {}
 

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/ClockSkew/AWSClockSkewProvider.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/ClockSkew/AWSClockSkewProvider.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import struct Foundation.TimeInterval
 import typealias ClientRuntime.ClockSkewProvider
 import protocol ClientRuntime.ServiceError
+import struct Foundation.TimeInterval
 import class SmithyHTTPAPI.HTTPRequest
 import class SmithyHTTPAPI.HTTPResponse
 @_spi(SmithyTimestamps) import struct SmithyTimestamps.TimestampFormatter

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Config/AWSDefaultClientConfiguration.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Config/AWSDefaultClientConfiguration.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import SmithyIdentity
 import enum AWSSDKChecksums.AWSChecksumCalculationMode
+import SmithyIdentity
 
 public protocol AWSDefaultClientConfiguration {
     /// The AWS credential identity resolver to be used for AWS credentials.

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Customizations/AuthTokenGenerator.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Customizations/AuthTokenGenerator.swift
@@ -7,13 +7,13 @@
 
 import struct AwsCommonRuntimeKit.CommonRuntimeKit
 import class AWSSDKHTTPAuth.AWSSigV4Signer
+import struct Foundation.Date
+import struct Foundation.TimeInterval
 import Smithy
 import SmithyHTTPAPI
 import SmithyHTTPAuth
 import SmithyHTTPAuthAPI
 import SmithyIdentity
-import struct Foundation.Date
-import struct Foundation.TimeInterval
 
 /// A utility class with utility methods that generate IAM authentication token used for connecting to RDS & Aurora DSQL.
 @_spi(AuthTokenGenerator)

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Customizations/BedrockAPIKeyInterceptor.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Customizations/BedrockAPIKeyInterceptor.swift
@@ -5,17 +5,17 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class Foundation.ProcessInfo
-import protocol ClientRuntime.Interceptor
 import protocol ClientRuntime.AfterSerialization
-import struct Smithy.Attributes
+import protocol ClientRuntime.Interceptor
+import class Foundation.ProcessInfo
 import struct Smithy.AttributeKey
+import struct Smithy.Attributes
 import class SmithyHTTPAPI.HTTPRequest
 import class SmithyHTTPAPI.HTTPResponse
-@_spi(ClientConfigDefaultIdentityResolver) import protocol SmithyIdentityAPI.ClientConfigDefaultIdentityResolver
-import protocol SmithyIdentity.BearerTokenIdentityResolver
 import struct SmithyIdentity.BearerTokenIdentity
+import protocol SmithyIdentity.BearerTokenIdentityResolver
 import struct SmithyIdentity.StaticBearerTokenIdentityResolver
+@_spi(ClientConfigDefaultIdentityResolver) import protocol SmithyIdentityAPI.ClientConfigDefaultIdentityResolver
 
 public struct BedrockAPIKeyInterceptor<InputType, OutputType>: Interceptor {
     public typealias RequestType = HTTPRequest

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Endpoints/AWSEndpointConfig.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Endpoints/AWSEndpointConfig.swift
@@ -5,11 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+@_spi(FileBasedConfig) import AWSSDKCommon
+import struct Foundation.Locale
 import class Foundation.ProcessInfo
 import enum Smithy.ClientError
-import struct Foundation.Locale
 import struct Smithy.SwiftLogger
-@_spi(FileBasedConfig) import AWSSDKCommon
 
 public enum AWSEndpointConfig {
 

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Endpoints/Context+AccountIDEndpointMode.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Endpoints/Context+AccountIDEndpointMode.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import struct Smithy.Attributes
 import struct Smithy.AttributeKey
+import struct Smithy.Attributes
 import class Smithy.Context
 import class Smithy.ContextBuilder
 

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Endpoints/Context+ResolvedAccountID.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Endpoints/Context+ResolvedAccountID.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class Smithy.Context
 import struct Smithy.AttributeKey
+import class Smithy.Context
 import struct SmithyIdentity.AWSCredentialIdentity
 
 public extension Context {

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Endpoints/EndpointResolverMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Endpoints/EndpointResolverMiddleware.swift
@@ -5,6 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import protocol ClientRuntime.ApplyEndpoint
+import struct ClientRuntime.DefaultEndpointsAuthSchemeResolver
+import enum ClientRuntime.EndpointsAuthScheme
+import protocol ClientRuntime.EndpointsAuthSchemeResolver
+import protocol ClientRuntime.EndpointsRequestContextProviding
+import enum Smithy.ClientError
 import class Smithy.Context
 import struct SmithyHTTPAPI.Endpoint
 import class SmithyHTTPAPI.HTTPRequest
@@ -12,12 +18,6 @@ import class SmithyHTTPAPI.HTTPRequestBuilder
 import struct SmithyHTTPAuthAPI.SelectedAuthScheme
 import enum SmithyHTTPAuthAPI.SigningAlgorithm
 import enum SmithyHTTPAuthAPI.SigningPropertyKeys
-import protocol ClientRuntime.ApplyEndpoint
-import struct ClientRuntime.DefaultEndpointsAuthSchemeResolver
-import enum ClientRuntime.EndpointsAuthScheme
-import protocol ClientRuntime.EndpointsAuthSchemeResolver
-import protocol ClientRuntime.EndpointsRequestContextProviding
-import enum Smithy.ClientError
 #if os(Linux)
 import Foundation
 #endif

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Endpoints/ServiceEndpointMetadata+Extension.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Endpoints/ServiceEndpointMetadata+Extension.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import enum Smithy.URIScheme
 import ClientRuntime
+import enum Smithy.URIScheme
 import SmithyHTTPAPI
 
 extension ServiceEndpointMetadata {

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Errors/AWSServiceError.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Errors/AWSServiceError.swift
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-import protocol ClientRuntime.ServiceError
 import protocol ClientRuntime.ModeledError
+import protocol ClientRuntime.ServiceError
 
 /// Provides properties for an error returned by an AWS service.
 public protocol AWSServiceError: ServiceError {

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Errors/Candidates/InvalidAccessKeyId.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Errors/Candidates/InvalidAccessKeyId.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class SmithyHTTPAPI.HTTPResponse
 import protocol ClientRuntime.HTTPError
+import class SmithyHTTPAPI.HTTPResponse
 
 /// An error that may be returned by AWS when the access key used cannot be found by the server.
 ///

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Errors/Candidates/UnknownAWSHTTPErrorCandidate.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Errors/Candidates/UnknownAWSHTTPErrorCandidate.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class SmithyHTTPAPI.HTTPResponse
-import protocol ClientRuntime.ServiceError
 import protocol ClientRuntime.HTTPError
+import protocol ClientRuntime.ServiceError
+import class SmithyHTTPAPI.HTTPResponse
 
 /// A protocol for a type that can be matched to an HTTP error response that does not match a modeled error.
 ///

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Errors/UnknownAWSHTTPServiceError.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Errors/UnknownAWSHTTPServiceError.swift
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-import class SmithyHTTPAPI.HTTPResponse
 import ClientRuntime
+import class SmithyHTTPAPI.HTTPResponse
 
 /// AWS specific Service Error structure used when exact error could not be deduced from the `HTTPResponse`
 /// Developers should catch unknown errors by the interface `AWSServiceError`, then use the `errorCode` to determine & handle each type of error.

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/AWSS3ErrorWith200StatusXMLMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/AWSS3ErrorWith200StatusXMLMiddleware.swift
@@ -5,13 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import ClientRuntime
+import struct Foundation.Data
 import enum Smithy.ByteStream
 import class Smithy.Context
-import ClientRuntime
 import SmithyHTTPAPI
-@_spi(SmithyReadWrite) import SmithyXML
-import struct Foundation.Data
 import SmithyStreams
+@_spi(SmithyReadWrite) import SmithyXML
 
 public struct AWSS3ErrorWith200StatusXMLMiddleware<OperationStackInput, OperationStackOutput> {
     public let id: String = "AWSS3ErrorWith200StatusXMLMiddleware"

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/AmzSdkInvocationIdMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/AmzSdkInvocationIdMiddleware.swift
@@ -6,8 +6,8 @@
 //
 
 import ClientRuntime
-import SmithyHTTPAPI
 import struct Foundation.UUID
+import SmithyHTTPAPI
 
 private let AMZ_SDK_INVOCATION_ID_HEADER = "amz-sdk-invocation-id"
 

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/AmzSdkRequestMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/AmzSdkRequestMiddleware.swift
@@ -6,14 +6,14 @@
 //
 
 import ClientRuntime
-import Smithy
-import SmithyHTTPAPI
 import struct Foundation.Date
 import class Foundation.DateFormatter
 import struct Foundation.Locale
 import struct Foundation.TimeInterval
 import struct Foundation.TimeZone
 import struct Foundation.UUID
+import Smithy
+import SmithyHTTPAPI
 
 private let AMZ_SDK_REQUEST_HEADER = "amz-sdk-request"
 

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/FlexibleChecksumsRequestMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/FlexibleChecksumsRequestMiddleware.swift
@@ -5,14 +5,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import enum SmithyChecksumsAPI.ChecksumAlgorithm
-import enum SmithyChecksums.ChecksumMismatchException
-import enum Smithy.ClientError
-import struct Smithy.URIQueryItem
-import class Smithy.Context
-import struct Foundation.Data
 import AWSSDKChecksums
 import ClientRuntime
+import struct Foundation.Data
+import enum Smithy.ClientError
+import class Smithy.Context
+import struct Smithy.URIQueryItem
+import enum SmithyChecksums.ChecksumMismatchException
+import enum SmithyChecksumsAPI.ChecksumAlgorithm
 import SmithyHTTPAPI
 
 public struct FlexibleChecksumsRequestMiddleware<OperationStackInput, OperationStackOutput> {

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/FlexibleChecksumsResponseMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/FlexibleChecksumsResponseMiddleware.swift
@@ -1,13 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0.
 
-import Smithy
-import SmithyHTTPAPI
-import enum SmithyChecksumsAPI.ChecksumAlgorithm
-import enum SmithyChecksums.ChecksumMismatchException
 import ClientRuntime
 import struct Foundation.NSRange
 import class Foundation.NSRegularExpression
+import Smithy
+import enum SmithyChecksums.ChecksumMismatchException
+import enum SmithyChecksumsAPI.ChecksumAlgorithm
+import SmithyHTTPAPI
 
 public struct FlexibleChecksumsResponseMiddleware<OperationStackInput, OperationStackOutput> {
 

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/Route53TrimHostedZoneMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/Route53TrimHostedZoneMiddleware.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class Smithy.Context
 import ClientRuntime
+import class Smithy.Context
 import SmithyHTTPAPI
 
 public struct Route53TrimHostedZoneMiddleware<Input, Output> {

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/Sha256TreeHashMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/Sha256TreeHashMiddleware.swift
@@ -1,11 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0.
 
-import class Smithy.Context
 import ClientRuntime
-import SmithyHTTPAPI
 import struct Foundation.Data
 import struct Smithy.AttributeKey
+import class Smithy.Context
+import SmithyHTTPAPI
 
 public struct Sha256TreeHashMiddleware<OperationStackInput, OperationStackOutput> {
     public let id: String = "Sha256TreeHash"

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/UserAgentMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/UserAgentMiddleware.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class Smithy.Context
 import ClientRuntime
+import class Smithy.Context
 import SmithyHTTPAPI
 
 public struct UserAgentMiddleware<OperationStackInput, OperationStackOutput> {

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/XAmzTargetMiddleware.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Middlewares/XAmzTargetMiddleware.swift
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0.
 
-import class Smithy.Context
 import ClientRuntime
+import class Smithy.Context
 import SmithyHTTPAPI
 
 public struct XAmzTargetMiddleware<OperationStackInput, OperationStackOutput> {

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Protocols/AWSQuery/AWSQueryCompatibleUtils.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Protocols/AWSQuery/AWSQueryCompatibleUtils.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-@_spi(SmithyReadWrite) import class SmithyJSON.Reader
 @_spi(SmithyReadWrite) import struct ClientRuntime.RpcV2CborError
 @_spi(SmithyReadWrite) import class SmithyCBOR.Reader
 import class SmithyHTTPAPI.HTTPResponse
+@_spi(SmithyReadWrite) import class SmithyJSON.Reader
 
 @_spi(SmithyReadWrite)
 public enum AWSQueryCompatibleUtils {

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Regions/DefaultRegionResolver.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Regions/DefaultRegionResolver.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import struct Smithy.SwiftLogger
 @_spi(FileBasedConfig) import AWSSDKCommon
+import struct Smithy.SwiftLogger
 
 @_spi(DefaultRegionResolver)
 public struct DefaultRegionResolver: RegionResolver {

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Regions/ProfileRegionProvider.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Regions/ProfileRegionProvider.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import struct Smithy.SwiftLogger
 @_spi(FileBasedConfig) import AWSSDKCommon
+import struct Smithy.SwiftLogger
 
 struct ProfileRegionProvider: RegionProvider {
     let logger: SwiftLogger

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Retry/AWSRetryErrorInfoProvider.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/Retry/AWSRetryErrorInfoProvider.swift
@@ -5,14 +5,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import struct Foundation.TimeInterval
 import enum AwsCommonRuntimeKit.CommonRunTimeError
-import protocol SmithyRetriesAPI.RetryErrorInfoProvider
 import enum ClientRuntime.DefaultRetryErrorInfoProvider
-import struct SmithyRetriesAPI.RetryErrorInfo
-import protocol ClientRuntime.ServiceError
 import protocol ClientRuntime.HTTPError
 import protocol ClientRuntime.ModeledError
+import protocol ClientRuntime.ServiceError
+import struct Foundation.TimeInterval
+import struct SmithyRetriesAPI.RetryErrorInfo
+import protocol SmithyRetriesAPI.RetryErrorInfoProvider
 
 public enum AWSRetryErrorInfoProvider: RetryErrorInfoProvider {
 

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/UserAgent/AWSUserAgentMetadata.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/UserAgent/AWSUserAgentMetadata.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import enum AWSSDKChecksums.AWSChecksumCalculationMode
 import ClientRuntime
 import class Smithy.Context
-import enum AWSSDKChecksums.AWSChecksumCalculationMode
 import struct SmithyHTTPAPI.Headers
 
 public struct AWSUserAgentMetadata {

--- a/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/UserAgent/BusinessMetrics.swift
+++ b/Sources/Core/AWSClientRuntime/Sources/AWSClientRuntime/UserAgent/BusinessMetrics.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class Smithy.Context
 import struct Smithy.AttributeKey
+import class Smithy.Context
 import struct SmithyHTTPAPI.Headers
 
 struct BusinessMetrics {

--- a/Sources/Core/AWSSDKChecksums/Sources/AWSSDKChecksums/AWSChunkedUtil.swift
+++ b/Sources/Core/AWSSDKChecksums/Sources/AWSSDKChecksums/AWSChunkedUtil.swift
@@ -5,13 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import struct AwsCommonRuntimeKit.SigningConfig
 import enum Smithy.ByteStream
 import enum Smithy.ClientError
+import class Smithy.Context
+import class SmithyChecksums.ChunkedStream
 import struct SmithyHTTPAPI.Headers
 import class SmithyHTTPAPI.HTTPRequestBuilder
-import class SmithyChecksums.ChunkedStream
-import class Smithy.Context
-import struct AwsCommonRuntimeKit.SigningConfig
 
 extension HTTPRequestBuilder {
 

--- a/Sources/Core/AWSSDKChecksums/Sources/AWSSDKChecksums/Context+Checksum.swift
+++ b/Sources/Core/AWSSDKChecksums/Sources/AWSSDKChecksums/Context+Checksum.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import struct Smithy.AttributeKey
 import class Smithy.Context
 import class Smithy.ContextBuilder
-import struct Smithy.AttributeKey
 
 public extension Context {
     var requestChecksumCalculation: AWSChecksumCalculationMode {

--- a/Sources/Core/AWSSDKEventStreamsAuth/Sources/AWSSDKEventStreamsAuth/AWSMessageSigner.swift
+++ b/Sources/Core/AWSSDKEventStreamsAuth/Sources/AWSSDKEventStreamsAuth/AWSMessageSigner.swift
@@ -5,14 +5,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import struct SmithyHTTPAuth.AWSSigningConfig
-import protocol SmithyEventStreamsAPI.MessageEncoder
-import struct SmithyEventStreamsAPI.Message
-import protocol SmithyEventStreamsAuthAPI.MessageSigner
-import protocol SmithyEventStreamsAuthAPI.MessageDataSigner
-import protocol SmithyHTTPAuthAPI.Signer
-import struct Smithy.Attributes
 import struct Smithy.AttributeKey
+import struct Smithy.Attributes
+import struct SmithyEventStreamsAPI.Message
+import protocol SmithyEventStreamsAPI.MessageEncoder
+import protocol SmithyEventStreamsAuthAPI.MessageDataSigner
+import protocol SmithyEventStreamsAuthAPI.MessageSigner
+import struct SmithyHTTPAuth.AWSSigningConfig
+import protocol SmithyHTTPAuthAPI.Signer
 
 /// Signs a `Message` using the AWS SigV4 signing algorithm
 public actor AWSMessageSigner: MessageSigner {

--- a/Sources/Core/AWSSDKEventStreamsAuth/Sources/AWSSDKEventStreamsAuth/AWSSigV4Signer+EventStreams.swift
+++ b/Sources/Core/AWSSDKEventStreamsAuth/Sources/AWSSDKEventStreamsAuth/AWSSigV4Signer+EventStreams.swift
@@ -5,12 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import class AwsCommonRuntimeKit.Signer
 import AWSSDKHTTPAuth
+import struct Foundation.Data
 import Smithy
 import SmithyEventStreamsAPI
 import SmithyEventStreamsAuthAPI
-import struct Foundation.Data
-import class AwsCommonRuntimeKit.Signer
 import SmithyHTTPAuth
 
 extension AWSSigV4Signer: MessageDataSigner {

--- a/Sources/Core/AWSSDKEventStreamsAuth/Sources/AWSSDKEventStreamsAuth/Context+Signing.swift
+++ b/Sources/Core/AWSSDKEventStreamsAuth/Sources/AWSSDKEventStreamsAuth/Context+Signing.swift
@@ -5,14 +5,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import struct Foundation.Date
+import struct Foundation.TimeInterval
 import Smithy
 import SmithyHTTPAPI
+import SmithyHTTPAuth
 import SmithyHTTPAuthAPI
 import SmithyIdentity
 import SmithyIdentityAPI
-import struct Foundation.Date
-import struct Foundation.TimeInterval
-import SmithyHTTPAuth
 
 extension Context {
 

--- a/Sources/Core/AWSSDKHTTPAuth/Sources/AWSSDKHTTPAuth/AWSSigV4Signer.swift
+++ b/Sources/Core/AWSSDKHTTPAuth/Sources/AWSSDKHTTPAuth/AWSSigV4Signer.swift
@@ -5,33 +5,33 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import struct AWSSDKIdentityAPI.S3ExpressIdentity
+import enum AwsCommonRuntimeKit.CommonRunTimeError
 import class AwsCommonRuntimeKit.HTTPRequestBase
 import class AwsCommonRuntimeKit.Signer
-import class SmithyHTTPAPI.HTTPRequest
-import class SmithyHTTPAPI.HTTPRequestBuilder
-import class Smithy.Context
-import enum AwsCommonRuntimeKit.CommonRunTimeError
-import enum Smithy.ClientError
-import enum SmithyHTTPAuthAPI.AWSSignedBodyHeader
-import enum SmithyHTTPAuthAPI.AWSSignedBodyValue
-import enum SmithyHTTPAuthAPI.AWSSignatureType
-import enum SmithyHTTPAuthAPI.SigningAlgorithm
-import enum SmithyHTTPAuthAPI.SigningPropertyKeys
-import protocol SmithyIdentity.AWSCredentialIdentityResolver
-import protocol SmithyIdentityAPI.Identity
-import protocol SmithyHTTPAuthAPI.Signer
 import struct AwsCommonRuntimeKit.SigningConfig
-import struct Smithy.AttributeKey
-import struct Smithy.Attributes
-import struct Smithy.SwiftLogger
-import struct SmithyIdentity.AWSCredentialIdentity
-import struct SmithyHTTPAuth.AWSSigningConfig
-import struct SmithyHTTPAuthAPI.SigningFlags
+import AWSSDKChecksums
+import struct AWSSDKIdentityAPI.S3ExpressIdentity
 import struct Foundation.Date
 import struct Foundation.TimeInterval
 import struct Foundation.URL
-import AWSSDKChecksums
+import struct Smithy.AttributeKey
+import struct Smithy.Attributes
+import enum Smithy.ClientError
+import class Smithy.Context
+import struct Smithy.SwiftLogger
+import class SmithyHTTPAPI.HTTPRequest
+import class SmithyHTTPAPI.HTTPRequestBuilder
+import struct SmithyHTTPAuth.AWSSigningConfig
+import enum SmithyHTTPAuthAPI.AWSSignatureType
+import enum SmithyHTTPAuthAPI.AWSSignedBodyHeader
+import enum SmithyHTTPAuthAPI.AWSSignedBodyValue
+import protocol SmithyHTTPAuthAPI.Signer
+import enum SmithyHTTPAuthAPI.SigningAlgorithm
+import struct SmithyHTTPAuthAPI.SigningFlags
+import enum SmithyHTTPAuthAPI.SigningPropertyKeys
+import struct SmithyIdentity.AWSCredentialIdentity
+import protocol SmithyIdentity.AWSCredentialIdentityResolver
+import protocol SmithyIdentityAPI.Identity
 
 public final class AWSSigV4Signer: SmithyHTTPAuthAPI.Signer, Sendable {
 

--- a/Sources/Core/AWSSDKHTTPAuth/Sources/AWSSDKHTTPAuth/CustomSigningPropertiesSetter.swift
+++ b/Sources/Core/AWSSDKHTTPAuth/Sources/AWSSDKHTTPAuth/CustomSigningPropertiesSetter.swift
@@ -5,12 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class Smithy.Context
+import struct Smithy.Attributes
 import enum Smithy.ClientError
-import enum SmithyIdentityAPI.FlowType
+import class Smithy.Context
 import enum SmithyHTTPAuthAPI.AWSSignedBodyHeader
 import enum SmithyHTTPAuthAPI.SigningPropertyKeys
-import struct Smithy.Attributes
+import enum SmithyIdentityAPI.FlowType
 
 // Service-specific signing properties customization setter.
 public class CustomSigningPropertiesSetter {

--- a/Sources/Core/AWSSDKHTTPAuth/Sources/AWSSDKHTTPAuth/SigV4AAuthScheme.swift
+++ b/Sources/Core/AWSSDKHTTPAuth/Sources/AWSSDKHTTPAuth/SigV4AAuthScheme.swift
@@ -5,12 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class Smithy.Context
-import enum SmithyHTTPAuthAPI.AWSSignedBodyHeader
-import enum SmithyHTTPAuthAPI.SigningPropertyKeys
-import protocol SmithyHTTPAuthAPI.AuthScheme
-import protocol SmithyHTTPAuthAPI.Signer
 import struct Smithy.Attributes
+import class Smithy.Context
+import protocol SmithyHTTPAuthAPI.AuthScheme
+import enum SmithyHTTPAuthAPI.AWSSignedBodyHeader
+import protocol SmithyHTTPAuthAPI.Signer
+import enum SmithyHTTPAuthAPI.SigningPropertyKeys
 
 public struct SigV4AAuthScheme: AuthScheme {
     public let schemeID: String = "aws.auth#sigv4a"

--- a/Sources/Core/AWSSDKHTTPAuth/Sources/AWSSDKHTTPAuth/SigV4AuthScheme.swift
+++ b/Sources/Core/AWSSDKHTTPAuth/Sources/AWSSDKHTTPAuth/SigV4AuthScheme.swift
@@ -5,12 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class Smithy.Context
-import enum SmithyHTTPAuthAPI.AWSSignedBodyHeader
-import enum SmithyHTTPAuthAPI.SigningPropertyKeys
-import protocol SmithyHTTPAuthAPI.AuthScheme
-import protocol SmithyHTTPAuthAPI.Signer
 import struct Smithy.Attributes
+import class Smithy.Context
+import protocol SmithyHTTPAuthAPI.AuthScheme
+import enum SmithyHTTPAuthAPI.AWSSignedBodyHeader
+import protocol SmithyHTTPAuthAPI.Signer
+import enum SmithyHTTPAuthAPI.SigningPropertyKeys
 
 public struct SigV4AuthScheme: AuthScheme {
     public let schemeID: String = "aws.auth#sigv4"

--- a/Sources/Core/AWSSDKHTTPAuth/Sources/AWSSDKHTTPAuth/SigV4S3ExpressAuthScheme.swift
+++ b/Sources/Core/AWSSDKHTTPAuth/Sources/AWSSDKHTTPAuth/SigV4S3ExpressAuthScheme.swift
@@ -5,12 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class Smithy.Context
-import enum SmithyHTTPAuthAPI.AWSSignedBodyHeader
-import enum SmithyHTTPAuthAPI.SigningPropertyKeys
-import protocol SmithyHTTPAuthAPI.AuthScheme
-import protocol SmithyHTTPAuthAPI.Signer
 import struct Smithy.Attributes
+import class Smithy.Context
+import protocol SmithyHTTPAuthAPI.AuthScheme
+import enum SmithyHTTPAuthAPI.AWSSignedBodyHeader
+import protocol SmithyHTTPAuthAPI.Signer
+import enum SmithyHTTPAuthAPI.SigningPropertyKeys
 
 public struct SigV4S3ExpressAuthScheme: AuthScheme {
     public let schemeID: String = "aws.auth#sigv4-s3express"

--- a/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/CachedAWSCredentialIdentityResolver.swift
+++ b/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/CachedAWSCredentialIdentityResolver.swift
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import protocol SmithyIdentity.AWSCredentialIdentityResolver
-import struct Foundation.TimeInterval
 import struct Foundation.Date
+import struct Foundation.TimeInterval
 import struct Smithy.Attributes
+import protocol SmithyIdentity.AWSCredentialIdentityResolver
 
 ///  A credential identity resolver that caches the credentials sourced from the provided resolver.
 public actor CachedAWSCredentialIdentityResolver: AWSCredentialIdentityResolver {

--- a/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/CognitoAWSCredentialIdentityResolver.swift
+++ b/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/CognitoAWSCredentialIdentityResolver.swift
@@ -5,14 +5,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import protocol SmithyIdentity.AWSCredentialIdentityResolver
 import class AwsCommonRuntimeKit.CredentialsProvider
-import struct Smithy.Attributes
 import class Foundation.ProcessInfo
+import struct Smithy.Attributes
 import enum Smithy.ClientError
+import protocol SmithyIdentity.AWSCredentialIdentityResolver
 
-import struct Foundation.Date
 @_spi(FileBasedConfig) import AWSSDKCommon
+import struct Foundation.Date
 
 /// A credential identity resolver that resolves credentials using AWS Cognito Identity.
 public actor CognitoAWSCredentialIdentityResolver: AWSCredentialIdentityResolver {

--- a/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/DefaultAWSCredentialIdentityResolverChain.swift
+++ b/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/DefaultAWSCredentialIdentityResolverChain.swift
@@ -5,12 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import struct Foundation.Date
-import protocol SmithyIdentity.AWSCredentialIdentityResolvedByCRT
 @_spi(FileBasedConfig) import AWSSDKCommon
-import protocol SmithyIdentity.AWSCredentialIdentityResolver
+import struct Foundation.Date
 import struct Smithy.Attributes
 import struct Smithy.SwiftLogger
+import protocol SmithyIdentity.AWSCredentialIdentityResolvedByCRT
+import protocol SmithyIdentity.AWSCredentialIdentityResolver
 
 // swiftlint:disable type_name
 // ^ Required to mute swiftlint warning about type name being too long.

--- a/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/ECSAWSCredentialIdentityResolver.swift
+++ b/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/ECSAWSCredentialIdentityResolver.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-import protocol SmithyIdentity.AWSCredentialIdentityResolver
 import struct Smithy.Attributes
+import protocol SmithyIdentity.AWSCredentialIdentityResolver
 #if os(Linux)
 import FoundationNetworking // For URLSession in Linux.
 #endif

--- a/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/EnvironmentAWSCredentialIdentityResolver.swift
+++ b/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/EnvironmentAWSCredentialIdentityResolver.swift
@@ -6,9 +6,9 @@
 //
 
 import class Foundation.ProcessInfo
-import protocol SmithyIdentity.AWSCredentialIdentityResolver
 import struct Smithy.Attributes
 @_spi(AWSCredentialIdentityResolver) import struct SmithyIdentity.AWSCredentialIdentity
+import protocol SmithyIdentity.AWSCredentialIdentityResolver
 
 /// A credential identity resolver that resolves credentials from the following environment variables:
 /// - `AWS_ACCESS_KEY_ID`

--- a/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/IMDSAWSCredentialIdentityResolver.swift
+++ b/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/IMDSAWSCredentialIdentityResolver.swift
@@ -5,14 +5,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class Foundation.ISO8601DateFormatter
-import class Foundation.JSONDecoder
-import protocol SmithyIdentity.AWSCredentialIdentityResolver
+import typealias AWSSDKCommon.CRTFileBasedConfiguration
 @_spi(FileBasedConfig) import struct AWSSDKCommon.FieldResolver
 import struct Foundation.Date
+import class Foundation.ISO8601DateFormatter
+import class Foundation.JSONDecoder
 import struct Foundation.URL
 import struct Smithy.Attributes
-import typealias AWSSDKCommon.CRTFileBasedConfiguration
+import protocol SmithyIdentity.AWSCredentialIdentityResolver
 
 /// A credentials provider that uses IMDSv2 to fetch credentials within an EC2 instance.
 public actor IMDSAWSCredentialIdentityResolver: AWSCredentialIdentityResolver {

--- a/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/ProcessAWSCredentialIdentityResolver.swift
+++ b/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/ProcessAWSCredentialIdentityResolver.swift
@@ -13,12 +13,12 @@ import class Foundation.Pipe
 // Foundation.Process is not available in non-mac apple platforms for security reasons.
 import class Foundation.Process
 #endif
-import class Foundation.ProcessInfo
-import protocol SmithyIdentity.AWSCredentialIdentityResolver
 import struct Foundation.Data
 import struct Foundation.Date
+import class Foundation.ProcessInfo
 import struct Foundation.URL
 import struct Smithy.Attributes
+import protocol SmithyIdentity.AWSCredentialIdentityResolver
 
 /// The process credential identity resolver resolves credentials from running a command or process.
 /// The command to run is sourced from a profile in the AWS config file, using the standard

--- a/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/ProfileAWSCredentialIdentityResolver.swift
+++ b/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/ProfileAWSCredentialIdentityResolver.swift
@@ -5,12 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import protocol SmithyIdentity.AWSCredentialIdentityResolver
-import struct Smithy.Attributes
-import struct SmithyIdentity.StaticAWSCredentialIdentityResolver
-import class Foundation.ProcessInfo
-import struct Smithy.SwiftLogger
 @_spi(FileBasedConfig) import AWSSDKCommon
+import class Foundation.ProcessInfo
+import struct Smithy.Attributes
+import struct Smithy.SwiftLogger
+import protocol SmithyIdentity.AWSCredentialIdentityResolver
+import struct SmithyIdentity.StaticAWSCredentialIdentityResolver
 
 /// A credential identity resolver that resolves credentials from a profile in `~/.aws/config` or the shared credentials file `~/.aws/credentials`.
 /// The profile name and the  locations of these files are configurable via the initializer and environment variables

--- a/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/SSOAWSCredentialIdentityResolver.swift
+++ b/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/SSOAWSCredentialIdentityResolver.swift
@@ -5,18 +5,18 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import protocol SmithyIdentity.AWSCredentialIdentityResolver
-import struct Smithy.Attributes
-import class Foundation.ProcessInfo
-import enum Smithy.ClientError
-import struct SmithyIdentity.BearerTokenIdentity
-import class Foundation.FileManager
-import struct Foundation.URL
+@_spi(FileBasedConfig) import AWSSDKCommon
 import struct Foundation.Data
 import struct Foundation.Date
+import class Foundation.FileManager
 import class Foundation.JSONDecoder
 import func Foundation.NSHomeDirectory
-@_spi(FileBasedConfig) import AWSSDKCommon
+import class Foundation.ProcessInfo
+import struct Foundation.URL
+import struct Smithy.Attributes
+import enum Smithy.ClientError
+import protocol SmithyIdentity.AWSCredentialIdentityResolver
+import struct SmithyIdentity.BearerTokenIdentity
 
 /// A credential identity resolver that resolves credentials using GetRoleCredentialsRequest to the AWS Single Sign-On Service to maintain short-lived sessions.
 /// [Details link](https://docs.aws.amazon.com/sdkref/latest/guide/feature-sso-credentials.html)

--- a/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/STSAssumeRoleAWSCredentialIdentityResolver.swift
+++ b/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/STSAssumeRoleAWSCredentialIdentityResolver.swift
@@ -5,11 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import enum Smithy.ClientError
-import protocol SmithyIdentity.AWSCredentialIdentityResolver
 import struct Foundation.TimeInterval
 import struct Foundation.UUID
 import struct Smithy.Attributes
+import enum Smithy.ClientError
+import protocol SmithyIdentity.AWSCredentialIdentityResolver
 
 // swiftlint:disable type_name
 // ^ Required to mute swiftlint warning about type name being too long.

--- a/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/STSWebIdentityAWSCredentialIdentityResolver.swift
+++ b/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/STSWebIdentityAWSCredentialIdentityResolver.swift
@@ -5,13 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import protocol SmithyIdentity.AWSCredentialIdentityResolver
+@_spi(FileBasedConfig) import AWSSDKCommon
+import class Foundation.FileManager
+import class Foundation.ProcessInfo
+import struct Foundation.URL
 import struct Foundation.UUID
 import struct Smithy.Attributes
-@_spi(FileBasedConfig) import AWSSDKCommon
-import class Foundation.ProcessInfo
-import class Foundation.FileManager
-import struct Foundation.URL
+import protocol SmithyIdentity.AWSCredentialIdentityResolver
 
 // swiftlint:disable type_name
 // ^ Required to mute swiftlint warning about type name being too long.

--- a/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/SharedConfigStaticAWSCredentialIdentityResolver.swift
+++ b/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/AWSCredentialIdentityResolvers/SharedConfigStaticAWSCredentialIdentityResolver.swift
@@ -6,10 +6,10 @@
 //
 
 @_spi(FileBasedConfig) import AWSSDKCommon
-import class Foundation.ProcessInfo
-import protocol SmithyIdentity.AWSCredentialIdentityResolver
 import struct Foundation.Date
+import class Foundation.ProcessInfo
 import struct Smithy.Attributes
+import protocol SmithyIdentity.AWSCredentialIdentityResolver
 
 // swiftlint:disable type_name
 /// A credential identity resolver that resolves credentials from the following shared config file properties:

--- a/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/BearerTokenIdentityResolvers/DefaultBearerTokenIdentityResolverChain.swift
+++ b/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/BearerTokenIdentityResolvers/DefaultBearerTokenIdentityResolverChain.swift
@@ -5,11 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import protocol SmithyIdentity.BearerTokenIdentityResolver
-import struct SmithyIdentity.BearerTokenIdentity
-@_spi(ClientConfigDefaultIdentityResolver) import protocol SmithyIdentityAPI.ClientConfigDefaultIdentityResolver
 import struct Smithy.Attributes
 import enum Smithy.ClientError
+import struct SmithyIdentity.BearerTokenIdentity
+import protocol SmithyIdentity.BearerTokenIdentityResolver
+@_spi(ClientConfigDefaultIdentityResolver) import protocol SmithyIdentityAPI.ClientConfigDefaultIdentityResolver
 
 /// The default chain of bearer token identity resolvers.
 /// This is the default resolver when no token identity resolver is provided by the user.

--- a/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/BearerTokenIdentityResolvers/SSOBearerTokenIdentityResolver.swift
+++ b/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/BearerTokenIdentityResolvers/SSOBearerTokenIdentityResolver.swift
@@ -5,21 +5,21 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import protocol SmithyIdentity.BearerTokenIdentityResolver
-import struct SmithyIdentity.BearerTokenIdentity
-import class Foundation.FileManager
-import class Foundation.ISO8601DateFormatter
-import struct Foundation.URL
+@_spi(FileBasedConfig) import AWSSDKCommon
 import struct Foundation.Data
 import struct Foundation.Date
-import struct Foundation.TimeInterval
+import class Foundation.FileManager
+import class Foundation.ISO8601DateFormatter
 import class Foundation.JSONDecoder
 import class Foundation.JSONEncoder
+import func Foundation.NSHomeDirectory
+import struct Foundation.TimeInterval
+import struct Foundation.URL
 import struct Smithy.Attributes
 import enum Smithy.ClientError
-import func Foundation.NSHomeDirectory
-@_spi(FileBasedConfig) import AWSSDKCommon
 import struct Smithy.SwiftLogger
+import struct SmithyIdentity.BearerTokenIdentity
+import protocol SmithyIdentity.BearerTokenIdentityResolver
 
 /// The bearer token identity resolver that resolves token identity using the config file & the cached SSO token.
 /// This resolver does not handle creation of the SSO token; it must be created by the user beforehand (e.g., using AWS CLI, etc.).

--- a/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/CredentialFeatureIDInterceptor.swift
+++ b/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/CredentialFeatureIDInterceptor.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import protocol ClientRuntime.HttpInterceptorProvider
 import protocol ClientRuntime.Interceptor
 import protocol ClientRuntime.MutableRequest
-import protocol ClientRuntime.HttpInterceptorProvider
 import class SmithyHTTPAPI.HTTPRequest
 import class SmithyHTTPAPI.HTTPResponse
 

--- a/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/S3Express/Context+S3ExpressIdentity.swift
+++ b/Sources/Core/AWSSDKIdentity/Sources/AWSSDKIdentity/S3Express/Context+S3ExpressIdentity.swift
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import class Smithy.Context
 import struct Smithy.AttributeKey
+import class Smithy.Context
 import struct SmithyIdentity.AWSCredentialIdentity
 
 public extension Context {

--- a/Sources/Core/AWSSDKIdentityAPI/Sources/AWSSDKIdentityAPI/S3ExpressIdentity.swift
+++ b/Sources/Core/AWSSDKIdentityAPI/Sources/AWSSDKIdentityAPI/S3ExpressIdentity.swift
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-import protocol SmithyIdentityAPI.Identity
 import struct Foundation.Date
 import struct Smithy.Attributes
+import protocol SmithyIdentityAPI.Identity
 
 public struct S3ExpressIdentity: Identity {
     public var accessKeyID: String


### PR DESCRIPTION
## Description of changes
A recent update to Swiftlint fixes its enforcement for sorted order of imports.
https://github.com/realm/SwiftLint/releases/tag/0.62.0

This change applies Swiftlint's automatic fix for import sort order.  Other than import sorting, there are no other changes in this PR.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.