### PR TITLE
chore: Apply auto-formatting to protocol-test-codegen-local

### DIFF
--- a/codegen/protocol-test-codegen-local/model/aws-query-extras.smithy
+++ b/codegen/protocol-test-codegen-local/model/aws-query-extras.smithy
@@ -2,37 +2,39 @@ $version: "2.0"
 
 namespace aws.protocoltests.query
 
-use aws.protocols#awsQuery
 use aws.api#service
+use aws.protocols#awsQuery
 use smithy.test#httpRequestTests
-use smithy.test#httpResponseTests
-
 
 @service(sdkId: "Query Protocol")
 @awsQuery
 @xmlNamespace(uri: "https://example.com/")
 service AwsQueryExtras {
-    version: "2019-12-16",
-    operations: [GetTimestamps]
+    version: "2019-12-16"
+    operations: [
+        GetTimestamps
+    ]
 }
 
 @httpRequestTests([
     {
-        id: "GetTimestampsRequest",
-        uri: "/",
-        body: "Action=GetTimestamps&Version=2019-12-16&StartTime=2023-09-19T21%3A09%3A28Z&endTime=2023-09-19T21%3A09%3A29Z",
+        id: "GetTimestampsRequest"
+        uri: "/"
+        body: "Action=GetTimestamps&Version=2019-12-16&StartTime=2023-09-19T21%3A09%3A28Z&endTime=2023-09-19T21%3A09%3A29Z"
         params: {
-            StartTime: 1695157768,  // 2023-09-19T21:09:28Z
-            endTime: 1695157769     // 2023-09-19T21:09:29Z
+            StartTime: 1695157768
+            // 2023-09-19T21:09:28Z
+            endTime: 1695157769
+            // 2023-09-19T21:09:29Z
         }
-        method: "POST",
-        bodyMediaType: "application/x-www-form-urlencoded",
+        method: "POST"
+        bodyMediaType: "application/x-www-form-urlencoded"
         protocol: awsQuery
     }
 ])
 @http(uri: "/", method: "POST")
 operation GetTimestamps {
-    input: HasTimestamp,
+    input: HasTimestamp
     output: HasTimestamp
 }
 
@@ -40,4 +42,3 @@ structure HasTimestamp {
     StartTime: Timestamp
     endTime: Timestamp
 }
-

--- a/codegen/protocol-test-codegen-local/model/endpoints-string-array.smithy
+++ b/codegen/protocol-test-codegen-local/model/endpoints-string-array.smithy
@@ -2,123 +2,115 @@ $version: "2.0"
 
 namespace aws.endpointtests.stringarray
 
-use smithy.rules#endpointRuleSet
-use smithy.rules#endpointTests
-use smithy.rules#staticContextParams
-use smithy.rules#operationContextParams
 use aws.api#service
 use aws.protocols#restJson1
