### PR TITLE
chore: Update Smithy to 1.69.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ kotlin.code.style=official
 org.gradle.jvmargs=-Xmx4096M
 
 # codegen
-smithyVersion=1.67.0
+smithyVersion=1.69.0
 smithyGradleVersion=0.6.0
 
 smithySwiftVersion = 0.1.0


### PR DESCRIPTION
## Description of changes
Update Smithy to latest published version:
https://github.com/smithy-lang/smithy/releases/tag/1.69.0

Note: running codegen with new Smithy results in zero-diff in AWS services.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.