### PR TITLE
chore: Add Red Hat Enterprise Linux to CI matrix

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -133,8 +133,10 @@ jobs:
           - ubuntu-24.04
           - ubuntu-24.04-arm
         swift:
-          - "5.9-jammy"
-          - "6.2-noble"
+          - 5.9-jammy
+          - 5.9-rhel-ubi9
+          - 6.2-noble
+          - 6.3-rhel-ubi9
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -142,8 +142,10 @@ jobs:
           - ubuntu-24.04
           - ubuntu-24.04-arm
         swift:
-          - "5.9-jammy"
-          - "6.2-noble"
+          - 5.9-jammy
+          - 5.9-rhel-ubi9
+          - 6.2-noble
+          - 6.3-rhel-ubi9
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:


### PR DESCRIPTION
## Description of changes
Add min/max Swift builds on Red Hat Enterprise Linux.

See justifications in https://github.com/smithy-lang/smithy-swift/pull/1053.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.