### PR TITLE
chore: Fix paths in protogen.sh script

### DIFF
--- a/scripts/protogen.sh
+++ b/scripts/protogen.sh
@@ -18,8 +18,8 @@ rm -rf codegen/protocol-test-codegen-local/build
 # Delete the generated Package.swift for protocol test packages so they may be seen in Xcode
 rm -f codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen/aws-restjson/swift-codegen/AWSRestJsonTestSDK/Package.swift
 rm -f codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen/aws-restjson-validation/swift-codegen/AWSRestJsonValidationTestSDK/Package.swift
-rm -f codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen/aws-json-10/swift-codegen/AWSJson1_0TestSDK/Package.swift
-rm -f codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen/aws-json-11/swift-codegen/AWSJson1_1TestSDK/Package.swift
+rm -f codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen/aws-json-10/swift-codegen/AWSJson10TestSDK/Package.swift
+rm -f codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen/aws-json-11/swift-codegen/AWSJson11TestSDK/Package.swift
 rm -f codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen/rest-xml/swift-codegen/RestXmlTestSDK/Package.swift
 rm -f codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen/rest-xml-xmlns/swift-codegen/RestXmlWithNamespaceTestSDK/Package.swift
 rm -f codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen/ec2-query/swift-codegen/Ec2QueryTestSDK/Package.swift
@@ -31,7 +31,7 @@ rm -f codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codege
 rm -f codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen/smithy-rpcv2-cbor/swift-codegen/RPCV2CBORTestSDK/Package.swift
 rm -f codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen/smithy-rpcv2-cbor-non-query-compat/swift-codegen/RPCV2CBORTestNonQueryCompatSDK/Package.swift
 rm -f codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen/smithy-rpcv2-cbor-query-compat/swift-codegen/RPCV2CBORTestQueryCompatSDK/Package.swift
-rm -f codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen/aws-json-10-query-compat/swift-codegen/AWSJson1_0TestQueryCompatSDK/Package.swift
+rm -f codegen/protocol-test-codegen/build/smithyprojections/protocol-test-codegen/aws-json-10-query-compat/swift-codegen/AWSJson10TestQueryCompatSDK/Package.swift
 
 # Now do the same for local protocol tests
 rm -f codegen/protocol-test-codegen-local/build/smithyprojections/protocol-test-codegen-local/rest_json_extras/swift-codegen/rest_json_extras/Package.swift


### PR DESCRIPTION
## Description of changes
Fixes paths in `scripts/protogen.sh` so that `Package.swift` is successfully deleted from protocol test generated code.

## New/existing dependencies impact assessment, if applicable
No new dependencies were added to this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.