### PR TITLE
fix: try using ephemeral instead of shared connections in s3 tests

### DIFF
--- a/IntegrationTests/Services/AWSS3IntegrationTests/S3XCTestCase.swift
+++ b/IntegrationTests/Services/AWSS3IntegrationTests/S3XCTestCase.swift
@@ -60,8 +60,10 @@ class S3XCTestCase: XCTestCase {
     /// - Returns: The data and optional http response, or empty data if the response has no body.
     /// - Throws: Any error returned by the data task, or `HTTPError` if the request completes and the HTTP status code is not 200 series.
     func perform(urlRequest: URLRequest) async throws -> (Data, HTTPURLResponse?) {
-        try await withCheckedThrowingContinuation { continuation in
-            let task = URLSession.shared.dataTask(with: urlRequest) { data, urlResponse, error in
+        let session = URLSession(configuration: .ephemeral)
+        defer { session.finishTasksAndInvalidate() }
+        return try await withCheckedThrowingContinuation { continuation in
+            let task = session.dataTask(with: urlRequest) { data, urlResponse, error in
                 if let error = error {
                     continuation.resume(throwing: error)
                 } else if let code = (urlResponse as? HTTPURLResponse)?.statusCode, !(200...299).contains(code) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->

## Description of changes
The presigned URL integration tests were intermittently failing with TLS error -1200. The tests used URLSession.shared, a singleton that persists connection state across tests. Since each test creates a new S3 bucket with a unique hostname, stale HTTP/2 connections and TLS sessions from previous tests could interfere with new connections. Switching to an ephemeral URLSession gives each request a fresh connection pool, eliminating the stale connection issue.

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.