### PR TITLE
chore: Disable S3 Select integration test

### DIFF
--- a/IntegrationTests/Services/AWSS3IntegrationTests/S3EventStreamTests.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/S3EventStreamTests.swift
@@ -26,7 +26,7 @@ class S3EventStreamTests: S3XCTestCase {
     }
 
     // Tests event stream output in restXml protocol using S3::SelectObjectContent.
-    func testEventStreamOutput() async throws {
+    func xtestEventStreamOutput() async throws {
         let result = try await client.selectObjectContent(input: SelectObjectContentInput(
             bucket: bucketName,
             // Gets the two ID objects from the S3 object content.


### PR DESCRIPTION
## Description of changes
Disables the S3 Select integration test while obtaining advice on handling of zero-length payloads in streamed events.

I did verify that `swift test --skip S3EventStreamTests.testEventStreamOutput` (used on the automated build system) still executes successfully with that test disabled.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.