### PR TITLE
feat: Add codegen build plugin to AWS services

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSCLIUtils/FileManager+Utils.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSCLIUtils/FileManager+Utils.swift
@@ -57,6 +57,8 @@ public extension FileManager {
             .contentsOfDirectory(atPath: "../smithy-swift/Sources")
             .sorted()
             .filter { $0 != "libxml2" } // Ignore libxml module
+            .filter { $0 != "SmithyCodegenCLI" } // Ignore codegen component
+            .filter { $0 != "SmithyCodegenCore" } // Ignore codegen component
             .filter { !$0.hasPrefix(".") }
     }
 

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.txt
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.txt
@@ -42,6 +42,11 @@ extension Target.Dependency {
     static var SmithyXML: Self { .product(name: "SmithyXML", package: "smithy-swift") }
 }
 
+extension Target.PluginUsage {
+    // Smithy plugins
+    static var SmithyCodeGenerator: Self { .plugin(name: "SmithyCodeGenerator", package: "smithy-swift") }
+}
+
 // MARK: Base Package
 
 let package = Package(
@@ -198,22 +203,26 @@ private var runtimeTargets: [Target] {
         .target(
             name: "InternalAWSSTS",
             dependencies: internalAWSSTSDependencies,
-            path: "Sources/Core/AWSSDKIdentity/InternalClients/InternalAWSSTS/Sources/InternalAWSSTS"
+            path: "Sources/Core/AWSSDKIdentity/InternalClients/InternalAWSSTS/Sources/InternalAWSSTS",
+            plugins: [.SmithyCodeGenerator]
         ),
         .target(
             name: "InternalAWSSSO",
             dependencies: internalAWSSSODependencies,
-            path: "Sources/Core/AWSSDKIdentity/InternalClients/InternalAWSSSO/Sources/InternalAWSSSO"
+            path: "Sources/Core/AWSSDKIdentity/InternalClients/InternalAWSSSO/Sources/InternalAWSSSO",
+            plugins: [.SmithyCodeGenerator]
         ),
         .target(
             name: "InternalAWSSSOOIDC",
             dependencies: internalAWSSSOOIDCDependencies,
-            path: "Sources/Core/AWSSDKIdentity/InternalClients/InternalAWSSSOOIDC/Sources/InternalAWSSSOOIDC"
+            path: "Sources/Core/AWSSDKIdentity/InternalClients/InternalAWSSSOOIDC/Sources/InternalAWSSSOOIDC",
+            plugins: [.SmithyCodeGenerator]
         ),
         .target(
             name: "InternalAWSCognitoIdentity",
             dependencies: internalAWSCognitoIdentityDependencies,
-            path: "Sources/Core/AWSSDKIdentity/InternalClients/InternalAWSCognitoIdentity/Sources/InternalAWSCognitoIdentity"
+            path: "Sources/Core/AWSSDKIdentity/InternalClients/InternalAWSCognitoIdentity/Sources/InternalAWSCognitoIdentity",
+            plugins: [.SmithyCodeGenerator]
         ),
         .target(
             name: "AWSSDKChecksums",
@@ -286,7 +295,8 @@ private func target(_ service: String, _ dependencies: [Target.Dependency]) -> T
     .target(
         name: service,
         dependencies: dependencies,
-        path: "Sources/Services/\(service)/Sources/\(service)"
+        path: "Sources/Services/\(service)/Sources/\(service)",
+        plugins: [.SmithyCodeGenerator]
     )
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -480,6 +480,11 @@ extension Target.Dependency {
     static var SmithyXML: Self { .product(name: "SmithyXML", package: "smithy-swift") }
 }
 
+extension Target.PluginUsage {
+    // Smithy plugins
+    static var SmithyCodeGenerator: Self { .plugin(name: "SmithyCodeGenerator", package: "smithy-swift") }
+}
+
 // MARK: Base Package
 
 let package = Package(
@@ -636,22 +641,26 @@ private var runtimeTargets: [Target] {
         .target(
             name: "InternalAWSSTS",
             dependencies: internalAWSSTSDependencies,
-            path: "Sources/Core/AWSSDKIdentity/InternalClients/InternalAWSSTS/Sources/InternalAWSSTS"
+            path: "Sources/Core/AWSSDKIdentity/InternalClients/InternalAWSSTS/Sources/InternalAWSSTS",
+            plugins: [.SmithyCodeGenerator]
         ),
         .target(
             name: "InternalAWSSSO",
             dependencies: internalAWSSSODependencies,
-            path: "Sources/Core/AWSSDKIdentity/InternalClients/InternalAWSSSO/Sources/InternalAWSSSO"
+            path: "Sources/Core/AWSSDKIdentity/InternalClients/InternalAWSSSO/Sources/InternalAWSSSO",
+            plugins: [.SmithyCodeGenerator]
         ),
         .target(
             name: "InternalAWSSSOOIDC",
             dependencies: internalAWSSSOOIDCDependencies,
-            path: "Sources/Core/AWSSDKIdentity/InternalClients/InternalAWSSSOOIDC/Sources/InternalAWSSSOOIDC"
+            path: "Sources/Core/AWSSDKIdentity/InternalClients/InternalAWSSSOOIDC/Sources/InternalAWSSSOOIDC",
+            plugins: [.SmithyCodeGenerator]
         ),
         .target(
             name: "InternalAWSCognitoIdentity",
             dependencies: internalAWSCognitoIdentityDependencies,
-            path: "Sources/Core/AWSSDKIdentity/InternalClients/InternalAWSCognitoIdentity/Sources/InternalAWSCognitoIdentity"
+            path: "Sources/Core/AWSSDKIdentity/InternalClients/InternalAWSCognitoIdentity/Sources/InternalAWSCognitoIdentity",
+            plugins: [.SmithyCodeGenerator]
         ),
         .target(
             name: "AWSSDKChecksums",
@@ -724,7 +733,8 @@ private func target(_ service: String, _ dependencies: [Target.Dependency]) -> T
     .target(
         name: service,
         dependencies: dependencies,
-        path: "Sources/Services/\(service)/Sources/\(service)"
+        path: "Sources/Services/\(service)/Sources/\(service)",
+        plugins: [.SmithyCodeGenerator]
     )
 }
 

--- a/scripts/codegen.sh
+++ b/scripts/codegen.sh
@@ -24,6 +24,7 @@ rm -rf ServiceClients/*
 rm -rf Sources/Services/*
 rm -rf Tests/Services/*
 rm -rf SmokeTests/*
+rm -rf Sources/Core/AWSIdentity/InternalClients/*
 
 # Regenerate code
 ./gradlew -p codegen/sdk-codegen build


### PR DESCRIPTION
## Description of changes
Applies the Swift-native codegen plugin defined in https://github.com/smithy-lang/smithy-swift/pull/993 to AWS service clients, including the internal ones.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.