### PR TITLE
chore: Enable prepare-release on any branch

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/AWSSDKSwiftCLI/Subcommands/PrepareRelease.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/AWSSDKSwiftCLI/Subcommands/PrepareRelease.swift
@@ -162,16 +162,16 @@ struct PrepareRelease {
         return newVersion
     }
 
-    /// Returns true if the `main` branch has changes since the previous release, otherwise returns false.
+    /// Returns true if `HEAD` has changes since the previous release, otherwise returns false.
     ///
     /// - Parameter previousVersion: The version of the previous release
-    /// - Returns: True if the `main` branch has changes since the previous release, otherwise returns false.
+    /// - Returns: True if `HEAD` has changes since the previous release, otherwise returns false.
     func repoHasChanges(_ previousVersion: Version) throws -> Bool {
-        let hasChanges = try diffChecker("main", previousVersion)
+        let hasChanges = try diffChecker("HEAD", previousVersion)
         if hasChanges {
-            log("Changes detected between 'main' and the previous release \(previousVersion)")
+            log("Changes detected between 'HEAD' and the previous release \(previousVersion)")
         } else {
-            log("No changes detected between 'main' and the previous release \(previousVersion)")
+            log("No changes detected between 'HEAD' and the previous release \(previousVersion)")
         }
         return hasChanges
     }


### PR DESCRIPTION
## Description of changes
When checking for git repo changes since last release, the `AWSSDKSwiftCLI` `prepare-release` command is hard-coded to get the git diff from the last release tag to the `main` branch.  This causes the command to fail whenever the `main` branch is not cloned to local, and prevents us from running this command successfully when building any branch other than `main`.

To remedy, `main` is replaced with `HEAD` so that the command will run no matter what branch is checked out, and its behavior is unchanged when `main` is the checked-out branch.

Other Git operations (i.e. checking for local changes, constructing a list of commits) already reference the `HEAD` commit instead of a hard-coded branch, so this change makes the diff checker command consistent with the other Git commands.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.