### PR TITLE
Revert "chore: Relax aws-crt-swift version requirement to float up (#…

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.txt
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Resources/Package.Base.txt
@@ -114,7 +114,7 @@ private var smithySwiftDependency: Package.Dependency {
 }
 
 private var crtDependency: Package.Dependency {
-    .package(url: "https://github.com/awslabs/aws-crt-swift", from: crtVersion)
+    .package(url: "https://github.com/awslabs/aws-crt-swift", exact: crtVersion)
 }
 
 private var doccDependencyOrNil: Package.Dependency? {

--- a/Package.swift
+++ b/Package.swift
@@ -2301,7 +2301,7 @@ private var smithySwiftDependency: Package.Dependency {
 }
 
 private var crtDependency: Package.Dependency {
-    .package(url: "https://github.com/awslabs/aws-crt-swift", from: crtVersion)
+    .package(url: "https://github.com/awslabs/aws-crt-swift", exact: crtVersion)
 }
 
 private var doccDependencyOrNil: Package.Dependency? {


### PR DESCRIPTION
…2182)"

This reverts commit 947c55c033b70213cb44055f42d887e5fb9f7bd2.

<!--- Provide a general summary of your changes in the Title above -->

## Issue \#
<!--- If it fixes an issue, please link to the issue here -->

## Description of changes
<!--- Why is this change required? What problem does it solve? -->

## New/existing dependencies impact assessment, if applicable
<!--- No new dependencies were added to this change. -->
<!--- If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly. -->

## Conventional Commits
<!--- Please use conventional commits to let us know what kind of change this is.-->
<!--- More info can be found here: https://www.conventionalcommits.org/en/v1.0.0/-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.