+use smithy.rules#endpointRuleSet
+use smithy.rules#endpointTests
+use smithy.rules#operationContextParams
+use smithy.rules#staticContextParams
 
 @endpointRuleSet({
-    version: "1.0",
+    version: "1.0"
     parameters: {
         stringArrayParam: {
-            type: "stringArray",
-            required: true,
-            default: ["defaultValue1", "defaultValue2"],
+            type: "stringArray"
+            required: true
+            default: ["defaultValue1", "defaultValue2"]
             documentation: "docs"
         }
-    },
+    }
     rules: [
         {
-            "documentation": "Template first array value into URI if set",
-            "conditions": [
+            documentation: "Template first array value into URI if set"
+            conditions: [
                 {
-                    "fn": "getAttr",
-                    "argv": [
+                    fn: "getAttr"
+                    argv: [
                         {
-                            "ref": "stringArrayParam"
-                        },
+                            ref: "stringArrayParam"
+                        }
                         "[0]"
-                    ],
-                    "assign": "arrayValue"
+                    ]
+                    assign: "arrayValue"
                 }
-            ],
-            "endpoint": {
-                "url": "https://example.com/{arrayValue}"
-            },
-            "type": "endpoint"
-        },
+            ]
+            endpoint: { url: "https://example.com/{arrayValue}" }
+            type: "endpoint"
+        }
         {
-            "conditions": [],
-            "documentation": "error fallthrough",
-            "error": "no array values set",
-            "type": "error"
+            conditions: []
+            documentation: "error fallthrough"
+            error: "no array values set"
+            type: "error"
         }
     ]
 })
 @endpointTests({
-    "version": "1.0",
-    "testCases": [
+    version: "1.0"
+    testCases: [
         {
-            "documentation": "Default array values used"
-            "params": {}
-            "expect": {
-                "endpoint": {
-                    "url": "https://example.com/defaultValue1"
-                }
-            },
-            "operationInputs": [
+            documentation: "Default array values used"
+            params: {}
+            expect: {
+                endpoint: { url: "https://example.com/defaultValue1" }
+            }
+            operationInputs: [
                 {
-                    "operationName": "NoBindingsOperation",
+                    operationName: "NoBindingsOperation"
                 }
             ]
-        },
+        }
         {
-            "documentation": "Empty array",
-            "params": {
-                "stringArrayParam": []
+            documentation: "Empty array"
+            params: {
+                stringArrayParam: []
             }
-            "expect": {
-                "error": "no array values set"
-            },
-            "operationInputs": [
+            expect: { error: "no array values set" }
+            operationInputs: [
                 {
-                    "operationName": "EmptyStaticContextOperation",
+                    operationName: "EmptyStaticContextOperation"
                 }
             ]
-        },
+        }
         {
-            "documentation": "Static value",
-            "params": {
-                "stringArrayParam": ["staticValue1"]
+            documentation: "Static value"
+            params: {
+                stringArrayParam: ["staticValue1"]
             }
-            "expect": {
-                "endpoint": {
-                    "url": "https://example.com/staticValue1"
-                }
-            },
-            "operationInputs": [
+            expect: {
+                endpoint: { url: "https://example.com/staticValue1" }
+            }
+            operationInputs: [
                 {
-                    "operationName": "StaticContextOperation",
+                    operationName: "StaticContextOperation"
                 }
             ]
-        },
+        }
         {
-            "documentation": "bound value from input",
-            "params": {
-                "stringArrayParam": ["key1"]
+            documentation: "bound value from input"
+            params: {
+                stringArrayParam: ["key1"]
             }
-            "expect": {
-                "endpoint": {
-                    "url": "https://example.com/key1"
-                }
-            },
-            "operationInputs": [
+            expect: {
+                endpoint: { url: "https://example.com/key1" }
+            }
+            operationInputs: [
                 {
-                    "operationName": "ListOfObjectsOperation",
-                    "operationParams": {
-                        "nested": {
-                            "listOfObjects": [{"key": "key1"}]
+                    operationName: "ListOfObjectsOperation"
+                    operationParams: {
+                        nested: {
+                            listOfObjects: [
+                                {
+                                    key: "key1"
+                                }
+                            ]
                         }
-                    },
-                },
+                    }
+                }
                 {
-                    "operationName": "MapOperation",
-                    "operationParams": {
-                        "map": {
-                            "key1": "value1"
-                        }
+                    operationName: "MapOperation"
+                    operationParams: {
+                        map: { key1: "value1" }
                     }
                 }
             ]
@@ -128,23 +120,25 @@ use aws.protocols#restJson1
 @service(sdkId: "EndpointStringArray")
 @restJson1
 service EndpointStringArray {
-    version: "2022-01-01",
+    version: "2022-01-01"
     operations: [
-        NoBindingsOperation,
-        EmptyStaticContextOperation,
-        StaticContextOperation,
-        ListOfObjectsOperation,
+        NoBindingsOperation
+        EmptyStaticContextOperation
+        StaticContextOperation
+        ListOfObjectsOperation
         MapOperation
     ]
 }
 
 @http(uri: "/1", method: "POST")
 operation NoBindingsOperation {
-    input:= {}
+    input := {}
 }
 
 @staticContextParams(
-    "stringArrayParam": {value: []}
+    stringArrayParam: {
+        value: []
+    }
 )
 @http(uri: "/2", method: "POST")
 operation EmptyStaticContextOperation {
@@ -152,7 +146,9 @@ operation EmptyStaticContextOperation {
 }
 
 @staticContextParams(
-    "stringArrayParam": {value: ["staticValue1"]}
+    stringArrayParam: {
+        value: ["staticValue1"]
+    }
 )
 @http(uri: "/3", method: "POST")
 operation StaticContextOperation {
@@ -160,21 +156,21 @@ operation StaticContextOperation {
 }
 
 @operationContextParams(
-    "stringArrayParam": {path: "nested.listOfObjects[*].key"}
+    stringArrayParam: { path: "nested.listOfObjects[*].key" }
 )
 @http(uri: "/4", method: "POST")
 operation ListOfObjectsOperation {
-    input:= {
+    input := {
         nested: Nested
     }
 }
 
 @operationContextParams(
-    "stringArrayParam": {path: "keys(map)"}
+    stringArrayParam: { path: "keys(map)" }
 )
 @http(uri: "/5", method: "POST")
 operation MapOperation {
-    input:= {
+    input := {
         map: Map
     }
 }
@@ -188,10 +184,10 @@ list ListOfObjects {
 }
 
 structure ObjectMember {
-    key: String,
+    key: String
 }
 
 map Map {
-    key: String,
+    key: String
     value: String
 }

--- a/codegen/protocol-test-codegen-local/model/eventstream-rpc.smithy
+++ b/codegen/protocol-test-codegen-local/model/eventstream-rpc.smithy
@@ -1,20 +1,28 @@
 $version: "2"
+
 namespace aws.protocoltests.eventstream
 
-use aws.protocols#awsJson1_1
 use aws.api#service
 use aws.auth#sigv4
+use aws.protocols#awsJson1_1
 
 @awsJson1_1
 @sigv4(name: "rpc-event-stream-test")
 @service(sdkId: "RPCEventStreamTest")
-service RPCTestService { version: "123", operations: [TestStreamOp] }
+service RPCTestService {
+    version: "123"
+    operations: [
+        TestStreamOp
+    ]
+}
 
 @http(method: "POST", uri: "/test")
 operation TestStreamOp {
-    input: TestStreamInputOutput,
-    output: TestStreamInputOutput,
-    errors: [SomeError],
+    input: TestStreamInputOutput
+    output: TestStreamInputOutput
+    errors: [
+        SomeError
+    ]
 }
 
 structure TestStreamInputOutput {
@@ -25,17 +33,17 @@ structure TestStreamInputOutput {
 
 @error("client")
 structure SomeError {
-    Message: String,
+    Message: String
 }
 
 union TestUnion {
-    Foo: String,
-    Bar: Integer,
+    Foo: String
+    Bar: Integer
 }
 
 structure TestStruct {
-    someString: String,
-    someInt: Integer,
+    someString: String
+    someInt: Integer
 }
 
 enum TestEnum {
@@ -50,49 +58,87 @@ intEnum TestIntEnum {
     C = 2
 }
 
-structure MessageWithBlob { @eventPayload data: Blob }
+structure MessageWithBlob {
+    @eventPayload
+    data: Blob
+}
 
-structure MessageWithString { @eventPayload data: String }
+structure MessageWithString {
+    @eventPayload
+    data: String
+}
 
-structure MessageWithStruct { @eventPayload someStruct: TestStruct }
+structure MessageWithStruct {
+    @eventPayload
+    someStruct: TestStruct
+}
 
-structure MessageWithUnion { @eventPayload someUnion: TestUnion }
+structure MessageWithUnion {
+    @eventPayload
+    someUnion: TestUnion
+}
 
 structure MessageWithHeaders {
-    @eventHeader blob: Blob,
-    @eventHeader boolean: Boolean,
-    @eventHeader byte: Byte,
-    @eventHeader int: Integer,
-    @eventHeader intEnum: TestIntEnum,
-    @eventHeader long: Long,
-    @eventHeader short: Short,
-    @eventHeader string: String,
-    @eventHeader enum: TestEnum,
-    @eventHeader timestamp: Timestamp,
+    @eventHeader
+    blob: Blob
+
+    @eventHeader
+    boolean: Boolean
+
+    @eventHeader
+    byte: Byte
+
+    @eventHeader
+    int: Integer
+
+    @eventHeader
+    intEnum: TestIntEnum
+
+    @eventHeader
+    long: Long
+
+    @eventHeader
+    short: Short
+
+    @eventHeader
+    string: String
+
+    @eventHeader
+    enum: TestEnum
+
+    @eventHeader
+    timestamp: Timestamp
 }
+
 structure MessageWithHeaderAndPayload {
-    @eventHeader header: String,
-    @eventPayload payload: Blob,
+    @eventHeader
+    header: String
+
+    @eventPayload
+    payload: Blob
 }
+
 structure MessageWithNoHeaderPayloadTraits {
-    someInt: Integer,
-    someString: String,
+    someInt: Integer
+    someString: String
 }
 
 structure MessageWithUnboundPayloadTraits {
-    @eventHeader header: String,
-    unboundString: String,
+    @eventHeader
+    header: String
+
+    unboundString: String
 }
 
 @streaming
 union TestStream {
-    MessageWithBlob: MessageWithBlob,
-    MessageWithString: MessageWithString,
-    MessageWithStruct: MessageWithStruct,
-    MessageWithUnion: MessageWithUnion,
-    MessageWithHeaders: MessageWithHeaders,
-    MessageWithHeaderAndPayload: MessageWithHeaderAndPayload,
-    MessageWithNoHeaderPayloadTraits: MessageWithNoHeaderPayloadTraits,
-    MessageWithUnboundPayloadTraits: MessageWithUnboundPayloadTraits,
-    SomeError: SomeError,
+    MessageWithBlob: MessageWithBlob
+    MessageWithString: MessageWithString
+    MessageWithStruct: MessageWithStruct
+    MessageWithUnion: MessageWithUnion
+    MessageWithHeaders: MessageWithHeaders
+    MessageWithHeaderAndPayload: MessageWithHeaderAndPayload
+    MessageWithNoHeaderPayloadTraits: MessageWithNoHeaderPayloadTraits
+    MessageWithUnboundPayloadTraits: MessageWithUnboundPayloadTraits
+    SomeError: SomeError
 }

--- a/codegen/protocol-test-codegen-local/model/eventstream.smithy
+++ b/codegen/protocol-test-codegen-local/model/eventstream.smithy
@@ -1,20 +1,28 @@
 $version: "2"
+
 namespace aws.protocoltests.eventstream
 
-use aws.protocols#restJson1
 use aws.api#service
 use aws.auth#sigv4
+use aws.protocols#restJson1
 
 @restJson1
 @sigv4(name: "event-stream-test")
 @service(sdkId: "EventStreamTest")
-service TestService { version: "123", operations: [TestStreamOp] }
+service TestService {
+    version: "123"
+    operations: [
+        TestStreamOp
+    ]
+}
 
 @http(method: "POST", uri: "/test")
 operation TestStreamOp {
-    input: TestStreamInputOutput,
-    output: TestStreamInputOutput,
-    errors: [SomeError],
+    input: TestStreamInputOutput
+    output: TestStreamInputOutput
+    errors: [
+        SomeError
+    ]
 }
 
 structure TestStreamInputOutput {
@@ -25,17 +33,17 @@ structure TestStreamInputOutput {
 
 @error("client")
 structure SomeError {
-    Message: String,
+    Message: String
 }
 
 union TestUnion {
-    Foo: String,
-    Bar: Integer,
+    Foo: String
+    Bar: Integer
 }
 
 structure TestStruct {
-    someString: String,
-    someInt: Integer,
+    someString: String
+    someInt: Integer
 }
 
 enum TestEnum {
@@ -50,49 +58,87 @@ intEnum TestIntEnum {
     C = 2
 }
 
-structure MessageWithBlob { @eventPayload data: Blob }
+structure MessageWithBlob {
+    @eventPayload
+    data: Blob
+}
 
-structure MessageWithString { @eventPayload data: String }
+structure MessageWithString {
+    @eventPayload
+    data: String
+}
 
-structure MessageWithStruct { @eventPayload someStruct: TestStruct }
+structure MessageWithStruct {
+    @eventPayload
+    someStruct: TestStruct
+}
 
-structure MessageWithUnion { @eventPayload someUnion: TestUnion }
+structure MessageWithUnion {
+    @eventPayload
+    someUnion: TestUnion
+}
 
 structure MessageWithHeaders {
-    @eventHeader blob: Blob,
-    @eventHeader boolean: Boolean,
-    @eventHeader byte: Byte,
-    @eventHeader int: Integer,
-    @eventHeader intEnum: TestIntEnum,
-    @eventHeader long: Long,
-    @eventHeader short: Short,
-    @eventHeader string: String,
-    @eventHeader enum: TestEnum,
-    @eventHeader timestamp: Timestamp,
+    @eventHeader
+    blob: Blob
+
+    @eventHeader
+    boolean: Boolean
+
+    @eventHeader
+    byte: Byte
+
+    @eventHeader
+    int: Integer
+
+    @eventHeader
+    intEnum: TestIntEnum
+
+    @eventHeader
+    long: Long
+
+    @eventHeader
+    short: Short
+
+    @eventHeader
+    string: String
+
+    @eventHeader
+    enum: TestEnum
+
+    @eventHeader
+    timestamp: Timestamp
 }
+
 structure MessageWithHeaderAndPayload {
-    @eventHeader header: String,
-    @eventPayload payload: Blob,
+    @eventHeader
+    header: String
+
+    @eventPayload
+    payload: Blob
 }
+
 structure MessageWithNoHeaderPayloadTraits {
-    someInt: Integer,
-    someString: String,
+    someInt: Integer
+    someString: String
 }
 
 structure MessageWithUnboundPayloadTraits {
-    @eventHeader header: String,
-    unboundString: String,
+    @eventHeader
+    header: String
+
+    unboundString: String
 }
 
 @streaming
 union TestStream {
-    MessageWithBlob: MessageWithBlob,
-    MessageWithString: MessageWithString,
-    MessageWithStruct: MessageWithStruct,
-    MessageWithUnion: MessageWithUnion,
-    MessageWithHeaders: MessageWithHeaders,
-    MessageWithHeaderAndPayload: MessageWithHeaderAndPayload,
-    MessageWithNoHeaderPayloadTraits: MessageWithNoHeaderPayloadTraits,
-    MessageWithUnboundPayloadTraits: MessageWithUnboundPayloadTraits,
-    SomeError: SomeError,
+    MessageWithBlob: MessageWithBlob
+    MessageWithString: MessageWithString
+    MessageWithStruct: MessageWithStruct
+    MessageWithUnion: MessageWithUnion
+    MessageWithHeaders: MessageWithHeaders
+    MessageWithHeaderAndPayload: MessageWithHeaderAndPayload
+    MessageWithNoHeaderPayloadTraits: MessageWithNoHeaderPayloadTraits
+    MessageWithUnboundPayloadTraits: MessageWithUnboundPayloadTraits
+    SomeError: SomeError
 }

--- a/codegen/protocol-test-codegen-local/model/rest-json-extras.smithy
+++ b/codegen/protocol-test-codegen-local/model/rest-json-extras.smithy
@@ -2,73 +2,71 @@ $version: "1.0"
 
 namespace aws.protocoltests.restjson
 
-use aws.protocols#restJson1
 use aws.api#service
+use aws.protocols#restJson1
 use smithy.test#httpRequestTests
 use smithy.test#httpResponseTests
 
 apply QueryPrecedence @httpRequestTests([
     {
-        id: "UrlParamsKeyEncoding",
-        documentation: "Keys and values must be url encoded",
-        protocol: restJson1,
-        method: "POST",
-        uri: "/Precedence",
-        body: "",
-        queryParams: ["bar=%26%F0%9F%90%B1", "hello%20there=how%27s%20your%20encoding%3F", "a%20%26%20b%20%26%20c=better%20encode%20%3D%20this"],
+        id: "UrlParamsKeyEncoding"
+        documentation: "Keys and values must be url encoded"
+        protocol: restJson1
+        method: "POST"
+        uri: "/Precedence"
+        body: ""
+        queryParams: ["bar=%26%F0%9F%90%B1", "hello%20there=how%27s%20your%20encoding%3F", "a%20%26%20b%20%26%20c=better%20encode%20%3D%20this"]
         params: {
-            foo: "&🐱",
-            baz: {
-                "hello there": "how's your encoding?",
-                "a & b & c": "better encode = this"
-            }
-        },
-        appliesTo: "client",
-    },
+            foo: "&🐱"
+            baz: { "hello there": "how's your encoding?", "a & b & c": "better encode = this" }
+        }
+        appliesTo: "client"
+    }
     {
-        id: "RestJsonQueryPrecedenceForbid",
-        documentation: "Prefer named query parameters when serializing",
-        protocol: restJson1,
-        method: "POST",
-        uri: "/Precedence",
-        body: "",
-        queryParams: [
-            "bar=named",
-            "qux=alsoFromMap"
-        ],
-        forbidQueryParams: ["bar=fromMap"],
+        id: "RestJsonQueryPrecedenceForbid"
+        documentation: "Prefer named query parameters when serializing"
+        protocol: restJson1
+        method: "POST"
+        uri: "/Precedence"
+        body: ""
+        queryParams: ["bar=named", "qux=alsoFromMap"]
+        forbidQueryParams: ["bar=fromMap"]
         params: {
-            foo: "named",
-            baz: {
-                bar: "fromMap",
-                qux: "alsoFromMap"
-            }
-        },
-        appliesTo: "client",
-    }]
-)
+            foo: "named"
+            baz: { bar: "fromMap", qux: "alsoFromMap" }
+        }
+        appliesTo: "client"
+    }
+])
 
 /// A REST JSON service that sends JSON requests and responses.
 @service(sdkId: "Rest Json Protocol")
 @restJson1
 service RestJsonExtras {
-    version: "2019-12-16",
-    operations: [EnumPayload, StringPayload, PrimitiveIntHeader, EnumQuery, CreateNestedMap, CreateNestedSparseMap]
+    version: "2019-12-16"
+    operations: [
+        EnumPayload
+        StringPayload
+        PrimitiveIntHeader
+        EnumQuery
+        CreateNestedMap
+        CreateNestedSparseMap
+    ]
 }
 
 @http(uri: "/EnumPayload", method: "POST")
 @httpRequestTests([
     {
-        id: "EnumPayload",
-        uri: "/EnumPayload",
-        body: "enumvalue",
-        params: { payload: "enumvalue" },
-        method: "POST",
+        id: "EnumPayload"
+        uri: "/EnumPayload"
+        body: "enumvalue"
+        params: { payload: "enumvalue" }
+        method: "POST"
         protocol: "aws.protocols#restJson1"
     }
 ])
 operation EnumPayload {
-    input: EnumPayloadInput,
+    input: EnumPayloadInput
     output: EnumPayloadInput
 }
 
@@ -80,16 +78,16 @@ structure EnumPayloadInput {
 @http(uri: "/StringPayload", method: "POST")
 @httpRequestTests([
     {
-        id: "StringPayload",
-        uri: "/StringPayload",
-        body: "rawstring",
-        params: { payload: "rawstring" },
-        method: "POST",
+        id: "StringPayload"
+        uri: "/StringPayload"
+        body: "rawstring"
+        params: { payload: "rawstring" }
+        method: "POST"
         protocol: "aws.protocols#restJson1"
     }
 ])
 operation StringPayload {
-    input: StringPayloadInput,
+    input: StringPayloadInput
     output: StringPayloadInput
 }
 
@@ -100,10 +98,10 @@ structure StringPayloadInput {
 
 @httpResponseTests([
     {
-        id: "DeserPrimitiveHeader",
-        protocol: "aws.protocols#restJson1",
-        code: 200,
-        headers: { "x-field": "123" },
+        id: "DeserPrimitiveHeader"
+        protocol: "aws.protocols#restJson1"
+        code: 200
+        headers: { "x-field": "123" }
         params: { field: 123 }
     }
 ])
@@ -123,10 +121,10 @@ structure PrimitiveIntHeaderInput {
 @http(uri: "/foo/{enum}", method: "GET")
 @httpRequestTests([
     {
-        id: "EnumQueryRequest",
-        uri: "/foo/enumvalue",
-        params: { enum: "enumvalue" },
-        method: "GET",
+        id: "EnumQueryRequest"
+        uri: "/foo/enumvalue"
+        params: { enum: "enumvalue" }
+        method: "GET"
         protocol: "aws.protocols#restJson1"
     }
 ])
@@ -152,9 +150,9 @@ structure EnumQueryInput {
         body: "{\"nestedMaps\":{\"a\":{\"b\":[\"x\",\"y\",\"z\"]}}}"
         bodyMediaType: "application/json"
         params: {
-            "nestedMaps": {
-                "a": {
-                    "b": ["x", "y", "z"]
+            nestedMaps: {
+                a: {
+                    b: ["x", "y", "z"]
                 }
             }
         }
@@ -167,16 +165,16 @@ structure EnumQueryInput {
         code: 201
         body: "{\"nestedMaps\":{\"a\":{\"b\":[\"x\",\"y\",\"z\"]}}}"
         params: {
-            "nestedMaps": {
-                "a": {
-                    "b": ["x", "y", "z"]
+            nestedMaps: {
+                a: {
+                    b: ["x", "y", "z"]
                 }
             }
         }
     }
 ])
 operation CreateNestedMap {
-    input: HasNestedMap,
+    input: HasNestedMap
     output: HasNestedMap
 }
 
@@ -210,18 +208,16 @@ list StringList {
         body: "{\"nestedSparseMaps\":{\"a\":{\"b\":[\"x\",null,\"y\",null,\"z\",null],\"c\":null},\"d\":null},\"sparseStructureMap\":{\"m\":{\"string\":\"rst\"},\"n\":null}}"
         bodyMediaType: "application/json"
         params: {
-            "nestedSparseMaps": {
-                "a": {
-                    "b": ["x", null, "y", null, "z", null]
-                    "c": null
-                },
-                "d": null
-            }
-            "sparseStructureMap": {
-                "m": {
-                    "string": "rst"
+            nestedSparseMaps: {
+                a: {
+                    b: ["x", null, "y", null, "z", null]
+                    c: null
                 }
-                "n": null
+                d: null
+            }
+            sparseStructureMap: {
+                m: { string: "rst" }
+                n: null
             }
         }
     }
@@ -233,24 +229,22 @@ list StringList {
         code: 201
         body: "{\"nestedSparseMaps\":{\"a\":{\"b\":[\"x\",null,\"y\",null,\"z\",null],\"c\":null},\"d\":null},\"sparseStructureMap\":{\"m\":{\"string\":\"rst\"},\"n\":null}}"
         params: {
-            "nestedSparseMaps": {
-                "a": {
-                    "b": ["x", null, "y", null, "z", null]
-                    "c": null
+            nestedSparseMaps: {
+                a: {
+                    b: ["x", null, "y", null, "z", null]
+                    c: null
                 }
-                "d": null
+                d: null
             }
-            "sparseStructureMap": {
-                "m": {
-                    "string": "rst"
-                }
-                "n": null
+            sparseStructureMap: {
+                m: { string: "rst" }
+                n: null
             }
         }
     }
 ])
 operation CreateNestedSparseMap {
-    input: HasNestedSparseMap,
+    input: HasNestedSparseMap
     output: HasNestedSparseMap
 }
 


### PR DESCRIPTION
## Description of changes
Apply Smithy auto-formatting to the Smithy files located in the `protocol-test-codegen-local` subproject.

(Smithy is already applying this on protocol test generation; this PR merely commits the applied formatting.)

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.