### PR TITLE
chore: Add announcements to release notes

### DIFF
--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/AWSSDKSwiftCLI/Subcommands/PrepareRelease.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Commands/AWSSDKSwiftCLI/Subcommands/PrepareRelease.swift
@@ -71,6 +71,17 @@ struct PrepareRelease {
 
     let sourceCodeArtifactId: String
 
+    /// Zero or more announcements to go at the top of the release notes.
+    /// Announcements should be hard-coded below by developers prior to release.
+    var announcements: [String] {
+        switch repoType {
+        case .awsSdkSwift:
+            []
+        case .smithySwift:
+            []
+        }
+    }
+
     typealias DiffChecker = (_ branch: String, _ version: Version) throws -> Bool
 
     /// Returns true if the repository has changes given the current branch and the version to compare, otherwise returns false
@@ -273,6 +284,7 @@ struct PrepareRelease {
             newVersion: newVersion,
             repoOrg: repoOrg,
             repoType: repoType,
+            announcements: announcements,
             commits: commits,
             buildRequest: buildRequestReader.getFeaturesFromFile(),
             featuresIDToServiceName: buildRequestReader.getFeaturesIDToServiceNameDictFromFile()

--- a/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Models/ReleaseNotesBuilder.swift
+++ b/AWSSDKSwiftCLI/Sources/AWSSDKSwiftCLI/Models/ReleaseNotesBuilder.swift
@@ -14,6 +14,7 @@ struct ReleaseNotesBuilder {
     let newVersion: Version
     let repoOrg: PrepareRelease.Org
     let repoType: PrepareRelease.Repo
+    let announcements: [String]
     let commits: [String]
     let buildRequest: BuildRequest
     let featuresIDToServiceName: [String: String]
@@ -21,13 +22,27 @@ struct ReleaseNotesBuilder {
     // MARK: - Build
 
     func build() throws -> String {
+        let announcements = buildAnnouncements()
         let sdkChanges: [String] = buildSDKChangeSection()
         let serviceClientChanges = repoType == .awsSdkSwift ? (try buildServiceChangeSection()) : []
         let fullCommitLogLink = [
             "\n**Full Changelog**: https://github.com/\(repoOrg.rawValue)/\(repoType.rawValue)/compare/\(previousVersion)...\(newVersion)"
         ]
-        let contents = ["## What's Changed"] + serviceClientChanges + sdkChanges + fullCommitLogLink
+        let contents = announcements + ["## What's Changed"] + serviceClientChanges + sdkChanges + fullCommitLogLink
         return contents.joined(separator: .newline)
+    }
+
+    func buildAnnouncements() -> [String] {
+        let header = "## Announcements"
+        if self.announcements.isEmpty {
+            return []
+        } else if self.announcements.count == 1 {
+            // For a single announcement, print it unbulleted under the header
+            return [header] + self.announcements
+        } else {
+            // For multiple announcements, print them each bulleted under the header
+            return [header] + self.announcements.map { "* \($0)" }
+        }
     }
 
     func buildSDKChangeSection() -> [String] {

--- a/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Models/ReleaseNotesBuilderTests.swift
+++ b/AWSSDKSwiftCLI/Tests/AWSSDKSwiftCLITests/Models/ReleaseNotesBuilderTests.swift
@@ -99,6 +99,36 @@ class ReleaseNotesBuilderTests: CLITestCase {
     }
     """
 
+    func testAllSectionsPresentWithOneAnnouncement() throws {
+        let buildRequest = """
+        { "features": [\(feature1), \(feature2), \(feature3)] }
+        """
+        setUpBuildRequestAndMappingJSONs(buildRequest, mapping)
+        let announcements = ["I, for one, welcome our Swift overlords"]
+        let builder = try setUpBuilder(announcements: announcements, testCommits: includedTestCommits)
+        let releaseNotes = try builder.build()
+        let expected = """
+        ## Announcements
+        I, for one, welcome our Swift overlords
+        ## What's Changed
+        ### Service Features
+        * **AWS Service 1**: New feature description A.
+        * **AWS Service 2**: New feature description B.
+        ### Service Documentation
+        * **AWS Service 3**: Doc update description C.
+        ### Miscellaneous
+        * fix: Correct X
+        * feat: Add Y
+        * docs: Document Z
+        * refactor: Change A
+        * perf: Speed up B
+        * test: Try out C
+
+        **Full Changelog**: https://github.com/awslabs/aws-sdk-swift/compare/1.0.0...1.0.1
+        """
+        XCTAssertEqual(releaseNotes, expected)
+    }
+
     func testAllSectionsPresent() throws {
         let buildRequest = """
         { "features": [\(feature1), \(feature2), \(feature3)] }
@@ -111,6 +141,34 @@ class ReleaseNotesBuilderTests: CLITestCase {
         ### Service Features
         * **AWS Service 1**: New feature description A.
         * **AWS Service 2**: New feature description B.
+        ### Service Documentation
+        * **AWS Service 3**: Doc update description C.
+        ### Miscellaneous
+        * fix: Correct X
+        * feat: Add Y
+        * docs: Document Z
+        * refactor: Change A
+        * perf: Speed up B
+        * test: Try out C
+
+        **Full Changelog**: https://github.com/awslabs/aws-sdk-swift/compare/1.0.0...1.0.1
+        """
+        XCTAssertEqual(releaseNotes, expected)
+    }
+
+    func testNoServiceFeatureSectionPresentWithTwoAnnouncements() throws {
+        let buildRequest = """
+        { "features": [\(feature3)] }
+        """
+        setUpBuildRequestAndMappingJSONs(buildRequest, mapping)
+        let announcements = ["One for the money", "Two for the show"]
+        let builder = try setUpBuilder(announcements: announcements, testCommits: includedTestCommits)
+        let releaseNotes = try builder.build()
+        let expected = """
+        ## Announcements
+        * One for the money
+        * Two for the show
+        ## What's Changed
         ### Service Documentation
         * **AWS Service 3**: Doc update description C.
         ### Miscellaneous
@@ -234,12 +292,13 @@ class ReleaseNotesBuilderTests: CLITestCase {
         FileManager.default.createFile(atPath: "../feature-service-id.json", contents: Data(mapping.utf8))
     }
 
-    private func setUpBuilder(testCommits: [String] = []) throws -> ReleaseNotesBuilder {
+    private func setUpBuilder(announcements: [String] = [], testCommits: [String] = []) throws -> ReleaseNotesBuilder {
         return try ReleaseNotesBuilder(
             previousVersion: Version("1.0.0"),
             newVersion: Version("1.0.1"),
             repoOrg: .awslabs,
             repoType: .awsSdkSwift,
+            announcements: announcements,
             commits: testCommits,
             // Parameterize behavior of FeaturesReader with paths used to create JSON test files
             buildRequest: BuildRequestReader().getFeaturesFromFile(),


### PR DESCRIPTION
## Description of changes
Adds an "Announcements" section to release notes.
- Announcements can be set separately for either aws-sdk-swift or smithy-swift
- Announcements are inserted at the top, above the existing release notes content
- Announcements are hard-coded into this project, since they will likely change infrequently

Also added tests to verify the correct rendering of announcements.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.
If any dependency was added / modified / removed, THIRD-PARTY-LICENSES must be updated accordingly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.