### PR TITLE
chore: Change build-request.json field from type to buildType

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/AWSSDKSwiftCLI/Subcommands/PrepareRelease.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/AWSSDKSwiftCLI/Subcommands/PrepareRelease.swift
@@ -109,7 +109,7 @@ struct PrepareRelease {
 
         // Determine the build type.  For known types that don't require publishing,
         // add the -nonrelease modifier to the tag
-        let buildType = try BuildRequestReader().getFeaturesFromFile().type
+        let buildType = try BuildRequestReader().getFeaturesFromFile().buildType
         let modifier = [BuildType.preview, .dryRun, .pullRequest].contains(buildType) ? "-nonrelease" : ""
 
         try stageFiles()

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Models/BuildRequest.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Models/BuildRequest.swift
@@ -30,7 +30,7 @@ struct BuildRequestReader {
 }
 
 struct BuildRequest: Decodable {
-    let type: BuildType?
+    let buildType: BuildType?
     let features: [Feature]?
 }
 

--- a/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Commands/PrepareReleaseTests.swift
+++ b/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Commands/PrepareReleaseTests.swift
@@ -252,7 +252,7 @@ class PrepareReleaseTests: CLITestCase {
     // MARK: - Private methods
 
     private func createBuildRequestAndMapping(type: BuildType) {
-        let buildRequest = "{\"type\":\"\(type.rawValue)\",\"features\":[]}"
+        let buildRequest = "{\"buildType\":\"\(type.rawValue)\",\"features\":[]}"
         FileManager.default.createFile(atPath: "../build-request.json", contents: Data(buildRequest.utf8))
 
         let mapping = "{}"


### PR DESCRIPTION
## Description of changes
Access the correct field for build type in `build-message.json`.  It should be `buildType`.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.