### PR TITLE
fix: Remove S3/200 cust from S3 Select op, re-enable int test

### DIFF
--- a/IntegrationTests/Services/AWSS3IntegrationTests/S3EventStreamTests.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/S3EventStreamTests.swift
@@ -26,7 +26,7 @@ class S3EventStreamTests: S3XCTestCase {
     }
 
     // Tests event stream output in restXml protocol using S3::SelectObjectContent.
-    func xtestEventStreamOutput() async throws {
+    func testEventStreamOutput() async throws {
         let result = try await client.selectObjectContent(input: SelectObjectContentInput(
             bucket: bucketName,
             // Gets the two ID objects from the S3 object content.

--- a/Sources/Services/AWSS3/Sources/AWSS3/S3Client.swift
+++ b/Sources/Services/AWSS3/Sources/AWSS3/S3Client.swift
@@ -9101,7 +9101,6 @@ extension S3Client {
         context.set(key: Smithy.AttributeKey<EndpointParams>(name: "EndpointParams"), value: endpointParamsBlock(context))
         builder.applyEndpoint(AWSClientRuntime.AWSEndpointResolverMiddleware<SelectObjectContentOutput, EndpointParams>(paramsBlock: endpointParamsBlock, resolverBlock: { [config] in try config.endpointResolver.resolve(params: $0) }))
         builder.selectAuthScheme(ClientRuntime.AuthSchemeMiddleware<SelectObjectContentOutput>())
-        builder.interceptors.add(AWSClientRuntime.AWSS3ErrorWith200StatusXMLMiddleware<SelectObjectContentInput, SelectObjectContentOutput>())
         builder.interceptors.add(AWSClientRuntime.AmzSdkInvocationIdMiddleware<SelectObjectContentInput, SelectObjectContentOutput>())
         builder.interceptors.add(AWSClientRuntime.AmzSdkRequestMiddleware<SelectObjectContentInput, SelectObjectContentOutput>(maxRetries: config.retryStrategyOptions.maxRetriesBase))
         builder.interceptors.add(AWSClientRuntime.UserAgentMiddleware<SelectObjectContentInput, SelectObjectContentOutput>(serviceID: serviceName, version: S3Client.version, config: config))

--- a/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/s3/S3ErrorWith200StatusIntegration.kt
+++ b/codegen/smithy-aws-swift-codegen/src/main/kotlin/software/amazon/smithy/aws/swift/codegen/customization/s3/S3ErrorWith200StatusIntegration.kt
@@ -40,15 +40,9 @@ class S3ErrorWith200StatusIntegration : SwiftIntegration {
         // Instead of playing whack-a-mole broadly apply this interceptor to everything but streaming responses
         // which adds a small amount of overhead to response processing.
         val output = ctx.model.expectShape(operationShape.output.get())
-        val outputIsNotAStreamingBlobShape =
-            output.members().none {
-                val targetShape = ctx.model.expectShape(it.target)
-                val isBlob = it.isBlobShape || targetShape.isBlobShape
-                val isStreaming = it.isStreaming || targetShape.isStreaming
-                isBlob && isStreaming
-            }
+        val outputIsNotAStreamingShape = output.members().none { ctx.model.expectShape(it.target).isStreaming }
 
-        if (outputIsNotAStreamingBlobShape) {
+        if (outputIsNotAStreamingShape) {
             operationMiddleware.appendMiddleware(operationShape, S3HandleError200ResponseMiddleware)
         }
     }


### PR DESCRIPTION
## Description of changes
- Removes the S3/200 customization from the S3 `SelectObjectContent` operation.  Per the spec it is not to be applied to event streaming operations, and it was causing S3 Select to fail because it was attempting to parse the entire event stream as XML.
- Re-enables the S3 `SelectObjectContent` integration test.
- The code-generated change to the S3 client (removing the customization from `SelectObjectContent`) is included in the PR.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.