### PR TITLE
fix: Use absolute links instead of relative links in new API ref landing page

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/AWSSDKSwiftCLI/Subcommands/GenerateDocIndex.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/AWSSDKSwiftCLI/Subcommands/GenerateDocIndex.swift
@@ -36,7 +36,7 @@ struct GenerateDocIndexCommand: ParsableCommand {
     func convertToNewFormat(_ content: String) -> String {
         var result = content.replacingOccurrences(
             of: "../../../../../swift/api/",
-            with: "../../../../../latest/api/"
+            with: "/sdk-for-swift/latest/api/"
         ).replacingOccurrences(
             of: "# ``AWSSDKForSwift``",
             with: "# ``SDKForSwift``"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->
N/A

## Description of changes
<!--- Why is this change required? What problem does it solve? -->
- Background: When doing a specific sequence of events in new API ref landing page (go to landing page, click on an article on left nav panel, then click back on landing page), the relative links in landing page get broken.
- Change: Use absolute links instead of brittle relative links for new API ref landing page

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.