### PR TITLE
chore: Remove debug output from AWSRestJson1ProtocolGeneratorTests

### DIFF
--- a/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsrestjson/AWSRestJson1ProtocolGeneratorTests.kt
+++ b/codegen/smithy-aws-swift-codegen/src/test/kotlin/software/amazon/smithy/aws/swift/codegen/awsrestjson/AWSRestJson1ProtocolGeneratorTests.kt
@@ -57,10 +57,6 @@ extension ExplicitBlobInput {
         val context = setupTests("http-binding-protocol-generator-test.smithy", "com.test#Example")
         val contents = getClientFileContents("Sources/Example", "ExampleClient.swift", context.manifest)
         contents.shouldSyntacticSanityCheck()
-
-        // Debug: Save actual generated output to file
-        java.io.File("aws-test-generated-output.txt").writeText(contents)
-
         val expectedContents = """
 public final class ExampleClient: AWSClientRuntime.AWSServiceClient {
     public static let clientName = "ExampleClient"


### PR DESCRIPTION
## Description of changes
Remove a debug write-to-file from `AWSRestJson1ProtocolGeneratorTests`.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.