### PR TITLE
chore: Quit the prepare_release CLI cmd early when build request or mapping JSON is missing

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/AWSSDKSwiftCLI/Subcommands/PrepareRelease.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/AWSSDKSwiftCLI/Subcommands/PrepareRelease.swift
@@ -81,6 +81,14 @@ struct PrepareRelease {
     func run() throws {
         try FileManager.default.changeWorkingDirectory(repoPath)
 
+        // Rename feature-service-id-smithy.json to feature-service-id.json if it exists
+        // This is needed when a build is triggered manually & merge step doesn't run
+        if FileManager.default.fileExists(atPath: "../feature-service-id-smithy.json") {
+            log("Renaming feature-service-id-smithy.json to feature-service-id.json.")
+            try FileManager.default.moveItem(atPath: "../feature-service-id-smithy.json", toPath: "../feature-service-id.json")
+            log("Renamed feature-service-id-smithy.json to feature-service-id.json.")
+        }
+
         guard BuildRequestReader.buildRequestAndMappingExist() else {
             // If the build request or mapping input files
             // don't exist, create an empty release-manifest.json file.
@@ -104,13 +112,6 @@ struct PrepareRelease {
             // Return without creating new commit or tag in local repos.
             // This makes GitPublisher be no-op.
             return
-        }
-
-        // Rename feature-service-id-smithy.json to feature-service-id.json if it exists
-        if FileManager.default.fileExists(atPath: "../feature-service-id-smithy.json") {
-            log("Renaming feature-service-id-smithy.json to feature-service-id.json.")
-            try FileManager.default.moveItem(atPath: "../feature-service-id-smithy.json", toPath: "../feature-service-id.json")
-            log("Renamed feature-service-id-smithy.json to feature-service-id.json.")
         }
 
         let newVersion = try createNewVersion(previousVersion)

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/AWSSDKSwiftCLI/Subcommands/PrepareRelease.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/AWSSDKSwiftCLI/Subcommands/PrepareRelease.swift
@@ -81,6 +81,17 @@ struct PrepareRelease {
     func run() throws {
         try FileManager.default.changeWorkingDirectory(repoPath)
 
+        guard BuildRequestReader.buildRequestAndMappingExist() else {
+            // If the build request or mapping input files
+            // don't exist, create an empty release-manifest.json file.
+            log("build-request.json and/or feature-service-id.json don't exist.")
+            log("Writing empty manifest and exiting.")
+            try createEmptyReleaseManifest()
+            // Return without creating new commit or tag in local repos.
+            // This makes GitPublisher be no-op.
+            return
+        }
+
         let previousVersion = try getPreviousVersion()
         guard try repoHasChanges(previousVersion) else {
             // If repo has no changes, create an empty release-manifest.json file.
@@ -100,17 +111,6 @@ struct PrepareRelease {
             log("Renaming feature-service-id-smithy.json to feature-service-id.json.")
             try FileManager.default.moveItem(atPath: "../feature-service-id-smithy.json", toPath: "../feature-service-id.json")
             log("Renamed feature-service-id-smithy.json to feature-service-id.json.")
-        }
-
-        guard BuildRequestReader.buildRequestAndMappingExist() else {
-            // If the build request or mapping input files
-            // don't exist, create an empty release-manifest.json file.
-            log("build-request.json and/or feature-service-id.json don't exist.")
-            log("Writing empty manifest and exiting.")
-            try createEmptyReleaseManifest()
-            // Return without creating new commit or tag in local repos.
-            // This makes GitPublisher be no-op.
-            return
         }
 
         let newVersion = try createNewVersion(previousVersion)


### PR DESCRIPTION
## Description of changes
When running the `prepare-release` CLI command, check that the build request and mapping exist before performing any other checks.

This ensures that Catapult can run successfully on SDK & smithy-swift branches for testing.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.