### PR TITLE
Chore: Eliminate duplicate token scope in int test workflow

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 env:
   AWS_SWIFT_SDK_USE_LOCAL_DEPS: 1
 


### PR DESCRIPTION
## Description of changes
Remove duplicate token scope from the integration test CI workflow.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.