### PR TITLE
chore: Relax aws-crt-swift version requirement to float up

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.txt
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.txt
@@ -114,7 +114,7 @@ private var smithySwiftDependency: Package.Dependency {
 }
 
 private var crtDependency: Package.Dependency {
-    .package(url: "https://github.com/awslabs/aws-crt-swift", exact: crtVersion)
+    .package(url: "https://github.com/awslabs/aws-crt-swift", from: crtVersion)
 }
 
 private var doccDependencyOrNil: Package.Dependency? {

--- a/Package.swift
+++ b/Package.swift
@@ -2301,7 +2301,7 @@ private var smithySwiftDependency: Package.Dependency {
 }
 
 private var crtDependency: Package.Dependency {
-    .package(url: "https://github.com/awslabs/aws-crt-swift", exact: crtVersion)
+    .package(url: "https://github.com/awslabs/aws-crt-swift", from: crtVersion)
 }
 
 private var doccDependencyOrNil: Package.Dependency? {


### PR DESCRIPTION
## Issue \#
https://github.com/awslabs/aws-sdk-swift/issues/2181

## Description of changes
Allow `aws-crt-swift` dependency to float up to next major version.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.