### PR TITLE
chore: Add complete jobs to GH CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -125,6 +125,13 @@ jobs:
             | xcbeautify
           cd ..
 
+  apple-ci-complete:
+    needs: apple-ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: Success
+        run: echo "apple-ci passed"
+
   linux-ci:
     if: github.repository == 'awslabs/aws-sdk-swift' || github.event_name == 'pull_request'
     runs-on: ${{ matrix.runner }}
@@ -196,3 +203,11 @@ jobs:
           cd aws-sdk-swift/codegen/
           swift test
           cd ..
+
+  linux-ci-complete:
+    needs: linux-ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: Success
+        run: echo "linux-ci passed"
+

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -130,6 +130,13 @@ jobs:
             test 2>&1 \
             | xcbeautify
 
+  apple-int-complete:
+    needs: apple-int
+    runs-on: ubuntu-latest
+    steps:
+      - name: Success
+        run: echo "apple-int passed"
+
   linux-int:
     if: github.repository == 'awslabs/aws-sdk-swift' || github.event_name == 'pull_request'
     runs-on: ${{ matrix.runner }}
@@ -201,3 +208,11 @@ jobs:
         run: |
           cd aws-sdk-swift/IntegrationTests
           swift test
+
+  linux-int-complete:
+    needs: linux-int
+    runs-on: ubuntu-latest
+    steps:
+      - name: Success
+        run: echo "linux-int passed"
+


### PR DESCRIPTION
## Description of changes
Adds "complete" jobs to CI which will be made required prior to merge.  This will prevent us from requiring individual OS / platform combinations on CI & int tests.

This is identical to the approach already used in smithy-swift: https://github.com/smithy-lang/smithy-swift/pull/1069

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.