### PR TITLE
fix: flaky integ tests by using exponential backoff

### DIFF
--- a/IntegrationTests/Services/AWSCognitoIdentityIntegrationTests/CognitoAWSCredentialIdentityResolverTests.swift
+++ b/IntegrationTests/Services/AWSCognitoIdentityIntegrationTests/CognitoAWSCredentialIdentityResolverTests.swift
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import AWSClientRuntime
 import AWSCognitoIdentity
 import AWSIAM
 import AWSSDKIdentity
@@ -97,7 +98,9 @@ class CognitoAWSCredentialIdentityResolverTests: XCTestCase {
         let cognitoStsClient = STSClient(config: cognitoStsConfig)
 
         // Retry with exponential backoff to handle IAM eventual consistency
+        // Only retry on errors indicating credentials aren't propagated yet
         // Worst-case wait: 5+10+20+20 = 55s
+        let retryableErrorCodes: Set<String> = ["InvalidClientTokenId", "AccessDenied"]
         var lastError: Error?
         let totalRetries = 5
         for attempt in 0..<totalRetries {
@@ -115,6 +118,11 @@ class CognitoAWSCredentialIdentityResolverTests: XCTestCase {
                 XCTAssertTrue(arn.contains(roleName))
                 return
             } catch {
+                guard let serviceError = error as? AWSServiceError,
+                      let code = serviceError.errorCode,
+                      retryableErrorCodes.contains(code) else {
+                    throw error
+                }
                 lastError = error
                 if attempt < (totalRetries-1) {
                     // Exponential backoff: 5s, 10s, 20s, 20s

--- a/IntegrationTests/Services/AWSSTSIntegrationTests/STSAssumeRoleAWSCredentialIdentityResolverTests.swift
+++ b/IntegrationTests/Services/AWSSTSIntegrationTests/STSAssumeRoleAWSCredentialIdentityResolverTests.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import XCTest
+import AWSClientRuntime
 import AWSSTS
 import AWSIAM
 import AWSSDKIdentity
@@ -60,7 +61,9 @@ class STSAssumeRoleAWSCredentialIdentityResolverTests: XCTestCase {
     // Confirm STS assume role credentials provider works by validating response.
     func testGetCallerIdentity() async throws {
         // Retry with exponential backoff to handle IAM eventual consistency
+        // Only retry on errors indicating credentials aren't propagated yet
         // Worst-case wait: 5+10+20+20 = 55s
+        let retryableErrorCodes: Set<String> = ["InvalidClientTokenId", "AccessDenied"]
         var lastError: Error?
         let totalRetries = 5
         for attempt in 0..<totalRetries {
@@ -78,6 +81,11 @@ class STSAssumeRoleAWSCredentialIdentityResolverTests: XCTestCase {
                 XCTAssertNotEqual(arn, "")
                 return
             } catch {
+                guard let serviceError = error as? AWSServiceError,
+                      let code = serviceError.errorCode,
+                      retryableErrorCodes.contains(code) else {
+                    throw error
+                }
                 lastError = error
                 if attempt < (totalRetries-1) {
                     // Exponential backoff: 5s, 10s, 20s, 20s


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.